### PR TITLE
Center revealed file when using Meta-|

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -152,8 +152,9 @@ class TreeView extends ScrollView
       if entry.hasClass('directory')
         entry.expand()
       else
+        centeringOffset = (@scrollBottom() - @scrollTop()) / 2
         @selectEntry(entry)
-        @scrollToEntry(entry)
+        @scrollToEntry(entry, centeringOffset)
 
   entryForPath: (path) ->
     fn = (bestMatchEntry, element) ->
@@ -326,15 +327,14 @@ class TreeView extends ScrollView
     else
       @scroller.scrollBottom()
 
-  scrollToEntry: (entry) ->
+  scrollToEntry: (entry, offset = 0) ->
     displayElement = if entry instanceof DirectoryView then entry.header else entry
     top = displayElement.position().top
     bottom = top + displayElement.outerHeight()
-    centeringOffset = (@scrollBottom() - @scrollTop()) / 2
     if bottom > @scrollBottom()
-      @scrollBottom(bottom + centeringOffset)
+      @scrollBottom(bottom + offset)
     if top < @scrollTop()
-      @scrollTop(top + centeringOffset)
+      @scrollTop(top + offset)
 
   scrollToBottom: ->
     @selectEntry(@root.find('.entry:last')) if @root


### PR DESCRIPTION
Currently when you hit `Meta-|` to reveal a file it only brings it just into the tree-view frame. 
![github 2013-10-24 17-28-35](https://f.cloud.github.com/assets/47749/1403402/3e080036-3cf3-11e3-8e35-6dbad402b5e6.jpg)

This change allows `scrollToEntry` to take an offset param which will let us center it up in the case of revealing files.

![github 2013-10-24 17-30-56](https://f.cloud.github.com/assets/47749/1403426/91f0dd4e-3cf3-11e3-8e67-ae5e0cf5c246.jpg)
