### PR TITLE
Close tree-view on escape

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -35,7 +35,7 @@ class TreeView extends ScrollView
     @command 'tree-view:move', => @moveSelectedEntry()
     @command 'tree-view:add', => @add()
     @command 'tree-view:remove', => @removeSelectedEntry()
-    @command 'tool-panel:unfocus', => rootView.focus()
+    @command 'tool-panel:unfocus', => @detach()
     @command 'tree-view:directory-modified', =>
       if @hasFocus()
         @selectEntryForPath(@selectedPath) if @selectedPath


### PR DESCRIPTION
Previously it would focus the rootview. I expect it to close when I git escape. This also matches the fnr behavior. 

If you feel strongly against this, let me know.
