### PR TITLE
Copy cut paste

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -10,6 +10,16 @@
   'ctrl-|': 'tree-view:reveal-active-file'
   'ctrl-0': 'tree-view:toggle-focus'
 
+'.platform-darwin .tree-view':
+  'cmd-c': 'tree-view:copy'
+  'cmd-x': 'tree-view:cut'
+  'cmd-v': 'tree-view:paste'
+
+'.platform-win32 .tree-view':
+  'ctrl-c': 'tree-view:copy'
+  'ctrl-x': 'tree-view:cut'
+  'ctrl-v': 'tree-view:paste'
+
 '.tree-view':
   'right': 'tree-view:expand-directory'
   'ctrl-]': 'tree-view:expand-directory'

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -21,15 +21,24 @@
 ]
 
 'context-menu':
-  '.tree-view':
+  '.tree-view.full-menu':
     'Add File': 'tree-view:add-file'
     'Add Folder': 'tree-view:add-folder'
     'Rename': 'tree-view:move'
     'Duplicate': 'tree-view:duplicate'
     'Delete': 'tree-view:remove'
+    'Copy Selected': 'tree-view:copy'
+    'Cut Selected': 'tree-view:cut'
+    'Paste': 'tree-view:paste'
     'Copy Full Path': 'tree-view:copy-full-path'
     'Copy Project Path': 'tree-view:copy-project-path'
     'Show in Finder': 'tree-view:show-in-file-manager'
+
+  '.tree-view.multi-select':
+    'Delete': 'tree-view:remove'
+    'Copy Selected': 'tree-view:copy'
+    'Cut Selected': 'tree-view:cut'
+    'Paste': 'tree-view:paste'
 
   '.pane .item-views':
     'Reveal in Tree View': 'tree-view:reveal-active-file'


### PR DESCRIPTION
Add copy/cut and paste file/directory functionality. This also uses localStorage to store the copy/cut path so that pasting across different instances of atom becomes possible.

Let me know if there is anything I missed, this is my first attempt at Atom stuff :)
