### PR TITLE
Preview behavior (like Sublime preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Tree View package
- Tree View for Atom Editor with preview mode
 
-![](https://dl.dropboxusercontent.com/u/16625639/tab.gif)
+Explore and open files in the current project.
+
+Press `cmd-\` to open/close the Tree view and `ctrl-0` to focus it.
+
+When the Tree view has focus you can press `a`, `m`, or `delete` to add, move
+or delete files and folders.
+
+![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)


### PR DESCRIPTION
Doesn't open a new tab every time the user click on a file item (like in Sublime), instead, it creates a atom.workspace.activePane.previewingItem, which will be removed if the user click on other file. It stays if the user doubleClick on the filename

![tab](https://f.cloud.github.com/assets/2464274/2292340/581f0c0e-a057-11e3-8198-ed1756f7b8f5.gif)
