### PR TITLE
Expose treeView on atom.workspaceView

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -30,6 +30,8 @@ class TreeView extends ScrollView
     scrollTopAfterAttach = -1
     selectedPath = null
 
+    atom.workspaceView.treeView = this
+
     @on 'click', '.entry', (e) => @entryClicked(e)
     @on 'mousedown', '.entry', (e) =>
       e.stopPropagation()


### PR DESCRIPTION
As seen in the status-bar package: http://git.io/Do6RPQ

This would allow for package authors to access, among other things, the currently selected file/directory in the tree: meaning package authors can create key bindings for path-specific commands, such as `npm init`.

If `tree-view` has been kept private intentionally, it would be great to still have a way to easily access to the currently selected file :)

Thanks!
