### PR TITLE
Add option to hide hidden files and directories

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -67,6 +67,10 @@ class Directory extends Model
       extension = path.extname(filePath)
       return true if extension and _.contains(ignoredNames, "*#{extension}")
 
+    if atom.config.get('tree-view.hideHiddenFiles')
+      name = path.basename(filePath)
+      return true if /^\.[^\.]/.test name
+
     false
 
   # Create a new model for the given atom.File or atom.Directory entry.

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -61,6 +61,8 @@ class TreeView extends ScrollView
       @updateRoot()
     @subscribe atom.config.observe 'tree-view.hideIgnoredNames', callNow: false, =>
       @updateRoot()
+    @subscribe atom.config.observe 'tree-view.hideHiddenFiles', callNow: false, =>
+      @updateRoot()
     @subscribe atom.config.observe 'core.ignoredNames', callNow: false, =>
       @updateRoot() if atom.config.get('tree-view.hideIgnoredNames')
 

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -4,6 +4,7 @@ module.exports =
   configDefaults:
     hideVcsIgnoredFiles: false
     hideIgnoredNames: false
+    hideHiddenFiles: false
 
   treeView: null
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1193,6 +1193,28 @@ describe "TreeView", ->
       expect(treeView.find('.directory .name:contains(test.js)').length).toBe 1
       expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
 
+  describe "the hideHiddenFiles config option", ->
+    beforeEach ->
+      atom.config.set('core.ignoredNames', ['.git', '*.js'])
+      dotGitFixture = path.join(__dirname, 'fixtures', 'git', 'working-dir', 'git.git')
+      projectPath = temp.mkdirSync('tree-view-project')
+      dotGit = path.join(projectPath, '.git')
+      fs.copySync(dotGitFixture, dotGit)
+      fs.writeFileSync(path.join(projectPath, '.hidden.txt'), '')
+      fs.writeFileSync(path.join(projectPath, 'test.txt'), '')
+      atom.project.setPath(projectPath)
+      atom.config.set "tree-view.hideHiddenFiles", false
+
+    it "hides hidden files and directories if the option is set, but otherwise shows them", ->
+      expect(treeView.find('.directory .name:contains(.git)').length).toBe 1
+      expect(treeView.find('.directory .name:contains(.hidden.txt)').length).toBe 1
+      expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
+
+      atom.config.set("tree-view.hideHiddenFiles", true)
+      expect(treeView.find('.directory .name:contains(.git)').length).toBe 0
+      expect(treeView.find('.directory .name:contains(.hidden.txt)').length).toBe 0
+      expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
+
   describe "Git status decorations", ->
     beforeEach ->
       projectPath = temp.mkdirSync('tree-view-project')


### PR DESCRIPTION
This adds a new config option to hide hidden files and directories. 

It's just a simple regex to test if the base file name starts with a period and followed by something else.

This only works on *nix systems based on path name. I don't think there is a reliable way to test for hidden files on Windows with Node.
