### PR TITLE
add feature: Duplicate command

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -20,6 +20,7 @@
   'm': 'tree-view:move'
   'a': 'tree-view:add-file'
   'shift-a': 'tree-view:add-folder'
+  'd': 'tree-view:duplicate'
   'delete': 'tree-view:remove'
   'backspace': 'tree-view:remove'
   'k': 'core:move-up'

--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -1,0 +1,53 @@
+path = require 'path'
+fs = require 'fs-plus'
+Dialog = require './dialog'
+
+module.exports =
+class CopyDialog extends Dialog
+  constructor: (@initialPath) ->
+    prompt = 'Enter the new path for the duplicate.'
+
+    super
+      prompt: prompt
+      initialPath: atom.project.relativize(@initialPath)
+      select: true
+      iconClass: 'icon-arrow-right'
+
+  onConfirm: (newPath) ->
+    newPath = atom.project.resolve(newPath)
+    return unless newPath
+
+    if @initialPath is newPath
+      @close()
+      return
+
+    unless @isNewPathValid(newPath)
+      @showError("'#{newPath}' already exists.")
+      return
+
+    directoryPath = path.dirname(newPath)
+    try
+      if fs.isDirectorySync(@initialPath)
+        fs.copySync(@initialPath, newPath)
+      else
+        fs.copy(@initialPath, newPath)
+      if repo = atom.project.getRepo()
+        repo.getPathStatus(@initialPath)
+        repo.getPathStatus(newPath)
+      @close()
+    catch error
+      @showError("#{error.message}.")
+
+  isNewPathValid: (newPath) ->
+    try
+      oldStat = fs.statSync(@initialPath)
+      newStat = fs.statSync(newPath)
+
+      # New path exists so check if it points to the same file as the initial
+      # path to see if the case of the file name is being changed on a on a
+      # case insensitive filesystem.
+      @initialPath.toLowerCase() is newPath.toLowerCase() and
+        oldStat.dev is newStat.dev and
+        oldStat.ino is newStat.ino
+    catch
+      true # new path does not exist so it is valid

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -7,6 +7,7 @@ fs = require 'fs-plus'
 
 AddDialog = null  # Defer requiring until actually needed
 MoveDialog = null # Defer requiring until actually needed
+CopyDialog = null # Defer requiring until actually needed
 
 Directory = require './directory'
 DirectoryView = require './directory-view'
@@ -45,6 +46,7 @@ class TreeView extends ScrollView
     @command 'tree-view:move', => @moveSelectedEntry()
     @command 'tree-view:add-file', => @add(true)
     @command 'tree-view:add-folder', => @add(false)
+    @command 'tree-view:duplicate', => @copySelectedEntry()
     @command 'tree-view:remove', => @removeSelectedEntry()
     @command 'tree-view:copy-full-path', => @copySelectedEntryPath(false)
     @command 'tree-view:show-in-file-manager', => @showSelectedEntryInFileManager()
@@ -300,6 +302,15 @@ class TreeView extends ScrollView
           buttons: ['OK']
 
     new BufferedProcess({command, args, stderr, exit})
+
+  copySelectedEntry: ->
+    entry = @selectedEntry()
+    return unless entry and entry isnt @root
+    oldPath = entry.getPath()
+
+    CopyDialog ?= require './copy-dialog'
+    dialog = new CopyDialog(oldPath)
+    dialog.attach()
 
   removeSelectedEntry: ->
     entry = @selectedEntry()

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -25,6 +25,7 @@
     'Add File': 'tree-view:add-file'
     'Add Folder': 'tree-view:add-folder'
     'Rename': 'tree-view:move'
+    'Duplicate': 'tree-view:duplicate'
     'Delete': 'tree-view:remove'
     'Copy Full Path': 'tree-view:copy-full-path'
     'Copy Project Path': 'tree-view:copy-project-path'


### PR DESCRIPTION
Addresses #57

Adds a command to duplicate a file or directory. Will create the tree if it doesn't already exist. 

It just extends the existing move function to take copy into account and renames `moveSelectedEntry` to the more logical `moveOrCopySelectedEntry` 
