### PR TITLE
Allow to move files and directories via Drag & Drop

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -7,7 +7,7 @@ File = require './file'
 module.exports =
 class DirectoryView extends View
   @content: ->
-    @li class: 'directory entry list-nested-item collapsed', =>
+    @li class: 'directory entry list-nested-item collapsed', draggable: true, =>
       @div outlet: 'header', class: 'header list-item', =>
         @span class: 'name icon', outlet: 'directoryName'
       @ol class: 'entries list-tree', outlet: 'entries'

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -3,7 +3,7 @@
 module.exports =
 class FileView extends View
   @content: ->
-    @li class: 'file entry list-item', =>
+    @li class: 'file entry list-item', draggable: true, =>
       @span class: 'name icon', outlet: 'fileName'
 
   initialize: (@file) ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -34,6 +34,9 @@ class TreeView extends ScrollView
     @on 'mousedown', '.entry', (e) =>
       e.stopPropagation()
       @selectEntry($(e.currentTarget).view())
+    @on 'dragstart', (e) => @startDragging(e)
+    @on 'dragover', (e) => @expandDirectoryOnDragOver(e)
+    @on 'drop', (e) => @moveEntryToTarget(e)
 
     @on 'mousedown', '.tree-view-resize-handle', (e) => @resizeStarted(e)
     @command 'core:move-up', => @moveUp()
@@ -323,6 +326,32 @@ class TreeView extends ScrollView
 
   deselect: ->
     @list.find('.selected').removeClass('selected')
+
+  startDragging: (e) ->
+    entry = $(e.target).view()
+    return false if entry.directory?.isRoot
+
+    @draggedPath = entry.getPath()
+
+  expandDirectoryOnDragOver: (e) ->
+    e.preventDefault()
+    entry = $(e.target).view()
+
+    if entry instanceof DirectoryView && !entry.isExpanded
+      entry.toggleExpansion()
+
+  moveEntryToTarget: (e) ->
+    e.preventDefault()
+    entry = $(e.target).view();
+    targetPath = if entry instanceof DirectoryView
+      entry.getPath()
+    else if entry instanceof FileView
+      path.dirname(entry.getPath())
+
+    if targetPath?
+      fs.moveSync(@draggedPath, path.join(targetPath, path.basename(@draggedPath)))
+
+    @draggedPath = null
 
   scrollTop: (top) ->
     if top?


### PR DESCRIPTION
This implements drag & drop for the tree view, as wanted in #55. It supports dragging files and directories.

It needs some interface love like an indicator to see where you move the file to, some delay for expanding directories and a better view when you actually drag directories.

This is how it works (don't know why the GIF is so choppy):
![tree_view](https://f.cloud.github.com/assets/82050/2371943/b68d4a4e-a831-11e3-93b8-e5c4f9f3244f.gif)

I have code ready to allow dragging external files into the tree to add them to the directory, but don't know what the behaviour there should be. Moving the files/directory or copying them? Or maybe a setting? I just need your input (/cc @SebastianSzturo) and I'll implement that.

Feedback is very welcome, I'll give it some interface love tomorrow.
