### PR TITLE
Listen for duplicate on atom.workspace

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -66,7 +66,6 @@ class TreeView extends ScrollView
     @command 'tree-view:collapse-directory', => @collapseDirectory()
     @command 'tree-view:open-selected-entry', => @openSelectedEntry(true)
     @command 'tree-view:move', => @moveSelectedEntry()
-    @command 'tree-view:duplicate', => @copySelectedEntry()
     @command 'tree-view:remove', => @removeSelectedEntries()
     @command 'tree-view:copy', => @copySelectedEntries()
     @command 'tree-view:cut', => @cutSelectedEntries()
@@ -332,9 +331,13 @@ class TreeView extends ScrollView
     new BufferedProcess({command, args, stderr, exit})
 
   copySelectedEntry: ->
-    entry = @selectedEntry()
-    return unless entry and entry isnt @root
-    oldPath = entry.getPath()
+    if @hasFocus()
+      entry = @selectedEntry()
+      return unless entry isnt root
+      oldPath = entry.getPath()
+    else
+      oldPath = @getActivePath()
+    return unless oldPath
 
     CopyDialog ?= require './copy-dialog'
     dialog = new CopyDialog(oldPath)

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -19,6 +19,7 @@ module.exports =
     atom.workspaceView.command 'tree-view:toggle-side', => @createView().toggleSide()
     atom.workspaceView.command 'tree-view:add-file', => @createView().add(true)
     atom.workspaceView.command 'tree-view:add-folder', => @createView().add(false)
+    atom.workspaceView.command 'tree-view:duplicate', => @createView().copySelectedEntry()
 
   deactivate: ->
     @treeView?.deactivate()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1542,6 +1542,18 @@ describe "TreeView", ->
           treeView.trigger "tree-view:duplicate"
           expect(atom.workspaceView.find(".tree-view-dialog").view()).not.toExist()
 
+      describe "when the editor has focus", ->
+        copyDialog = null
+
+        beforeEach ->
+          atom.workspaceView.openSync('tree-view.js')
+          editorView = atom.workspaceView.getActiveView()
+          editorView.trigger "tree-view:duplicate"
+          copyDialog = atom.workspaceView.find(".tree-view-dialog").view()
+
+        it "duplicates the current file", ->
+          expect(copyDialog.miniEditor.getText()).toBe('tree-view.js')
+
     describe "tree-view:remove", ->
       it "shows the native alert dialog", ->
         spyOn(atom, 'confirm')


### PR DESCRIPTION
Duplicates the active file without tree view open or focused.

Fixes #117.  Similar to #113.
