### PR TITLE
Resize cursor on windows

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -15,7 +15,7 @@
     top: 0;
     bottom: 0;
     width: 10px;
-    cursor: ew-resize;
+    cursor: col-resize;
     z-index: 3;
   }
 
@@ -49,5 +49,15 @@
   .entry:before {
     content: '';
     position: absolute;
+  }
+}
+
+.platform-win32 {
+
+  .tree-view-resizer {
+
+    .tree-view-resize-handle {
+      cursor: ew-resize;
+    }
   }
 }


### PR DESCRIPTION
The col-resize cursor does not show up on a windows build. The ones that are working are:
- e-resize
- w-resize
- ew-resize
