### PR TITLE
Add 'show in file manager' to active document context

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -355,6 +355,10 @@ class TreeView extends ScrollView
 
     new BufferedProcess({command, args, stderr, exit})
 
+  showActiveInFileManager: ->
+    @revealActiveFile()
+    @showSelectedEntryInFileManager()
+
   copySelectedEntry: ->
     if @hasFocus()
       entry = @selectedEntry()

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -16,6 +16,7 @@ module.exports =
     atom.workspaceView.command 'tree-view:toggle', => @createView().toggle()
     atom.workspaceView.command 'tree-view:toggle-focus', => @createView().toggleFocus()
     atom.workspaceView.command 'tree-view:reveal-active-file', => @createView().revealActiveFile()
+    atom.workspaceView.command 'tree-view:show-active-in-file-manager', => @createView().showActiveInFileManager()
     atom.workspaceView.command 'tree-view:toggle-side', => @createView().toggleSide()
     atom.workspaceView.command 'tree-view:add-file', => @createView().add(true)
     atom.workspaceView.command 'tree-view:add-folder', => @createView().add(false)

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -52,3 +52,12 @@
 
   '.pane .tab.active':
     'Reveal in Tree View': 'tree-view:reveal-active-file'
+
+  '.platform-darwin .pane .item-views':
+    'Show in Finder': 'tree-view:show-active-in-file-manager'
+
+  '.platform-win32 .pane .item-views':
+    'Show in Explorer': 'tree-view:show-active-in-file-manager'
+
+  '.platform-linux .pane .item-views':
+    'Show in File Manager': 'tree-view:show-active-in-file-manager'


### PR DESCRIPTION
This adds the "Show in File Manager (/Explorer/Finder)" to the context menu of the active document - a feature from my ex-editor that I used a lot. 
![showinfinder](https://cloud.githubusercontent.com/assets/129330/3070543/8d8393a2-e2aa-11e3-9694-ef6db410603e.png)
It works by running the `revealActiveFile`, followed by `showSelectedEntryInFileManager`. If it's not the kind of thing you're looking for, then feel free to close this guy.
