### PR TITLE
Turn off default up/down scrolling from ScrollView's core:move-up/down event handling

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -59,6 +59,10 @@ class TreeView extends ScrollView
         @selectEntry(entryToSelect)
         @showFullMenu()
 
+    # turn off default scrolling behavior from ScrollView
+    @off 'core:move-up'
+    @off 'core:move-down'
+
     @on 'mousedown', '.tree-view-resize-handle', (e) => @resizeStarted(e)
     @command 'core:move-up', => @moveUp()
     @command 'core:move-down', => @moveDown()


### PR DESCRIPTION
Fixes #152.

When https://github.com/atom/atom/pull/2368 was merged, ScrollView gained the ability to scroll when the up and down arrow keys are pressed (more precisely, when `core:move-up` or `core:move-down` events are triggered).

Since Tree View uses a ScrollView, this means that `core:move-up` and `core:move-down` events both select the previous/next item in the Tree View, and make the Tree View scroll up/down.

This change turns off the scrolling behavior by removing the ScrollView's default event handler for the `core:move-up` and `core:move-down` events.

Of course, the alternative is to roll back the changes from https://github.com/atom/atom/pull/2368 (wondering if some other packages might have been affected?). Personally, I think that ScrollView _should_ support `core:move-up` and `core:move-down` for scrolling by default, since it's a _Scroll_View. If subclasses want to disable this behavior, they're free to do so (and it's simple). Still, would love a :+1: on this reasoning.

cc @probablycorey
