### PR TITLE
Get specs green on Windows

### DIFF
--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -859,7 +859,6 @@ describe "TreeView", ->
         fileView2 = treeView.find('.file:contains(test-file2.txt)').view()
         fileView3 = treeView.find('.file:contains(test-file3.txt)').view()
 
-
     describe "tree-view:copy", ->
       LocalStorage = window.localStorage
       beforeEach ->


### PR DESCRIPTION
There were several specs with hard-coded `/` characters in expected paths.
