### PR TITLE
Remove delete button from delete panel

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -406,9 +406,6 @@ class TreeView extends ScrollView
           for selectedPath in selectedPaths
             shell.moveItemToTrash(selectedPath)
         "Cancel": null
-        "Delete": =>
-          for selectedPath in selectedPaths
-            @removeSync(selectedPath)
 
   removeSync: (pathToRemove) ->
     try


### PR DESCRIPTION
The delete panel has "move to trash" and "delete" buttons. Because of
default keybindings, the "delete" button can easily be triggered by
accident while typing text.

Removing the delete button prevents data loss like I suffered
yesterday, when my entire project and the git repository were erased.

closes #172
closes #173
