### PR TITLE
Add command and keybinding for toggling VCS ignored files

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -40,6 +40,7 @@
   'backspace': 'tree-view:remove'
   'k': 'core:move-up'
   'j': 'core:move-down'
+  'i': 'tree-view:toggleVcsIgnoredFiles'
 
 '.tree-view-dialog .mini.editor':
   'enter': 'core:confirm'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -78,6 +78,8 @@ class TreeView extends ScrollView
     @command 'tree-view:open-in-new-window', => @openSelectedEntryInNewWindow()
     @command 'tree-view:copy-project-path', => @copySelectedEntryPath(true)
     @command 'tool-panel:unfocus', => @unfocus()
+    @command 'tree-view:toggleVcsIgnoredFiles', =>
+      atom.config.toggle 'tree-view.hideVcsIgnoredFiles'
 
     @on 'tree-view:directory-modified', =>
       if @hasFocus()


### PR DESCRIPTION
Fixes #170

This binds a command to toggle VCS ignored files to the `i` key, as suggested in #170:

> Yeah, I like this idea, maybe just the i keybinding when the tree view is focused? i for ignore.

This works as expected, but also collapses all open folders (because the whole tree view is updated):

![](https://cloud.githubusercontent.com/assets/38924/3376726/02cdc574-fbd8-11e3-86eb-db2e1587fb3c.gif)

(In the GIF, I expand two folders, then press `i` a few times.)

I'm fine with this behavior, but still wanted to point it out in case this is a :scream:. This is also how the tree view behaves when you flip the option in Atom > Preferences.

cc @kevinsawicki @kuatsure
