### PR TITLE
Add option to filter dot files.

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -64,6 +64,7 @@ class Directory extends Model
       ignoredNames = [ignoredNames] if typeof ignoredNames is 'string'
       name = path.basename(filePath)
       return true if _.contains(ignoredNames, name)
+      return true if name.charAt(0) == "." and atom.config.get('tree-view.hideDotFiles')
       extension = path.extname(filePath)
       return true if extension and _.contains(ignoredNames, "*#{extension}")
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -96,8 +96,11 @@ class TreeView extends ScrollView
       @updateRoot()
     @subscribe atom.config.observe 'tree-view.hideIgnoredNames', callNow: false, =>
       @updateRoot()
+    @subscribe atom.config.observe 'tree-view.hideDotFiles', callNow: false, =>
+      @updateRoot()
     @subscribe atom.config.observe 'core.ignoredNames', callNow: false, =>
       @updateRoot() if atom.config.get('tree-view.hideIgnoredNames')
+
     @subscribe atom.config.observe 'tree-view.showOnRightSide', callNow: false, (newValue) =>
       @onSideToggled(newValue)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -100,7 +100,6 @@ class TreeView extends ScrollView
       @updateRoot()
     @subscribe atom.config.observe 'core.ignoredNames', callNow: false, =>
       @updateRoot() if atom.config.get('tree-view.hideIgnoredNames')
-
     @subscribe atom.config.observe 'tree-view.showOnRightSide', callNow: false, (newValue) =>
       @onSideToggled(newValue)
 

--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -4,6 +4,7 @@ module.exports =
   configDefaults:
     hideVcsIgnoredFiles: false
     hideIgnoredNames: false
+    hideDotFiles: false
     showOnRightSide: false
 
   treeView: null


### PR DESCRIPTION
This lets you hide those annoying hidden files and directories like ***.ssh*** or ***.bashrc*** and you can still open them with ***Ctrl + P*** if you really need to.

![image](https://cloud.githubusercontent.com/assets/1369748/3485443/73e8ec7c-03dd-11e4-8d09-6b3ae3697bef.png)
