### PR TITLE
tree-view auto show when project path changed

### DIFF
--- a/lib/tree.coffee
+++ b/lib/tree.coffee
@@ -12,6 +12,7 @@ module.exports =
     @state.attached ?= true if @shouldAttach()
 
     @createView() if @state.attached
+    atom.project.on 'path-changed', => @createView().show()
     atom.workspaceView.command 'tree-view:show', => @createView().show()
     atom.workspaceView.command 'tree-view:toggle', => @createView().toggle()
     atom.workspaceView.command 'tree-view:toggle-focus', => @createView().toggleFocus()


### PR DESCRIPTION
Fix `Open file paths in focused window` at https://github.com/atom/atom/pull/3355 but tree-view not show.
