### PR TITLE
Attach after project path is initially set

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -107,6 +107,7 @@ class TreeView extends ScrollView
     @focusAfterAttach = state.hasFocus
     @scrollTopAfterAttach = state.scrollTop if state.scrollTop
     @scrollLeftAfterAttach = state.scrollLeft if state.scrollLeft
+    @attachAfterProjectPathSet = state.attached and not atom.project.getPath()
     @width(state.width) if state.width > 0
     @attach() if state.attached
 
@@ -221,8 +222,13 @@ class TreeView extends ScrollView
       directory = new Directory({directory: rootDirectory, isExpanded: true, expandedEntries, isRoot: true})
       @root = new DirectoryView(directory)
       @list.append(@root)
+
+      if @attachAfterProjectPathSet
+        @attach()
+        @attachAfterProjectPathSet = false
     else
       @root = null
+
 
   getActivePath: -> atom.workspace.getActivePaneItem()?.getPath?()
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -111,14 +111,14 @@ describe "TreeView", ->
           expect(treeView.root).not.toExist()
 
       describe "when the project is assigned a path because a new buffer is saved", ->
-        it "creates a root directory view but does not attach to the root view", ->
+        it "creates a root directory view and attaches to the root view", ->
           waitsForPromise ->
             atom.workspaceView.open()
 
           runs ->
             projectPath = temp.mkdirSync('atom-project')
             atom.workspace.getActivePaneItem().saveAs(path.join(projectPath, 'test.txt'))
-            expect(treeView.hasParent()).toBeFalsy()
+            expect(treeView.hasParent()).toBeTruthy()
             expect(fs.absolute(treeView.root.getPath())).toBe fs.absolute(projectPath)
             expect(treeView.root.parent()).toMatchSelector(".tree-view")
 


### PR DESCRIPTION
Show the tree view when an untitled buffer is saved in an untitled window or a folder path is opened from an untitled window.
