### PR TITLE
Make Dir Separator Windows-aware

### DIFF
--- a/lib/add-dialog.coffee
+++ b/lib/add-dialog.coffee
@@ -23,7 +23,7 @@ class AddDialog extends Dialog
 
   onConfirm: (relativePath) ->
     relativePath = relativePath.replace(/\s+$/, '') # Remove trailing whitespace
-    endsWithDirectorySeparator = /\/|\\$/.test(relativePath)
+    endsWithDirectorySeparator = relativePath[relativePath.length - 1] is path.sep
     pathToCreate = atom.project.resolve(relativePath)
     return unless pathToCreate
 


### PR DESCRIPTION
On Windows this dialog uses conflicting directory separators:
![image](https://cloud.githubusercontent.com/assets/7287076/4254391/70525756-3aab-11e4-8773-c5d41e7a4430.png)

This attempts to fix that by replacing the trailing '/' separator with the Windows equivalent (i.e. '\').
Both OSX and Linux should not be affected of course.

It's a very small change, but someone please make sure this works properly. I'm new to this.

Thanks.
