### PR TITLE
lstatSyncNoException can return false

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -162,6 +162,7 @@ class Directory
       continue if @isPathIgnored(fullPath)
 
       stat = fs.lstatSyncNoException(fullPath)
+      continue unless stat
       symlink = stat.isSymbolicLink()
       stat = fs.statSyncNoException(fullPath) if symlink
 


### PR DESCRIPTION
I ran into some `undefined is not a function` errors while changing branches. Looks like it was introduced by 7619a0190446276b90f13a37bcf034d554890dc2.
