### PR TITLE
WIP use the new panel API

### DIFF
--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -30,8 +30,8 @@ describe "TreeView", ->
       atom.packages.activatePackage("tree-view")
 
     runs ->
-      atom.workspaceView.trigger 'tree-view:toggle'
       treeView = atom.workspaceView.find(".tree-view").view()
+      treeView.show()
       root = $(treeView.root)
       sampleJs = treeView.find('.file:contains(tree-view.js)')
       sampleTxt = treeView.find('.file:contains(tree-view.txt)')
@@ -134,7 +134,7 @@ describe "TreeView", ->
 
         runs ->
           treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
-          expect(treeView.hasParent()).toBeFalsy()
+          expect(treeView.isVisible()).toBeFalsy()
           expect(treeView.root).toBeTruthy()
 
     describe "when the root view is opened to a directory", ->


### PR DESCRIPTION
This works, but the specs are broken currently.

The tree view relies on `detach` to hide and `attach` to show. These concepts are pretty baked into the tests. 

The new panel API always attaches the node, then just hide/shows it. 

@kevinsawicki feel free to start over if you want to. This is just here for reference.

New Panel API: https://github.com/atom/atom/pull/3837