### PR TITLE
Add option to delete files permanently in removeSelectedEntries confirm dialog

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs'
 path = require 'path'
 shell = require 'shell'
 
@@ -455,6 +456,9 @@ class TreeView extends ScrollView
           "Move to Trash": ->
             for selectedPath in selectedPaths
               shell.moveItemToTrash(selectedPath)
+          "Delete permanently": ->
+            for selectedPath in selectedPaths
+              fs.unlink(selectedPath)
           "Cancel": null
 
   # Public: Copy the path of the selected entry element.

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1713,7 +1713,7 @@ describe "TreeView", ->
         runs ->
           treeView.trigger 'tree-view:remove'
           args = atom.confirm.mostRecentCall.args[0]
-          expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Cancel']
+          expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Delete permanently', 'Cancel']
 
   describe "file system events", ->
     temporaryFilePath = null


### PR DESCRIPTION
This PR adds a third button in the removeSelectedEntries confirm dialog that allows to delete files permanently, instead of moving to trash, using fs.unlink. The button is in between the 'move to trash' and the 'cancel' buttons. The 'move to trash' button is still focused by default.

I ran the updated specs, and they all passed.
