### PR TITLE
Add option to delete files permanently in removeSelectedEntries confirm dialog

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,7 @@ module.exports =
     hideVcsIgnoredFiles: false
     hideIgnoredNames: false
     showOnRightSide: false
+    showPermanentDeleteButton: false
 
   treeView: null
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs-plus'
 path = require 'path'
 shell = require 'shell'
 
@@ -455,6 +456,19 @@ class TreeView extends ScrollView
           "Move to Trash": ->
             for selectedPath in selectedPaths
               shell.moveItemToTrash(selectedPath)
+          "Delete permanently": ->
+            # recursively removes directories (and their contained files)
+            rmdirR = (dirPath) ->
+              fs.traverseTreeSync dirPath, (filePath) ->
+                fs.unlinkSync filePath
+              , (subDirPath) ->
+                rmdirR subDirPath
+              fs.rmdirSync dirPath
+            for selectedPath in selectedPaths
+              fs.isDirectory selectedPath, (answer) ->
+                # fs.unlink if file, else remove directory and their contents
+                return fs.unlinkSync selectedPath unless answer
+                rmdirR selectedPath
           "Cancel": null
 
   # Public: Copy the path of the selected entry element.

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -463,9 +463,9 @@ class TreeView extends ScrollView
               rmdirR subDirPath
             fs.rmdirSync dirPath
           for selectedPath in selectedPaths
-            fs.isDirectory selectedPath, (answer) ->
+            fs.isDirectory selectedPath, (isDirectory) ->
               # fs.unlink if file, else remove directory and their contents
-              return fs.unlinkSync selectedPath unless answer
+              return fs.unlinkSync selectedPath unless isDirectory
               rmdirR selectedPath
       buttons["Cancel"] = null
       atom.confirm

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1704,16 +1704,31 @@ describe "TreeView", ->
         args = atom.confirm.mostRecentCall.args[0]
         expect(args.buttons).toEqual ['OK']
 
-      it "shows the native alert dialog", ->
-        spyOn(atom, 'confirm')
+      describe "when the showPermanentDeleteButton config option is disabled", ->
+        it "shows the native alert dialog with two buttons", ->
+          spyOn(atom, 'confirm')
 
-        waitsForFileToOpen ->
-          fileView.click()
+          waitsForFileToOpen ->
+            fileView.click()
 
-        runs ->
-          treeView.trigger 'tree-view:remove'
-          args = atom.confirm.mostRecentCall.args[0]
-          expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Delete permanently', 'Cancel']
+          runs ->
+            atom.config.set 'tree-view.showPermanentDeleteButton', false
+            treeView.trigger 'tree-view:remove'
+            buttons = atom.confirm.mostRecentCall.args[0].buttons
+            expect(Object.keys(buttons)).toEqual ['Move to Trash', 'Cancel']
+
+      describe "when the showPermanentDeleteButton config option is enabled", ->
+        it "shows the native alert dialog with three buttons", ->
+          spyOn(atom, 'confirm')
+
+          waitsForFileToOpen ->
+            fileView.click()
+
+          runs ->
+            atom.config.set 'tree-view.showPermanentDeleteButton', true
+            treeView.trigger 'tree-view:remove'
+            buttons = atom.confirm.mostRecentCall.args[0].buttons
+            expect(Object.keys(buttons)).toEqual ['Move to Trash', 'Delete permanently', 'Cancel']
 
   describe "file system events", ->
     temporaryFilePath = null

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1713,7 +1713,7 @@ describe "TreeView", ->
         runs ->
           treeView.trigger 'tree-view:remove'
           args = atom.confirm.mostRecentCall.args[0]
-          expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Cancel']
+          expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Delete permanently', 'Cancel']
 
   describe "file system events", ->
     temporaryFilePath = null

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1705,7 +1705,7 @@ describe "TreeView", ->
         expect(args.buttons).toEqual ['OK']
 
       describe "when the showPermanentDeleteButton config option is disabled", ->
-        it "shows the native alert dialog with two buttons", ->
+        it "shows the native alert dialog with 'Move to Trash' and 'Cancel' buttons", ->
           spyOn(atom, 'confirm')
 
           waitsForFileToOpen ->
@@ -1718,7 +1718,7 @@ describe "TreeView", ->
             expect(Object.keys(buttons)).toEqual ['Move to Trash', 'Cancel']
 
       describe "when the showPermanentDeleteButton config option is enabled", ->
-        it "shows the native alert dialog with three buttons", ->
+        it "shows the native alert dialog with a third 'Delete Permanently' button", ->
           spyOn(atom, 'confirm')
 
           waitsForFileToOpen ->


### PR DESCRIPTION
This PR adds a third button in the removeSelectedEntries confirm dialog that allows to delete files permanently, instead of moving to trash, using fs.unlink and fs.rmdir. The button is in between the 'move to trash' and the 'cancel' buttons. The 'move to trash' button is still focused by default.

I ran the updated specs, and they all passed.