### PR TITLE
add w-resize cursor rule

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -15,6 +15,7 @@
     top: 0;
     bottom: 0;
     width: 10px;
+    cursor: w-resize;
     cursor: col-resize;
     z-index: 3;
   }


### PR DESCRIPTION
This should fix the cursor problem (on windows) as a fallback, if `col-resize` is not recognised then `w-resize` should be the default on the handle