### PR TITLE
Dont run onsidetoggled if tree view is off. Fixes #272

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -642,7 +642,8 @@ class TreeView extends View
     else
       @selectEntry(entryToSelect)
       @showFullMenu()
-
+  
+  # Toggles the tree view side (from left to right & vice versa) when the user hits the menu dropdown option
   onSideToggled: (newValue) ->
     if @isVisible()  
       @detach()


### PR DESCRIPTION
Causes a crash because you can't detach stuff that doesn't exist. Fixes #272 
