### PR TITLE
Capitalize 'VCS' in tree-view config settings.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,6 +6,7 @@ module.exports =
     hideVcsIgnoredFiles:
       type: 'boolean'
       default: false
+      title: 'Hide VCS Ignored Files'
     hideIgnoredNames:
       type: 'boolean'
       default: false


### PR DESCRIPTION
:lipstick: Capitalize 'VCS' in tree-view config settings.

this matches main Atom settings panel and the fix here is the same done for that settings panel as seen by this commit: https://github.com/atom/atom/commit/a12fb94d77c3bcdad7b0ef0098a32a6b740d1b67

Thanks.
