### PR TITLE
Fix serialization of attached state

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -70,7 +70,7 @@ class TreeView extends View
     directoryExpansionStates: @root?.directory.serializeExpansionStates()
     selectedPath: @selectedEntry()?.getPath()
     hasFocus: @hasFocus()
-    attached: @hasParent()
+    attached: @panel?
     scrollLeft: @scroller.scrollLeft()
     scrollTop: @scrollTop()
     width: @width()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -162,6 +162,19 @@ describe "TreeView", ->
           expect(treeView).toBeFalsy()
 
   describe "serialization", ->
+    it "restores the attached/detached state of the tree-view", ->
+      jasmine.attachToDOM(workspaceElement)
+      atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
+      expect(atom.workspace.getLeftPanels().length).toBe(0)
+
+      atom.packages.deactivatePackage("tree-view")
+
+      waitsForPromise ->
+        atom.packages.activatePackage("tree-view")
+
+      runs ->
+        expect(atom.workspace.getLeftPanels().length).toBe(0)
+
     it "restores expanded directories and selected file when deserialized", ->
       root.find('.directory:contains(dir1)').click()
 


### PR DESCRIPTION
So the tree-view doesn't always show on reload.

Fixes #258
