### PR TITLE
Add enableVcsColoring config variable

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -44,8 +44,9 @@ class DirectoryView extends HTMLElement
     @expand() if @directory.isExpanded
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified', 'status-added')
-    @classList.add("status-#{@directory.status}") if @directory.status?
+    if atom.config.get('tree-view.enableVcsColoring')
+      @classList.remove('status-ignored', 'status-modified', 'status-added')
+      @classList.add("status-#{@directory.status}") if @directory.status?
 
   subscribeToDirectory: ->
     @subscriptions.add @directory.onDidAddEntries (addedEntries) =>

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -44,9 +44,9 @@ class DirectoryView extends HTMLElement
     @expand() if @directory.isExpanded
 
   updateStatus: ->
-    if atom.config.get('tree-view.enableVcsColoring')
-      @classList.remove('status-ignored', 'status-modified', 'status-added')
-      @classList.add("status-#{@directory.status}") if @directory.status?
+    @classList.remove('status-ignored', 'status-modified', 'status-added')
+    if atom.config.get('tree-view.enableVcsColoring') and @directory.status?
+      @classList.add("status-#{@directory.status}")
 
   subscribeToDirectory: ->
     @subscriptions.add @directory.onDidAddEntries (addedEntries) =>

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -30,9 +30,9 @@ class FileView extends HTMLElement
     @updateStatus()
 
   updateStatus: ->
-    if atom.config.get('tree-view.enableVcsColoring')
-      @classList.remove('status-ignored', 'status-modified',  'status-added')
-      @classList.add("status-#{@file.status}") if @file.status?
+    @classList.remove('status-ignored', 'status-modified',  'status-added')
+    if atom.config.get('tree-view.enableVcsColoring') and @file.status?
+      @classList.add("status-#{@file.status}")
 
   getPath: ->
     @fileName.dataset.path

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -30,8 +30,9 @@ class FileView extends HTMLElement
     @updateStatus()
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified',  'status-added')
-    @classList.add("status-#{@file.status}") if @file.status?
+    if atom.config.get('tree-view.enableVcsColoring')
+      @classList.remove('status-ignored', 'status-modified',  'status-added')
+      @classList.add("status-#{@file.status}") if @file.status?
 
   getPath: ->
     @fileName.dataset.path

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,9 @@ module.exports =
     showOnRightSide:
       type: 'boolean'
       default: false
+    enableVcsColoring:
+      type: 'boolean'
+      default: true
 
   treeView: null
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -125,6 +125,8 @@ class TreeView extends View
       @updateRoot()
     @disposables.add atom.config.onDidChange 'tree-view.hideIgnoredNames', =>
       @updateRoot()
+    @disposables.add atom.config.onDidChange 'tree-view.enableVcsColoring', =>
+      @updateRoot()
     @disposables.add atom.config.onDidChange 'core.ignoredNames', =>
       @updateRoot() if atom.config.get('tree-view.hideIgnoredNames')
     @disposables.add atom.config.onDidChange 'tree-view.showOnRightSide', ({newValue}) =>

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1875,31 +1875,61 @@ describe "TreeView", ->
       treeView.updateRoot()
       $(treeView.root.entries).find('.directory:contains(dir)')[0].expand()
 
-    describe "when the project is the repository root", ->
-      it "adds a custom style", ->
-        expect(treeView.find('.icon-repo').length).toBe 1
+    describe "with enableVcsColoring set to true", ->
+      beforeEach ->
+        atom.config.set "tree-view.enableVcsColoring", true
 
-    describe "when a file is modified", ->
-      it "adds a custom style", ->
-        $(treeView.root.entries).find('.directory:contains(dir)')[0].expand()
-        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+      describe "when the project is the repository root", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.icon-repo').length).toBe 1
 
-    describe "when a directory if modified", ->
-      it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+      describe "when a file is modified", ->
+        it "adds a custom style", ->
+          $(treeView.root.entries).find('.directory:contains(dir)')[0].expand()
+          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
 
-    describe "when a file is new", ->
-      it "adds a custom style", ->
-        $(treeView.root.entries).find('.directory:contains(dir2)')[0].expand()
-        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
+      describe "when a directory if modified", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
 
-    describe "when a directory is new", ->
-      it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+      describe "when a file is new", ->
+        it "adds a custom style", ->
+          $(treeView.root.entries).find('.directory:contains(dir2)')[0].expand()
+          expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
 
-    describe "when a file is ignored", ->
-      it "adds a custom style", ->
-        expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
+      describe "when a directory is new", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+
+      describe "when a file is ignored", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
+
+    describe "with enableVcsColoring set to false", ->
+      beforeEach ->
+        atom.config.set "tree-view.enableVcsColoring", false
+
+      describe "when a file is modified", ->
+        it "adds a custom style", ->
+          $(treeView.root.entries).find('.directory:contains(dir)')[0].expand()
+          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
+
+      describe "when a directory if modified", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
+
+      describe "when a file is new", ->
+        it "adds a custom style", ->
+          $(treeView.root.entries).find('.directory:contains(dir2)')[0].expand()
+          expect(treeView.find('.file:contains(new2)')).not.toHaveClass 'status-added'
+
+      describe "when a directory is new", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.directory:contains(dir2)')).not.toHaveClass 'status-added'
+
+      describe "when a file is ignored", ->
+        it "adds a custom style", ->
+          expect(treeView.find('.file:contains(ignored.txt)')).not.toHaveClass 'status-ignored'
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->


### PR DESCRIPTION
The `tree-view.enableVcsColoring` configuration variable specifies
whether or not the tree view should change the color of modified /
newly added files and directories. Defaults to true.

(Bad branch naming, sorry.)