### PR TITLE
Add a generic way of hiding files by regex.

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -94,6 +94,16 @@ class Directory
       for ignoredPattern in @ignoredPatterns
         return true if ignoredPattern.match(filePath)
 
+    if atom.config.get('tree-view.hidePattern')
+      basePath = path.basename(filePath)
+      hidePattern = atom.config.get('tree-view.hidePattern')
+      try
+        match = basePath.match(hidePattern)
+      catch
+        console.warn("Bad regex " + hidePattern)
+        return false
+      return true if match
+
     false
 
   # Does given full path start with the given prefix?

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -100,7 +100,7 @@ class Directory
       try
         match = basePath.match(hidePattern)
       catch
-        console.warn("Bad regex " + hidePattern)
+        console.warn("Bad hidePattern regex: " + hidePattern)
         return false
       return true if match
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,9 @@ module.exports =
     showOnRightSide:
       type: 'boolean'
       default: false
+    hidePattern:
+      type: 'string'
+      default: ''
 
   treeView: null
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -129,6 +129,8 @@ class TreeView extends View
       @updateRoot() if atom.config.get('tree-view.hideIgnoredNames')
     @disposables.add atom.config.onDidChange 'tree-view.showOnRightSide', ({newValue}) =>
       @onSideToggled(newValue)
+    @disposables.add atom.config.onDidChange 'tree-view.hidePattern', =>
+      @updateRoot()
 
   toggle: ->
     if @isVisible()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1847,6 +1847,20 @@ describe "TreeView", ->
       expect(treeView.find('.directory .name:contains(test.js)').length).toBe 1
       expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
 
+  describe "the hidePattern config option", ->
+    beforeEach ->
+      atom.config.set('tree-view.hidePattern', '\.txt')
+      dotGitFixture = path.join(__dirname, 'fixtures', 'git', 'working-dir')
+      atom.project.setPaths([dotGitFixture])
+
+    it "hides files matching the pattern given", ->
+      expect(treeView.find('.directory .name:contains(file.txt)').length).toBe 0
+      expect(treeView.find('.directory .name:contains(other.txt)').length).toBe 0
+
+      atom.config.set('tree-view.hidePattern', '')
+      expect(treeView.find('.directory .name:contains(file.txt)').length).toBe 1
+      expect(treeView.find('.directory .name:contains(other.txt)').length).toBe 1
+
   describe "Git status decorations", ->
     beforeEach ->
       projectPath = fs.realpathSync(temp.mkdirSync('tree-view-project'))


### PR DESCRIPTION
This introduces a new config value, `atom.tree-view.hidePattern`, which stores a regex to use to determine whether to hide a file or directory from the tree view.

Please be harsh! This is my first time writing coffeescript and my first time contributing to atom. I am not attached to the implementation, but defintely want the feature.