### PR TITLE
Added tree-view:reveal-active-file-if-open command

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -27,6 +27,7 @@ module.exports =
       'tree-view:toggle': => @createView().toggle()
       'tree-view:toggle-focus': => @createView().toggleFocus()
       'tree-view:reveal-active-file': => @createView().revealActiveFile()
+      'tree-view:reveal-active-file-if-open': => @createView().revealActiveFile() if @treeView?
       'tree-view:toggle-side': => @createView().toggleSide()
       'tree-view:add-file': => @createView().add(true)
       'tree-view:add-folder': => @createView().add(false)


### PR DESCRIPTION
I wanted to add a feature to [atom/fuzzy-finder](https://github.com/atom/fuzzy-finder) that would reveal the active file after opening it. Unfortunately `tree-view:reveal-active-file` will open the tree view if it's currently not open. So I added a command that checks that the view is open before revealing the active file.