### PR TITLE
Rename tags to use custom elements

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -10,7 +10,7 @@
   'ctrl-|': 'tree-view:reveal-active-file'
   'ctrl-0': 'tree-view:toggle-focus'
 
-'.platform-darwin .tree-view':
+'.platform-darwin tree-view':
   'cmd-c': 'tree-view:copy'
   'cmd-x': 'tree-view:cut'
   'cmd-v': 'tree-view:paste'
@@ -18,12 +18,12 @@
   'ctrl-b': 'tree-view:collapse-directory'
 
 
-'.platform-win32 .tree-view, .platform-linux .tree-view':
+'.platform-win32 tree-view, .platform-linux tree-view':
   'ctrl-c': 'tree-view:copy'
   'ctrl-x': 'tree-view:cut'
   'ctrl-v': 'tree-view:paste'
 
-'.tree-view':
+'tree-view':
   'right': 'tree-view:expand-directory'
   'ctrl-]': 'tree-view:expand-directory'
   'l': 'tree-view:expand-directory'

--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -41,7 +41,7 @@ class Dialog extends View
 
   cancel: ->
     @close()
-    $('.tree-view').focus()
+    $('tree-view .list-tree').focus()
 
   showError: (message='') ->
     @errorMessage.text(message)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -670,7 +670,7 @@ class TreeView extends View
       @showFullMenu()
 
   onSideToggled: (newValue) ->
-    @element.dataset.showOnRightSide = newValue
+    @element.setAttribute('show-on-right-side', newValue)
     if @isVisible()
       @detach()
       @attach()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -19,15 +19,41 @@ LocalStorage = window.localStorage
 toggleConfig = (keyPath) ->
   atom.config.set(keyPath, not atom.config.get(keyPath))
 
+TreeViewElementPototype = Object.create(HTMLElement::)
+TreeViewElementPototype.attachedCallback = -> @attached?()
+TreeViewElementPototype.detachedCallback = -> @detached?()
+
+document.registerElement 'tree-view', prototype: Object.create(TreeViewElementPototype)
+
 module.exports =
 class TreeView extends View
   panel: null
 
-  @content: ->
-    @div class: 'tree-view-resizer tool-panel', 'data-show-on-right-side': atom.config.get('tree-view.showOnRightSide'), =>
-      @div class: 'tree-view-scroller', outlet: 'scroller', =>
-        @ol class: 'tree-view full-menu list-tree has-collapsable-children focusable-panel', tabindex: -1, outlet: 'list'
-      @div class: 'tree-view-resize-handle', outlet: 'resizeHandle'
+  constructor: ->
+    @element = document.createElement('tree-view')
+    @element.setAttribute('show-on-right-side', atom.config.get('tree-view.showOnRightSide'))
+    @element.classList.add('tree-view-resizer')
+
+    @element.attached = => @attached()
+    @element.detached = => @detached()
+
+    scroller = document.createElement('div')
+    scroller.classList.add('tree-view-scroller')
+    @scroller = $(scroller)
+
+    list = document.createElement('ol')
+    list.setAttribute('tabindex', -1)
+    list.classList.add('tree-view', 'full-menu', 'list-tree', 'has-collapsable-children', 'focusable-panel')
+    @list = $(list)
+
+    resizeHandle = document.createElement('div')
+    resizeHandle.classList.add('tree-view-resize-handle')
+    @resizeHandle = $(resizeHandle)
+
+    scroller.appendChild(list)
+    @element.appendChild(scroller)
+    @element.appendChild(resizeHandle)
+    super
 
   initialize: (state) ->
     @disposables = new CompositeDisposable

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -20,7 +20,7 @@
 ]
 
 'context-menu':
-  '.tree-view.full-menu': [
+  'tree-view .full-menu': [
     {'label': 'Add File', 'command': 'tree-view:add-file'}
     {'label': 'Add Folder', 'command': 'tree-view:add-folder'}
     {'type': 'separator'}
@@ -38,19 +38,19 @@
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
   ]
 
-  '.platform-darwin .tree-view.full-menu': [
+  '.platform-darwin tree-view .full-menu': [
     {'label': 'Show in Finder', 'command': 'tree-view:show-in-file-manager'}
   ]
 
-  '.platform-win32 .tree-view.full-menu': [
+  '.platform-win32 tree-view .full-menu': [
     {'label': 'Show in Explorer', 'command': 'tree-view:show-in-file-manager'}
   ]
 
-  '.platform-linux .tree-view.full-menu': [
+  '.platform-linux tree-view .full-menu': [
     {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
   ]
 
-  '.tree-view.multi-select': [
+  'tree-view .multi-select': [
     {'label': 'Delete', 'command': 'tree-view:remove'}
     {'label': 'Copy', 'command': 'tree-view:copy'}
     {'label': 'Cut', 'command': 'tree-view:cut'}

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -269,7 +269,7 @@ describe "TreeView", ->
         it "moves the tree view to the right", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
-          expect(treeView).toMatchSelector('[data-show-on-right-side="true"]')
+          expect(treeView).toMatchSelector('[show-on-right-side="true"]')
 
       describe "when the tree view is on the right", ->
         beforeEach ->
@@ -278,7 +278,7 @@ describe "TreeView", ->
         it "moves the tree view to the left", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
-          expect(treeView).toMatchSelector('[data-show-on-right-side="false"]')
+          expect(treeView).toMatchSelector('[show-on-right-side="false"]')
 
       describe "when the tree view is hidden", ->
         it "shows the tree view on the other side next time it is opened", ->
@@ -287,7 +287,7 @@ describe "TreeView", ->
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
           expect(atom.workspace.getLeftPanels().length).toBe 0
           treeView = $(atom.workspace.getRightPanels()[0].getItem()).view()
-          expect(treeView).toMatchSelector('[data-show-on-right-side="true"]')
+          expect(treeView).toMatchSelector('[show-on-right-side="true"]')
 
   describe "when tree-view:toggle-focus is triggered on the root view", ->
     beforeEach ->

--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -1,6 +1,7 @@
 @import "ui-variables";
 
-.tree-view-resizer {
+tree-view {
+  display: block;
   position: relative;
   height: 100%;
   overflow: hidden;
@@ -19,36 +20,36 @@
     z-index: 3;
   }
 
-  &[data-show-on-right-side='true'] {
+  &[show-on-right-side='true'] {
     .tree-view-resize-handle {
       left: -5px;
     }
   }
 
-  &[data-show-on-right-side='false'] {
+  &[show-on-right-side='false'] {
     .tree-view-resize-handle {
       right: -5px;
     }
   }
-}
 
-.tree-view-scroller {
-  height: 100%;
-  width: 100%;
-  overflow: auto;
-}
+  .tree-view-scroller {
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+  }
 
-.tree-view {
-  min-width: -webkit-min-content;
-  min-height: 100%;
-  padding-left: @component-icon-padding;
-  padding-right: @component-padding;
-  position: relative;
+  .list-tree {
+    min-width: -webkit-min-content;
+    min-height: 100%;
+    padding-left: @component-icon-padding;
+    padding-right: @component-padding;
+    position: relative;
 
-  // This fixes #110, see that issue for more details
-  .entry:before {
-    content: '';
-    position: absolute;
+    // This fixes #110, see that issue for more details
+    .entry:before {
+      content: '';
+      position: absolute;
+    }
   }
 }
 


### PR DESCRIPTION
Caveat: the `tree-view` element is at the root of the package's markup. `.tree-view` pointed at the list and was a child of the resizer and scroller. The resizer will likely be pulled out into the panel eventually.

So to replace the `.tree-view` exactly, one would need to use `tree-view .list-tree`. Maybe this is not ideal.

Refs https://github.com/atom/atom/issues/5020

### TODO

* [x] Use `tree-view` tag in place of `.tree-view`
* [ ] Use `tree-view-file` tag in place of `.file`
* [ ] Use `tree-view-directory` tag in place of `.directory`