### PR TITLE
Added "Automatically Reveal File" config

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,14 @@ module.exports =
     showOnRightSide:
       type: 'boolean'
       default: false
+    automaticallyRevealFile:
+      type: 'string'
+      default: 'Never'
+      enum: [
+        'Never',
+        'Upon Opening',
+        'Upon Focusing'
+      ]
 
   treeView: null
 
@@ -34,6 +42,16 @@ module.exports =
       'tree-view:remove': => @createView().removeSelectedEntries()
       'tree-view:rename': => @createView().moveSelectedEntry()
     })
+
+    workspaceElement = atom.views.getView(atom.workspace)
+
+    atom.workspace.onDidOpen ->
+      if atom.config.get('tree-view.automaticallyRevealFile') is 'Upon Opening'
+        atom.commands.dispatch workspaceElement, 'tree-view:reveal-active-file'
+
+    atom.workspace.onDidChangeActivePaneItem ->
+      if atom.config.get('tree-view.automaticallyRevealFile') is 'Upon Focusing'
+        atom.commands.dispatch workspaceElement, 'tree-view:reveal-active-file'
 
   deactivate: ->
     @disposables.dispose()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2083,3 +2083,52 @@ describe "TreeView", ->
               expect(fileView3).toHaveClass('selected')
               expect(treeView.list).toHaveClass('full-menu')
               expect(treeView.list).not.toHaveClass('multi-select')
+
+  describe 'the automaticallyRevealFile config option', ->
+    file1 = 'tree-view.js'
+    file2 = 'tree-view.txt'
+
+    beforeEach ->
+      spyOn(treeView, 'revealActiveFile')
+
+    describe 'when it is set to "Never"', ->
+      it 'will only reveal the active file when the user chooses to', ->
+        atom.config.set('tree-view.automaticallyRevealFile', 'Never')
+
+        waitsForPromise ->
+          atom.workspace.open(file1)
+
+        waitsForPromise ->
+          atom.workspace.open(file2)
+
+        runs ->
+          atom.workspace.getActivePane().activateItemAtIndex(0)
+          expect(treeView.revealActiveFile.calls.length).toEqual(0);
+
+    describe 'when it is set to "Upon Opening"', ->
+      it 'will reveal the active file when a file is opened', ->
+        atom.config.set('tree-view.automaticallyRevealFile', 'Upon Opening')
+
+        waitsForPromise ->
+          atom.workspace.open(file1)
+
+        waitsForPromise ->
+          atom.workspace.open(file2)
+
+        runs ->
+          atom.workspace.getActivePane().activateItemAtIndex(0)
+          expect(treeView.revealActiveFile.calls.length).toEqual(2);
+
+    describe 'when it is set to "Upon Focusing"', ->
+      it 'will reveal the active file when a file is focused', ->
+        atom.config.set('tree-view.automaticallyRevealFile', 'Upon Focusing')
+
+        waitsForPromise ->
+          atom.workspace.open(file1)
+
+        waitsForPromise ->
+          atom.workspace.open(file2)
+
+        runs ->
+          atom.workspace.getActivePane().activateItemAtIndex(0)
+          expect(treeView.revealActiveFile.calls.length).toEqual(3);


### PR DESCRIPTION
This adds the config option to Automatically Reveal the Active File. The 3 values are `Never`, `Upon Opening`, and `Upon Focusing`. I also added specs for this.

@kevinsawicki This is in reference to #320.