### PR TITLE
Removed /root switch when opening a directory. Just used select instead.

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -381,10 +381,7 @@ class TreeView extends View
         label: 'Finder'
         args: ['-R', pathToOpen]
       when 'win32'
-        if isFile
-          args = ["/select,#{pathToOpen}"]
-        else
-          args = ["/root,#{pathToOpen}"]
+        args = ["/select,#{pathToOpen}"]
 
         if process.env.SystemRoot
           command = path.join(process.env.SystemRoot, 'explorer.exe')


### PR DESCRIPTION
When opening a directory, running explorer.exe /root,[directory] prohibits the user from navigating outside of that directory without an error. Select can be used for both directories and files and gives the desired results. This fixes an [issue](https://github.com/atom/atom/issues/5218) reported on atom. 