### PR TITLE
Alt-click to open in Split

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -192,6 +192,7 @@ class TreeView extends View
     switch e.originalEvent?.detail ? 1
       when 1
         @selectEntry(entry)
+        @openSelectedEntrySplit 'horizontal', 'after' if entry instanceof FileView and e.altKey
         @openSelectedEntry(false) if entry instanceof FileView
         entry.toggleExpansion(isRecursive) if entry instanceof DirectoryView
       when 2


### PR DESCRIPTION
**Problem**: Split panes are a powerful tool, but usually hard to access for beginners. 
**Solution**: alt-click to open the entry in a split pane. 

![recoridng](http://g.recordit.co/jrEyUk5I9v.gif)

Any thoughts on this?

Open Questions:
- Should alt-click always open in the same split pane or create new split views?
- Controlling the position of the split pane with other modifiers like shift?
- Should we add the "Split Up/Down/Right" menu items from the tab menu to the tree-view?