### PR TITLE
Add split commands to context menu

### DIFF
--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -33,6 +33,12 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
     {'type': 'separator'}
 
+    {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
+    {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
+    {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}
+    {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
+    {'type': 'separator'}
+
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}


### PR DESCRIPTION
![recording](http://g.recordit.co/MeoCFQffRr.gif)

Now we have the same split commands available as in the editors context menu and the tab context menu.
As suggested in #361 