### PR TITLE
Check if entries exist before pasting them

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -541,7 +541,7 @@ class TreeView extends View
 
     for initialPath in initialPaths ? []
       initialPathIsDirectory = fs.isDirectorySync(initialPath)
-      if entry and initialPath
+      if entry and initialPath and fs.existsSync(initialPath)
         basePath = atom.project.getDirectories()[0].resolve(entry.getPath())
         basePath = path.dirname(basePath) if entry instanceof FileView
         newPath = path.join(basePath, path.basename(initialPath))

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1168,6 +1168,23 @@ describe "TreeView", ->
             expect(fs.existsSync(dirPath)).toBeTruthy()
             expect(fs.existsSync(path.join(dirPath, path.basename(dirPath)))).toBeFalsy()
 
+      describe "when pasting entries which don't exist anymore", ->
+        it "skips the entry which doesn't exist", ->
+          filePathDoesntExist1 = path.join(dirPath2, "test-file-doesnt-exist1.txt")
+          filePathDoesntExist2 = path.join(dirPath2, "test-file-doesnt-exist2.txt")
+
+          LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath2, filePathDoesntExist1, filePath3, filePathDoesntExist2])
+
+          fileView.click()
+          atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+          expect(fs.existsSync(path.join(dirPath, path.basename(filePath2)))).toBeTruthy()
+          expect(fs.existsSync(path.join(dirPath, path.basename(filePath3)))).toBeTruthy()
+          expect(fs.existsSync(path.join(dirPath, path.basename(filePathDoesntExist1)))).toBeFalsy()
+          expect(fs.existsSync(path.join(dirPath, path.basename(filePathDoesntExist2)))).toBeFalsy()
+          expect(fs.existsSync(filePath2)).toBeTruthy()
+          expect(fs.existsSync(filePath3)).toBeTruthy()
+
       describe "when a file has been copied", ->
         describe "when a file is selected", ->
           it "creates a copy of the original file in the selected file's parent directory", ->


### PR DESCRIPTION
Fixes https://github.com/atom/tree-view/issues/356 and a bunch of other issues merged into that one:

* 93054a6 adds a failing test case for which the test output throws the exception mentioned in the issue:

  ```
$ apm test

TreeView
  file modification
    tree-view:paste
      when pasting entries which don't exist anymore
        it skips the entry which doesn't exist
          Error: ENOENT, no such file or directory '/private/var/folders/60/ft83xwb56ssf35_50_zr1kcm0000gn/T/tree-view115115-4915-scz0ax/test-dir2/test-file-doesnt-exist1.txt'
            Error: ENOENT, no such file or directory '/private/var/folders/60/ft83xwb56ssf35_50_zr1kcm0000gn/T/tree-view115115-4915-scz0ax/test-dir2/test-file-doesnt-exist1.txt'
            at Error (native)
            at Object.fs.openSync (fs.js:503:18)
            at Object.module.(anonymous function) [as openSync] (/Applications/Atom.app/Contents/Resources/atom/common/lib/asar.js:422:20)
            at Object.fs.readFileSync (fs.js:355:15)
            at Object.fs.readFileSync (/Applications/Atom.app/Contents/Resources/atom/common/lib/asar.js:329:27)
            at TreeView.module.exports.TreeView.pasteEntries (/Users/izuzak/github/tree-view/lib/tree-view.coffee:566:42)
            at space-pen-div.atom.commands.add.tree-view:paste (/Users/izuzak/github/tree-view/lib/tree-view.coffee:115:29)
            at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Users/izuzak/github/atom/src/command-registry.coffee:225:27)
            at CommandRegistry.handleCommandEvent (/Users/izuzak/github/atom/src/command-registry.coffee:1:1)
            at CommandRegistry.module.exports.CommandRegistry.dispatch (/Users/izuzak/github/atom/src/command-registry.coffee:173:6)
            at [object Object].<anonymous> (/Users/izuzak/github/tree-view/spec/tree-view-spec.coffee:1179:25)
            at _fulfilled (/Users/izuzak/github/atom/node_modules/q/q.js:794:54)
            at self.promiseDispatch.done (/Users/izuzak/github/atom/node_modules/q/q.js:823:30)
            at Promise.promise.promiseDispatch (/Users/izuzak/github/atom/node_modules/q/q.js:756:13)
            at /Users/izuzak/github/atom/node_modules/q/q.js:564:44
            at flush (/Users/izuzak/github/atom/node_modules/q/q.js:110:17)
            at process._tickCallback (node.js:364:11)

Finished in 29.807 seconds
194 tests, 700 assertions, 1 failure, 0 skipped
```

*  8a67618 adds a check so that entries which don't exist anymore are skipped when pasting. Running the test now completes without failures.

Notes: 
* using `fs.existsSync` is not recommended in the [official docs](http://nodejs.org/api/fs.html#fs_fs_exists_path_callback). An alternative would be to let the code execute and catch+handle the exception. Still, I think the current solution is good enough in this case for now (and we use `fs.existsSync` in a bunch of other places).
* wasn't sure how many tests would be cool for this, so added just one. The code path is the same for both files/directories (as a source and as a target) and for both copy/cut operations. Still, happy to add more tests for those variations if there's a chance this would prevent future breakage. :+1: 

cc @kevinsawicki for :eyes: 