### PR TITLE
Add context menu item for removing a project path

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -120,6 +120,7 @@ class TreeView extends View
      'tool-panel:unfocus': => @unfocus()
      'tree-view:toggle-vcs-ignored-files': -> toggleConfig 'tree-view.hideVcsIgnoredFiles'
      'tree-view:toggle-ignored-names': -> toggleConfig 'tree-view.hideIgnoredNames'
+     'tree-view:remove-root-folder': (e) => @removeRootFolder(e)
 
     [0..8].forEach (index) =>
       atom.commands.add @element, "tree-view:open-selected-entry-in-pane-#{index + 1}", =>
@@ -602,6 +603,10 @@ class TreeView extends View
   addRootFolder: ->
     atom.pickFolder (selectedPaths = []) ->
       atom.project.addPath(selectedPath) for selectedPath in selectedPaths
+
+  removeRootFolder: (e) ->
+    pathToRemove = $(e.target).closest(".project-root > .header").find(".name").data("path")
+    atom.project.removePath(pathToRemove) if pathToRemove?
 
   selectedEntry: ->
     @list[0].querySelector('.selected')

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -606,7 +606,11 @@ class TreeView extends View
 
   removeRootFolder: (e) ->
     pathToRemove = $(e.target).closest(".project-root > .header").find(".name").data("path")
-    atom.project.removePath(pathToRemove) if pathToRemove?
+
+    # TODO: remove this conditional once the addition of Project::removePath
+    # is released.
+    if atom.project.removePath?
+      atom.project.removePath(pathToRemove) if pathToRemove?
 
   selectedEntry: ->
     @list[0].querySelector('.selected')

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -40,6 +40,36 @@
     {'type': 'separator'}
 
     {'label': 'Add Root Folder', 'command': 'tree-view:add-root-folder'}
+    {'type': 'separator'}
+
+    {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
+    {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
+    {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
+  ]
+
+  '.tree-view.full-menu .project-root > .header': [
+    {'label': 'New File', 'command': 'tree-view:add-file'}
+    {'label': 'New Folder', 'command': 'tree-view:add-folder'}
+    {'type': 'separator'}
+
+    {'label': 'Rename', 'command': 'tree-view:move'}
+    {'label': 'Duplicate', 'command': 'tree-view:duplicate'}
+    {'label': 'Delete', 'command': 'tree-view:remove'}
+    {'label': 'Copy', 'command': 'tree-view:copy'}
+    {'label': 'Cut', 'command': 'tree-view:cut'}
+    {'label': 'Paste', 'command': 'tree-view:paste'}
+    {'type': 'separator'}
+
+    {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
+    {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
+    {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}
+    {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
+    {'type': 'separator'}
+
+    {'label': 'Add Root Folder', 'command': 'tree-view:add-root-folder'}
+    {'label': 'Remove Root Folder', 'command': 'tree-view:remove-root-folder'}
+    {'type': 'separator'}
+
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1073,8 +1073,12 @@ describe "TreeView", ->
   describe "removing a root folder", ->
     it "removes the root folder from the project", ->
       rootHeader = treeView.roots[1].querySelector(".header")
-      atom.commands.dispatch(rootHeader, "tree-view:remove-root-folder")
-      expect(atom.project.getPaths()).toHaveLength(1)
+
+      # TODO: remove this conditional once the addition of Project::removePath
+      # is released.
+      if atom.project.removePath?
+        atom.commands.dispatch(rootHeader, "tree-view:remove-root-folder")
+        expect(atom.project.getPaths()).toHaveLength(1)
 
   describe "file modification", ->
     [dirView, dirView2, dirView3, fileView, fileView2, fileView3, fileView4] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1070,6 +1070,12 @@ describe "TreeView", ->
       atom.commands.dispatch(workspaceElement, 'tree-view:add-root-folder')
       expect(atom.project.getPaths()).toEqual(initialPaths)
 
+  describe "removing a root folder", ->
+    it "removes the root folder from the project", ->
+      rootHeader = treeView.roots[1].querySelector(".header")
+      atom.commands.dispatch(rootHeader, "tree-view:remove-root-folder")
+      expect(atom.project.getPaths()).toHaveLength(1)
+
   describe "file modification", ->
     [dirView, dirView2, dirView3, fileView, fileView2, fileView3, fileView4] = []
     [rootDirPath, rootDirPath2, dirPath, dirPath2, dirPath3, filePath, filePath2, filePath3, filePath4] = []


### PR DESCRIPTION
Uses new method `Project::removePath`, added in atom/atom#5641, which will be released in Atom v0.182.

I edited this so that it's a noop against the current release because I'd really like this feature to ship *with* the rest of the multi-folder tree-view stuff.