### PR TITLE
Retain expansion state over project changes and restarts

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -42,7 +42,7 @@ class DirectoryView extends HTMLElement
       @subscriptions.add @directory.onDidStatusChange => @updateStatus()
       @updateStatus()
 
-    @expand() if @directory.isExpanded
+    @expand() if @directory.expansionState.isExpanded
 
   updateStatus: ->
     @classList.remove('status-ignored', 'status-modified', 'status-added')


### PR DESCRIPTION
With this PR, expansion state will now be saved over project changes and restarts.
The lack of the latter was caused by a bug where state was saved as an array while code was expecting it to be an object.
This fixes atom/atom#5663.

I changed the way expansion state is saved since a directory could have the following 3 states:

1. Seen expanded before
2. Seen collapsed before
3. Newly added, in which case a default must be chosen which is expanded for root directories and collapsed for all others.

This could not be represented with the previous `expandedEntries` representation.

I'm not very experienced in Javascript or Coffeescript, so any comments are appreciated! :)