### PR TITLE
Changing default order to natural order

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -157,6 +157,7 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
+    natural_sort.insensitive = true
     names.sort(natural_sort)
 
     files = []

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -157,8 +157,8 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-    natural_sort.insensitive = true
-    names.sort(natural_sort)
+    NaturalSort.insensitive = true
+    names.sort(NaturalSort)
 
     files = []
     directories = []

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore-plus'
 {CompositeDisposable, Emitter} = require 'event-kit'
 fs = require 'fs-plus'
 PathWatcher = require 'pathwatcher'
+NaturalSort = require 'javascript-natural-sort'
 File = require './file'
 {repoForPath} = require './helpers'
 
@@ -156,8 +157,7 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-
-    names.sort (name1, name2) -> name1.toLowerCase().localeCompare(name2.toLowerCase())
+    names.sort(natural_sort)
 
     files = []
     directories = []

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "atom-space-pen-views": "^2.0.0",
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
+    "javascript-natural-sort": "^0.7.1",
     "minimatch": "~0.3.0",
     "pathwatcher": "^3.0.0",
     "temp": "~0.8.1",


### PR DESCRIPTION
This correction make files organizations more "human like".
Before:
![order](https://cloud.githubusercontent.com/assets/5847145/6484556/d96440d2-c25b-11e4-90b5-7a8844ad02a4.jpg)

After:
![natural_order](https://cloud.githubusercontent.com/assets/5847145/6490951/bd8993bc-c288-11e4-8924-141626ae1c85.jpg)

it fixes issues:  #391 and #395