### PR TITLE
Remove "Reveal in Tree View" from items without file paths

### DIFF
--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,10 +94,10 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane .item-views > *:not(.settings-view)': [
+  'atom-pane atom-text-editor': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 
-  'atom-pane .tab.active:not([data-type="SettingsView"])': [
+  'atom-pane .tab.active[data-type="TextEditor"]': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,10 +94,10 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane .item-views': [
+  'atom-pane .item-views > *:not(.settings-view)': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 
-  'atom-pane .tab.active': [
+  'atom-pane .tab.active:not([data-type="SettingsView"])': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,10 +94,10 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane[data-active-path] .item-views': [
+  'atom-pane[data-active-item-path] .item-views': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 
-  'atom-pane[data-active-path] .tab.active': [
+  'atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,6 +94,10 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane[data-active-path]': [
+  'atom-pane[data-active-path] .item-views': [
+    {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
+  ]
+
+  'atom-pane[data-active-path] .tab.active': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,7 +94,7 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane atom-text-editor': [
+  'atom-pane .item-views .has-file-path': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -94,10 +94,6 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
   ]
 
-  'atom-pane .item-views .has-file-path': [
-    {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
-  ]
-
-  'atom-pane .tab.active[data-type="TextEditor"]': [
+  'atom-pane[data-active-path]': [
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]


### PR DESCRIPTION
Part of atom/settings-view#354

This removes Reveal in Tree View from appearing in settings-view's context menu, where it never really made sense.

Also please let me know if there would be a performance hit from the `'atom-pane .item-views > *:not(.settings-view)'` selector – generally there is with `*`, but I'm not sure if that still applies to how Atom parses selectors for menu entries.

Also let me know if you think I should add a spec for this (I'm thinking maybe).

- [x] Depends on atom/atom#6383