### PR TITLE
preview selected file on key 'right'

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -57,7 +57,7 @@
   'ctrl-9': 'tree-view:open-selected-entry-in-pane-9'
 
 '.tree-view':
-  'right': 'tree-view:expand-directory'
+  'right': 'tree-view:preview-selected-entry'
   'ctrl-]': 'tree-view:expand-directory'
   'l': 'tree-view:expand-directory'
   'left': 'tree-view:collapse-directory'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -106,6 +106,7 @@ class TreeView extends View
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
+     'tree-view:preview-selected-entry': => @openSelectedEntry(false)
      'tree-view:open-selected-entry': => @openSelectedEntry(true)
      'tree-view:open-selected-entry-right': => @openSelectedEntryRight()
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
@@ -376,7 +377,7 @@ class TreeView extends View
   openSelectedEntry: (activatePane) ->
     selectedEntry = @selectedEntry()
     if selectedEntry instanceof DirectoryView
-      selectedEntry.toggleExpansion()
+      selectedEntry.expand()
     else if selectedEntry instanceof FileView
       atom.workspace.open(selectedEntry.getPath(), {activatePane})
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -950,9 +950,8 @@ describe "TreeView", ->
         it "opens the file in the editor and focuses it", ->
           jasmine.attachToDOM(workspaceElement)
 
-          waitsForFileToOpen ->
-            root1.find('.file:contains(tree-view.js)').click()
-
+          selectEntry 'tree-view.js'
+          
           waitsForFileToOpen ->
             atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry')
 
@@ -962,20 +961,49 @@ describe "TreeView", ->
             expect(atom.views.getView(item)).toHaveFocus()
 
       describe "when a directory is selected", ->
-        it "expands or collapses the directory", ->
-          subdir = root1.find('.directory').first()
-          subdir.click()
-          subdir[0].collapse()
-
+        it "expands the directory", ->
+          selectEntry 'dir1'
+          subdir = treeView.selectedEntry()
           expect(subdir).not.toHaveClass 'expanded'
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry')
           expect(subdir).toHaveClass 'expanded'
-          atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry')
-          expect(subdir).not.toHaveClass 'expanded'
 
       describe "when nothing is selected", ->
         it "does nothing", ->
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry')
+          expect(atom.workspace.getActivePaneItem()).toBeUndefined()
+
+    describe "tree-view:preview-selected-entry", ->
+      describe "when a file is selected", ->
+        it "opens the file in the editor without focusing it", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          selectEntry 'tree-view.js'
+          
+          treeView.focus()
+          expect(treeView.list).toMatchSelector ':focus'
+          
+          waitsForFileToOpen ->
+            atom.commands.dispatch(treeView.element, 'tree-view:preview-selected-entry')
+
+          runs ->
+            item = atom.workspace.getActivePaneItem()
+            expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+            expect(atom.views.getView(item)).not.toHaveFocus()
+            expect(treeView.list).toMatchSelector ':focus'
+
+      describe "when a directory is selected", ->
+        it "expands the directory", ->
+          selectEntry 'dir1'
+          subdir = treeView.selectedEntry()
+
+          expect(subdir).not.toHaveClass 'expanded'
+          atom.commands.dispatch(treeView.element, 'tree-view:preview-selected-entry')
+          expect(subdir).toHaveClass 'expanded'
+
+      describe "when nothing is selected", ->
+        it "does nothing", ->
+          atom.commands.dispatch(treeView.element, 'tree-view:preview-selected-entry')
           expect(atom.workspace.getActivePaneItem()).toBeUndefined()
 
     describe "opening in new split panes", ->


### PR DESCRIPTION
* Added a new command `preview-selected-entry` and attached it to the `right` cursor key.
* The `preview-selected-entry` command is the same as `open-selected-entry` but with a false `activatePane` argument for the `openSelectedEntry` method.
* Added specs to test the new behaviour. 
Fixed specs for `tree-view:open-selected-entry`, they didn't test the command properly.