### PR TITLE
Remove tree-view:add-root-folder command

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,7 +36,6 @@ module.exports =
       'tree-view:duplicate': => @createView().copySelectedEntry()
       'tree-view:remove': => @createView().removeSelectedEntries()
       'tree-view:rename': => @createView().moveSelectedEntry()
-      'tree-view:add-root-folder': => @createView().addRootFolder()
     })
 
   deactivate: ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -605,10 +605,6 @@ class TreeView extends View
       false
     dialog.attach()
 
-  addRootFolder: ->
-    atom.pickFolder (selectedPaths = []) ->
-      atom.project.addPath(selectedPath) for selectedPath in selectedPaths
-
   removeRootFolder: (e) ->
     pathToRemove = $(e.target).closest(".project-root > .header").find(".name").data("path")
 

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -39,7 +39,7 @@
     {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
     {'type': 'separator'}
 
-    {'label': 'Add Root Folder', 'command': 'tree-view:add-root-folder'}
+    {'label': 'Add Root Folder', 'command': 'application:add-root-folder'}
     {'type': 'separator'}
 
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
@@ -66,7 +66,7 @@
     {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
     {'type': 'separator'}
 
-    {'label': 'Add Root Folder', 'command': 'tree-view:add-root-folder'}
+    {'label': 'Add Root Folder', 'command': 'application:add-root-folder'}
     {'label': 'Remove Root Folder', 'command': 'tree-view:remove-root-folder'}
     {'type': 'separator'}
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1054,22 +1054,6 @@ describe "TreeView", ->
             expect(atom.views.getView(pane)).toHaveFocus()
             expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
 
-  describe "adding a root folder", ->
-    it "adds a second path to the project", ->
-      initialPaths = atom.project.getPaths()
-      tempDirectory = temp.mkdirSync("a-new-directory")
-      spyOn(atom, "pickFolder").andCallFake (callback) ->
-        callback([tempDirectory])
-      atom.commands.dispatch(workspaceElement, 'tree-view:add-root-folder')
-      expect(atom.project.getPaths()).toEqual(initialPaths.concat([tempDirectory]))
-
-    it "does nothing if the user dismisses the file picker", ->
-      initialPaths = atom.project.getPaths()
-      tempDirectory = temp.mkdirSync("a-new-directory")
-      spyOn(atom, "pickFolder").andCallFake (callback) -> callback(null)
-      atom.commands.dispatch(workspaceElement, 'tree-view:add-root-folder')
-      expect(atom.project.getPaths()).toEqual(initialPaths)
-
   describe "removing a root folder", ->
     it "removes the root folder from the project", ->
       rootHeader = treeView.roots[1].querySelector(".header")


### PR DESCRIPTION
It'll now be defined in Atom core, on the workspace-element.

Refs atom/atom#6273.