### PR TITLE
Rename "Remove Project Folder" to "Detach Project Folder"

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -122,7 +122,7 @@ class TreeView extends View
      'tool-panel:unfocus': => @unfocus()
      'tree-view:toggle-vcs-ignored-files': -> toggleConfig 'tree-view.hideVcsIgnoredFiles'
      'tree-view:toggle-ignored-names': -> toggleConfig 'tree-view.hideIgnoredNames'
-     'tree-view:remove-project-folder': (e) => @removeProjectFolder(e)
+     'tree-view:detach-project-folder': (e) => @removeProjectFolder(e)
 
     [0..8].forEach (index) =>
       atom.commands.add @element, "tree-view:open-selected-entry-in-pane-#{index + 1}", =>

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -67,7 +67,7 @@
     {'type': 'separator'}
 
     {'label': 'Add Project Folder', 'command': 'application:add-project-folder'}
-    {'label': 'Remove Project Folder', 'command': 'tree-view:remove-project-folder'}
+    {'label': 'Detach Project Folder', 'command': 'tree-view:detach-project-folder'}
     {'type': 'separator'}
 
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1057,7 +1057,7 @@ describe "TreeView", ->
   describe "removing a project folder", ->
     it "removes the folder from the project", ->
       rootHeader = treeView.roots[1].querySelector(".header")
-      atom.commands.dispatch(rootHeader, "tree-view:remove-project-folder")
+      atom.commands.dispatch(rootHeader, "tree-view:detach-project-folder")
       expect(atom.project.getPaths()).toHaveLength(1)
 
   describe "file modification", ->


### PR DESCRIPTION
I ran into this today. I had accidentally added my home directory as a project folder, and the option to fix that was to "remove" it. It wasn't clear to me whether or not this folder was going to be removed from the disk. I chose not to try it and went looking for help.

![tree-view-spec coffee - _users_ben_github_tree-view - atom](https://cloud.githubusercontent.com/assets/12676/7052603/451c0f30-ddf5-11e4-8a2b-a229de005f65.png)

Not sure if "detach" is the right word and I have not tested this locally. Just opening up a PR to start a discussion.