### PR TITLE
Only show pane split commands in context menu if file is selected

### DIFF
--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -33,18 +33,20 @@
     {'label': 'Paste', 'command': 'tree-view:paste'}
     {'type': 'separator'}
 
-    {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
-    {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
-    {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}
-    {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
-    {'type': 'separator'}
-
     {'label': 'Add Project Folder', 'command': 'application:add-project-folder'}
     {'type': 'separator'}
 
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
+  ]
+  
+  '.tree-view.full-menu [is="tree-view-file"]': [
+    {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
+    {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
+    {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}
+    {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
+    {'type': 'separator'}
   ]
 
   '.tree-view.full-menu .project-root > .header': [
@@ -58,12 +60,6 @@
     {'label': 'Copy', 'command': 'tree-view:copy'}
     {'label': 'Cut', 'command': 'tree-view:cut'}
     {'label': 'Paste', 'command': 'tree-view:paste'}
-    {'type': 'separator'}
-
-    {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
-    {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
-    {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}
-    {'label': 'Split Right', 'command': 'tree-view:open-selected-entry-right'}
     {'type': 'separator'}
 
     {'label': 'Add Project Folder', 'command': 'application:add-project-folder'}


### PR DESCRIPTION
The pane split commands only work if used on a file. This PR removes the pane split commands from every element in tree-view that isn't a file.

Only downside is that now the pane split commands appear at the top of the menu – changing that depends on atom/atom#6270 getting implemented (/cc @jessegrosjean)