### PR TITLE
Change VCS toggle keybind

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -16,6 +16,7 @@
   'cmd-v': 'tree-view:paste'
   'ctrl-f': 'tree-view:expand-directory'
   'ctrl-b': 'tree-view:collapse-directory'
+  'cmd-i': 'tree-view:toggle-vcs-ignored-files'
   'cmd-k right': 'tree-view:open-selected-entry-right'
   'cmd-k l': 'tree-view:open-selected-entry-right'
   'cmd-k left': 'tree-view:open-selected-entry-left'
@@ -38,6 +39,7 @@
   'ctrl-c': 'tree-view:copy'
   'ctrl-x': 'tree-view:cut'
   'ctrl-v': 'tree-view:paste'
+  'ctrl-i': 'tree-view:toggle-vcs-ignored-files'
   'ctrl-k right': 'tree-view:open-selected-entry-right'
   'ctrl-k l': 'tree-view:open-selected-entry-right'
   'ctrl-k left': 'tree-view:open-selected-entry-left'
@@ -78,7 +80,6 @@
   'backspace': 'tree-view:remove'
   'k': 'core:move-up'
   'j': 'core:move-down'
-  'i': 'tree-view:toggle-vcs-ignored-files'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'


### PR DESCRIPTION
Applies to #455 

Changes the keybinding from <kbd>I</kbd> to <kbd>Cmd/Ctrl+I</kbd>.
