### PR TITLE
Double click file in preview to unpreview tab

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -95,6 +95,9 @@ class TreeView extends View
 
     @on 'mousedown', '.tree-view-resize-handle', (e) => @resizeStarted(e)
 
+    @on 'dblclick', 'li[is=tree-view-file]', (e) =>
+      $(document.body).find('li.active[is=tabs-tab]').get(0)?.clearPreview?()
+
     atom.commands.add @element,
      'core:move-up': @moveUp.bind(this)
      'core:move-down': @moveDown.bind(this)


### PR DESCRIPTION
Currently, this is a hacky proof of concept, but I'd like some feedback on this change, which brings back a feature that was in sublime-tabs, where a file in the tree view could be double-clicked to make the tab permanent / not a preview.

What is the proper approach to do this, how should it be tested, etc.? I'd like to finish this feature properly so that it's suitable to be merged into core!

Fixes https://github.com/atom/tabs/issues/156