### PR TITLE
Add a file icon service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ or delete files and folders.
 
 ## API
 
-The Tree View displays icons next to files. These icons are customizable by installing a package that provides a `tree-view.file-icons` service.
+The Tree View displays icons next to files. These icons are customizable by installing a package that provides an `atom.file-icons` service.
 
-The `tree-view.file-icons` API must provide the following methods:
+The `atom.file-icons` service must provide the following methods:
 
 * `iconClassForPath(path)` - Returns a CSS class name to add to the file view
 * `onWillDeactivate` - An event that lets the tree view return to its default icon strategy

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ or delete files and folders.
 
 ## API
 
-The Tree View displays icons next to files. These icons are customizable by installing a package that provides a `file-icons` service.
+The Tree View displays icons next to files. These icons are customizable by installing a package that provides a `tree-view.file-icons` service.
 
-The `file-icons` API must provide the following methods:
+The `tree-view.file-icons` API must provide the following methods:
 
-* `getIconForPath(path)` - Returns a CSS class name to add to the file view
+* `iconClassForPath(path)` - Returns a CSS class name to add to the file view
 * `onWillDeactivate` - An event that lets the tree view return to its default icon strategy

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ When the Tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>, <kb
 or delete files and folders.
 
 ![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)
+
+## API
+
+The Tree View displays icons next to files. These icons are customizable by installing a package that provides a `file-icons` service.
+
+The `file-icons` API provides the following method:
+
+* `getIconForPath(path)` - Returns a CSS class name to add to the file view

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ or delete files and folders.
 
 The Tree View displays icons next to files. These icons are customizable by installing a package that provides a `file-icons` service.
 
-The `file-icons` API provides the following method:
+The `file-icons` API must provide the following methods:
 
 * `getIconForPath(path)` - Returns a CSS class name to add to the file view
+* `onWillDeactivate` - An event that lets the tree view return to its default icon strategy

--- a/lib/default-file-icons.coffee
+++ b/lib/default-file-icons.coffee
@@ -1,0 +1,23 @@
+fs = require 'fs-plus'
+path = require 'path'
+
+class DefaultFileIcons
+  getIconForPath: (filePath) ->
+    extension = path.extname(filePath)
+
+    if fs.isSymbolicLinkSync(filePath)
+      'icon-file-symlink-file'
+    else if fs.isReadmePath(filePath)
+      'icon-book'
+    else if fs.isCompressedExtension(extension)
+      'icon-file-zip'
+    else if fs.isImageExtension(extension)
+      'icon-file-media'
+    else if fs.isPdfExtension(extension)
+      'icon-file-pdf'
+    else if fs.isBinaryExtension(extension)
+      'icon-file-binary'
+    else
+      'icon-file-text'
+
+module.exports = DefaultFileIcons

--- a/lib/default-file-icons.coffee
+++ b/lib/default-file-icons.coffee
@@ -2,7 +2,7 @@ fs = require 'fs-plus'
 path = require 'path'
 
 class DefaultFileIcons
-  getIconForPath: (filePath) ->
+  iconClassForPath: (filePath) ->
     extension = path.extname(filePath)
 
     if fs.isSymbolicLinkSync(filePath)

--- a/lib/file-icons.coffee
+++ b/lib/file-icons.coffee
@@ -7,4 +7,9 @@ class FileIcons
   getService: ->
     @service
 
+  resetService: ->
+    @service = new DefaultFileIcons
+
+  setService: (@service) ->
+
 module.exports = new FileIcons

--- a/lib/file-icons.coffee
+++ b/lib/file-icons.coffee
@@ -1,0 +1,10 @@
+DefaultFileIcons = require './default-file-icons'
+
+class FileIcons
+  constructor: ->
+    @service = new DefaultFileIcons
+
+  getService: ->
+    @service
+
+module.exports = new FileIcons

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -18,7 +18,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    @fileName.classList.add(FileIcons.getService().getIconForPath(@file.path))
+    @fileName.classList.add(FileIcons.getService().iconClassForPath(@file.path))
 
     @subscriptions.add @file.onDidStatusChange => @updateStatus()
     @updateStatus()

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -1,4 +1,5 @@
 {CompositeDisposable} = require 'event-kit'
+FileIcons = require './file-icons'
 
 module.exports =
 class FileView extends HTMLElement
@@ -17,16 +18,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    if @file.symlink
-      @fileName.classList.add('icon-file-symlink-file')
-    else
-      switch @file.type
-        when 'binary'     then @fileName.classList.add('icon-file-binary')
-        when 'compressed' then @fileName.classList.add('icon-file-zip')
-        when 'image'      then @fileName.classList.add('icon-file-media')
-        when 'pdf'        then @fileName.classList.add('icon-file-pdf')
-        when 'readme'     then @fileName.classList.add('icon-book')
-        when 'text'       then @fileName.classList.add('icon-file-text')
+    @fileName.classList.add(FileIcons.getService().getIconForPath(@file.path))
 
     @subscriptions.add @file.onDidStatusChange => @updateStatus()
     @updateStatus()

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -13,20 +13,6 @@ class File
     @path = fullPath
     @realPath = @path
 
-    extension = path.extname(@path)
-    if fs.isReadmePath(@path)
-      @type = 'readme'
-    else if fs.isCompressedExtension(extension)
-      @type = 'compressed'
-    else if fs.isImageExtension(extension)
-      @type = 'image'
-    else if fs.isPdfExtension(extension)
-      @type = 'pdf'
-    else if fs.isBinaryExtension(extension)
-      @type = 'binary'
-    else
-      @type = 'text'
-
     @subscribeToRepo()
     @updateStatus()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,8 @@
 {CompositeDisposable} = require 'event-kit'
 path = require 'path'
 
+FileIcons = require './file-icons'
+
 module.exports =
   config:
     hideVcsIgnoredFiles:
@@ -40,8 +42,13 @@ module.exports =
 
   deactivate: ->
     @disposables.dispose()
+    @fileIconsDisposable?.dispose()
     @treeView?.deactivate()
     @treeView = null
+
+  consumeFileIcons: (service) ->
+    FileIcons.setService(service)
+    @fileIconsDisposable = service.onWillDeactivate -> FileIcons.resetService()
 
   serialize: ->
     if @treeView?

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coffeelint": "^1.9.7"
   },
   "consumedServices": {
-    "tree-view.file-icons": {
+    "atom.file-icons": {
       "versions": {
         "1.0.0": "consumeFileIcons"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coffeelint": "^1.9.7"
   },
   "consumedServices": {
-    "file-icons": {
+    "tree-view.file-icons": {
       "versions": {
         "1.0.0": "consumeFileIcons"
       }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,12 @@
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"
+  },
+  "consumedServices": {
+    "file-icons": {
+      "versions": {
+        "1.0.0": "consumeFileIcons"
+      }
+    }
   }
 }

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -4,7 +4,7 @@ temp = require('temp').track()
 
 DefaultFileIcons = require '../lib/default-file-icons'
 
-fdescribe 'DefaultFileIcons', ->
+describe 'DefaultFileIcons', ->
   [fileIcons] = []
 
   beforeEach ->

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -1,0 +1,54 @@
+fs = require 'fs-plus'
+path = require 'path'
+temp = require('temp').track()
+
+DefaultFileIcons = require '../lib/default-file-icons'
+
+fdescribe 'DefaultFileIcons', ->
+  [fileIcons] = []
+
+  beforeEach ->
+    fileIcons = new DefaultFileIcons
+
+  it 'defaults to text', ->
+    expect(fileIcons.getIconForPath('foo.bar')).toEqual('icon-file-text')
+
+  it 'recognizes READMEs', ->
+    expect(fileIcons.getIconForPath('README.md')).toEqual('icon-book')
+
+  it 'recognizes compressed files', ->
+    expect(fileIcons.getIconForPath('foo.zip')).toEqual('icon-file-zip')
+
+  it 'recognizes image files', ->
+    expect(fileIcons.getIconForPath('foo.png')).toEqual('icon-file-media')
+
+  it 'recognizes PDF files', ->
+    expect(fileIcons.getIconForPath('foo.pdf')).toEqual('icon-file-pdf')
+
+  it 'recognizes binary files', ->
+    expect(fileIcons.getIconForPath('foo.exe')).toEqual('icon-file-binary')
+
+  describe 'symlinks', ->
+    [tempDir] = []
+
+    beforeEach ->
+      tempDir = temp.mkdirSync('atom-tree-view')
+
+    afterEach ->
+      temp.cleanupSync()
+
+    it 'recognizes symlinks', ->
+      filePath = path.join(tempDir, 'foo.bar')
+      linkPath = path.join(tempDir, 'link.bar')
+      fs.writeFileSync(filePath, '')
+      fs.symlinkSync(filePath, linkPath)
+
+      expect(fileIcons.getIconForPath(linkPath)).toEqual('icon-file-symlink-file')
+
+    it 'recognizes as symlink instead of other types', ->
+      filePath = path.join(tempDir, 'foo.zip')
+      linkPath = path.join(tempDir, 'link.zip')
+      fs.writeFileSync(filePath, '')
+      fs.symlinkSync(filePath, linkPath)
+
+      expect(fileIcons.getIconForPath(linkPath)).toEqual('icon-file-symlink-file')

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -11,22 +11,22 @@ describe 'DefaultFileIcons', ->
     fileIcons = new DefaultFileIcons
 
   it 'defaults to text', ->
-    expect(fileIcons.getIconForPath('foo.bar')).toEqual('icon-file-text')
+    expect(fileIcons.iconClassForPath('foo.bar')).toEqual('icon-file-text')
 
   it 'recognizes READMEs', ->
-    expect(fileIcons.getIconForPath('README.md')).toEqual('icon-book')
+    expect(fileIcons.iconClassForPath('README.md')).toEqual('icon-book')
 
   it 'recognizes compressed files', ->
-    expect(fileIcons.getIconForPath('foo.zip')).toEqual('icon-file-zip')
+    expect(fileIcons.iconClassForPath('foo.zip')).toEqual('icon-file-zip')
 
   it 'recognizes image files', ->
-    expect(fileIcons.getIconForPath('foo.png')).toEqual('icon-file-media')
+    expect(fileIcons.iconClassForPath('foo.png')).toEqual('icon-file-media')
 
   it 'recognizes PDF files', ->
-    expect(fileIcons.getIconForPath('foo.pdf')).toEqual('icon-file-pdf')
+    expect(fileIcons.iconClassForPath('foo.pdf')).toEqual('icon-file-pdf')
 
   it 'recognizes binary files', ->
-    expect(fileIcons.getIconForPath('foo.exe')).toEqual('icon-file-binary')
+    expect(fileIcons.iconClassForPath('foo.exe')).toEqual('icon-file-binary')
 
   describe 'symlinks', ->
     [tempDir] = []
@@ -43,7 +43,7 @@ describe 'DefaultFileIcons', ->
       fs.writeFileSync(filePath, '')
       fs.symlinkSync(filePath, linkPath)
 
-      expect(fileIcons.getIconForPath(linkPath)).toEqual('icon-file-symlink-file')
+      expect(fileIcons.iconClassForPath(linkPath)).toEqual('icon-file-symlink-file')
 
     it 'recognizes as symlink instead of other types', ->
       filePath = path.join(tempDir, 'foo.zip')
@@ -51,4 +51,4 @@ describe 'DefaultFileIcons', ->
       fs.writeFileSync(filePath, '')
       fs.symlinkSync(filePath, linkPath)
 
-      expect(fileIcons.getIconForPath(linkPath)).toEqual('icon-file-symlink-file')
+      expect(fileIcons.iconClassForPath(linkPath)).toEqual('icon-file-symlink-file')

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,7 +1,23 @@
+DefaultFileIcons = require '../lib/default-file-icons'
 FileIcons = require '../lib/file-icons'
 
 describe 'FileIcons', ->
-  describe 'getService', ->
-    it 'provides a default', ->
-      expect(FileIcons.getService()).toBeDefined()
-      expect(FileIcons.getService()).not.toBeNull()
+  afterEach ->
+    FileIcons.setService(new DefaultFileIcons)
+
+  it 'provides a default', ->
+    expect(FileIcons.getService()).toBeDefined()
+    expect(FileIcons.getService()).not.toBeNull()
+
+  it 'allows the default to be overridden', ->
+    service = new Object
+    FileIcons.setService(service)
+
+    expect(FileIcons.getService()).toBe(service)
+
+  it 'allows the service to be reset to the default easily', ->
+    service = new Object
+    FileIcons.setService(service)
+    FileIcons.resetService()
+
+    expect(FileIcons.getService()).not.toBe(service)

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,6 +1,6 @@
 FileIcons = require '../lib/file-icons'
 
-fdescribe 'FileIcons', ->
+describe 'FileIcons', ->
   describe 'getService', ->
     it 'provides a default', ->
       expect(FileIcons.getService()).toBeDefined()

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,0 +1,7 @@
+FileIcons = require '../lib/file-icons'
+
+fdescribe 'FileIcons', ->
+  describe 'getService', ->
+    it 'provides a default', ->
+      expect(FileIcons.getService()).toBeDefined()
+      expect(FileIcons.getService()).not.toBeNull()


### PR DESCRIPTION
This is intended to allow for a more flexible customization of the icons used for files (though it could be extended to folders too). A package could provide a service that is called to determine the icon class to associate with a file in the tree view and then provide styles to display whatever icon they wish.

See the [file-icons package](https://atom.io/packages/file-icons), the [file-type-icons package](https://atom.io/packages/file-type-icons) as well as a number of UI themes that perform this kind of customization. They currently depend on parsing the path, where this is problematic is that there is sometimes a disconnect between the grammar that Atom uses for a file and the type of file that the icon says it is.

This could also allow for more complex logic like recognizing that a project is a Rails project rather than standard Ruby and changing some of the icons.