### PR TITLE
Consistent behavior of HOME and END keys

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -79,6 +79,8 @@
   'k': 'core:move-up'
   'j': 'core:move-down'
   'i': 'tree-view:toggle-vcs-ignored-files'
+  'home': 'core:move-to-top'
+  'end': 'core:move-to-bottom'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'


### PR DESCRIPTION
When we press the HOME key, the focus should be set on the topmost (or the bottommost, when END is pressed) file in the tree view. All the IDEs I've ever used behave this way.