### PR TITLE
Fix cannot read property 'getPath' of null issue

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -2,13 +2,15 @@ path = require "path"
 
 module.exports =
   repoForPath: (goalPath) ->
-    for projectPath, i in atom.project.getPaths()
-      if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
-        return atom.project.getRepositories()[i]
+    if atom.project
+      for projectPath, i in atom.project.getPaths()
+        if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
+          return atom.project.getRepositories()[i]
     null
 
   relativizePath: (goalPath) ->
-    for projectPath in atom.project.getPaths()
-      if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
-        return [projectPath, path.relative(projectPath, goalPath)]
+    if atom.project
+      for projectPath in atom.project.getPaths()
+        if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
+          return [projectPath, path.relative(projectPath, goalPath)]
     [null, goalPath]


### PR DESCRIPTION
This occurs when running unit tests with `apm test`.
