### PR TITLE
Updated preview on click feature

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,9 @@ module.exports =
     hideIgnoredNames:
       type: 'boolean'
       default: false
+    showFileWhenSelected:
+      type: 'boolean'
+      default: false
     showOnRightSide:
       type: 'boolean'
       default: false

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -201,7 +201,7 @@ class TreeView extends View
       when 2
         if entry instanceof FileView
           if not atom.config.get('tree-view.showFileWhenSelected')
-            @openSelectedEntry(false) if entry instanceof FileView
+            @openSelectedEntry(false)
           @unfocus()
         else if DirectoryView
           entry.toggleExpansion(isRecursive)
@@ -384,7 +384,7 @@ class TreeView extends View
     if selectedEntry instanceof DirectoryView
       selectedEntry.toggleExpansion()
     else if selectedEntry instanceof FileView
-      atom.workspace.open(selectedEntry.getPath(), {activatePane}).done (editor) =>
+      atom.workspace.open(selectedEntry.getPath(), {activatePane}).then (editor) =>
         @clearPreview(editor) if not atom.config.get('tree-view.showFileWhenSelected')
 
   openSelectedEntrySplit: (orientation, side) ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -648,6 +648,7 @@ class TreeView extends View
   scrollToEntry: (entry) ->
     element = if entry instanceof DirectoryView then entry.header else entry
     element.scrollIntoViewIfNeeded(true) # true = center around item if possible
+    @openSelectedEntry(false) if entry instanceof FileView
 
   scrollToBottom: ->
     if lastEntry = _.last(@list[0].querySelectorAll('.entry'))

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -195,10 +195,13 @@ class TreeView extends View
     switch e.originalEvent?.detail ? 1
       when 1
         @selectEntry(entry)
-        @openSelectedEntry(false) if entry instanceof FileView
+        if atom.config.get('tree-view.showFileWhenSelected')
+          @openSelectedEntry(false) if entry instanceof FileView
         entry.toggleExpansion(isRecursive) if entry instanceof DirectoryView
       when 2
         if entry instanceof FileView
+          if not atom.config.get('tree-view.showFileWhenSelected')
+            @openSelectedEntry(false) if entry instanceof FileView
           @unfocus()
         else if DirectoryView
           entry.toggleExpansion(isRecursive)
@@ -372,12 +375,17 @@ class TreeView extends View
       directory.collapse(isRecursive)
       @selectEntry(directory)
 
+  clearPreview: (editor) ->
+    editorElement = atom.views.getView(editor)
+    atom.commands.dispatch(editorElement, 'tabs:keep-preview-tab')
+
   openSelectedEntry: (activatePane) ->
     selectedEntry = @selectedEntry()
     if selectedEntry instanceof DirectoryView
       selectedEntry.toggleExpansion()
     else if selectedEntry instanceof FileView
-      atom.workspace.open(selectedEntry.getPath(), {activatePane})
+      atom.workspace.open(selectedEntry.getPath(), {activatePane}).done (editor) =>
+        @clearPreview(editor) if not atom.config.get('tree-view.showFileWhenSelected')
 
   openSelectedEntrySplit: (orientation, side) ->
     selectedEntry = @selectedEntry()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -648,7 +648,8 @@ class TreeView extends View
   scrollToEntry: (entry) ->
     element = if entry instanceof DirectoryView then entry.header else entry
     element.scrollIntoViewIfNeeded(true) # true = center around item if possible
-    @openSelectedEntry(false) if entry instanceof FileView
+    if atom.config.get('tree-view.showFileWhenSelected')
+      @openSelectedEntry(false) if entry instanceof FileView
 
   scrollToBottom: ->
     if lastEntry = _.last(@list[0].querySelectorAll('.entry'))

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -368,17 +368,6 @@ describe "TreeView", ->
           expect(treeView.hasParent()).toBeTruthy()
           expect(treeView.focus).toHaveBeenCalled()
 
-    describe "if the file is selected", ->
-      it "opens selected file", ->
-        file = path.join(atom.project.getPaths()[0], 'dir1', 'file1')
-
-        waitsForPromise ->
-          atom.workspace.open(file)
-
-        runs ->
-          atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-          expect(atom.workspace.getActivePaneItem().getPath()).toBe file
-
     describe "if there is no editor open", ->
       it "shows and focuses the tree view, but does not attempt to select a specific file", ->
         expect(atom.workspace.getActivePaneItem()).toBeUndefined()
@@ -528,6 +517,19 @@ describe "TreeView", ->
       expect(sampleJs).not.toHaveClass 'selected'
       sampleJs.mousedown()
       expect(sampleJs).toHaveClass 'selected'
+
+  describe "when a file is selected", ->
+    fit "it shows the file if the option is set, without changing focus", ->
+      atom.config.set("tree-view.showFileWhenSelected", true)
+      treeView.focus()
+      file = path.join(atom.project.getPaths()[0], 'dir1', 'file1')
+
+      waitsForPromise ->
+        atom.workspace.open(file)
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(atom.workspace.getActivePaneItem().getPath()).toBe file
 
   describe "when a file is single-clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -368,6 +368,17 @@ describe "TreeView", ->
           expect(treeView.hasParent()).toBeTruthy()
           expect(treeView.focus).toHaveBeenCalled()
 
+    describe "if the file is selected", ->
+      it "opens selected file", ->
+        file = path.join(atom.project.getPaths()[0], 'dir1', 'file1')
+
+        waitsForPromise ->
+          atom.workspace.open(file)
+
+        runs ->
+          atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+          expect(atom.workspace.getActivePaneItem().getPath()).toBe file
+
     describe "if there is no editor open", ->
       it "shows and focuses the tree view, but does not attempt to select a specific file", ->
         expect(atom.workspace.getActivePaneItem()).toBeUndefined()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -23,6 +23,7 @@ describe "TreeView", ->
     path1 = path.join(fixturesPath, "root-dir1")
     path2 = path.join(fixturesPath, "root-dir2")
     atom.project.setPaths([path1, path2])
+    atom.config.set("tree-view.showFileWhenSelected", true)
 
     workspaceElement = atom.views.getView(atom.workspace)
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -519,7 +519,7 @@ describe "TreeView", ->
       expect(sampleJs).toHaveClass 'selected'
 
   describe "when a file is selected", ->
-    fit "it shows the file if the option is set, without changing focus", ->
+    it "it shows the file if the option is set, without changing focus", ->
       atom.config.set("tree-view.showFileWhenSelected", true)
       treeView.focus()
       file = path.join(atom.project.getPaths()[0], 'dir1', 'file1')


### PR DESCRIPTION
ST style "preview-on-click" feature that allows files to be shown in the preview pane when navigating the files using the keyboard.  When user press enter, it promotes the file to be a working file.

Added new "Show File When Selected" package setting to turn this feature on:

<img width="266" alt="screen shot 2015-07-05 at 6 11 15 am" src="https://cloud.githubusercontent.com/assets/5921938/8514308/282f2a06-2341-11e5-9932-78e785efcdc0.png">

Works best when Use Preview Tabs (from the **tabs** package setting) is turned on.  Depends on https://github.com/atom/tabs/pull/191
