### PR TITLE
Handle errors thrown from spawning file manager

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -476,7 +476,7 @@ class TreeView extends View
       if process.platform is 'win32' and code is 1 and not error
         failed = false
 
-      handleError(error) if failed
+      handleError(message: error) if failed
 
     showProcess = new BufferedProcess({command, args, stderr, exit})
     showProcess.onWillThrowError ({error, handle}) ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -462,10 +462,9 @@ class TreeView extends View
     {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
 
     handleError = (error) ->
-      atom.confirm
-        message: "Opening #{if isFile then 'file' else 'folder'} in #{label} failed"
-        detailedMessage: error
-        buttons: ['OK']
+      atom.notifications.addError "Opening #{if isFile then 'file' else 'folder'} in #{label} failed",
+        detail: error.message
+        dismissable: true
 
     errorLines = []
     stderr = (lines) -> errorLines.push(lines)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -461,27 +461,27 @@ class TreeView extends View
     isFile = entry instanceof FileView
     {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
 
-    handleError = (error) ->
+    handleError = (errorMessage) ->
       atom.notifications.addError "Opening #{if isFile then 'file' else 'folder'} in #{label} failed",
-        detail: error.message
+        detail: errorMessage
         dismissable: true
 
     errorLines = []
     stderr = (lines) -> errorLines.push(lines)
     exit = (code) ->
       failed = code isnt 0
-      error = errorLines.join('\n')
+      errorMessage = errorLines.join('\n')
 
       # Windows 8 seems to return a 1 with no error output even on success
       if process.platform is 'win32' and code is 1 and not error
         failed = false
 
-      handleError(message: error) if failed
+      handleError(errorMessage) if failed
 
     showProcess = new BufferedProcess({command, args, stderr, exit})
     showProcess.onWillThrowError ({error, handle}) ->
       handle()
-      handleError(error)
+      handleError(error?.message)
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2422,7 +2422,8 @@ describe "TreeView", ->
         atom.notifications.getNotifications().length is 1
 
       runs ->
-        expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder in Finder failed'
+        expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder'
+        expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'failed'
         expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'bad process'
 
     it "handle errors thrown when spawning the OS file manager", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2396,7 +2396,6 @@ describe "TreeView", ->
 
   describe "showSelectedEntryInFileManager()", ->
     it "handle errors thrown when spawning the OS file manager", ->
-      spyOn(atom, 'confirm')
       spyOn(treeView, 'fileManagerCommandForPath').andReturn
         command: '/this/command/does/not/exist'
         label: 'Finder'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2395,7 +2395,7 @@ describe "TreeView", ->
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
   describe "showSelectedEntryInFileManager()", ->
-    it "spawns a command to show the file in the OS file manager", ->
+    it "handle errors throw when spawning the OS file manager", ->
       spyOn(atom, 'confirm')
       spyOn(treeView, 'fileManagerCommandForPath').andReturn
         command: '/this/command/does/not/exist'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2393,3 +2393,14 @@ describe "TreeView", ->
         element.innerText
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
+
+  describe "showSelectedEntryInFileManager()", ->
+    it "spawns a command to show the file in the OS file manager", ->
+      spyOn(atom, 'confirm')
+      spyOn(treeView, 'fileManagerCommandForPath').andReturn
+        command: '/this/command/does/not/exist'
+        label: 'Finder'
+        args: ['foo']
+
+      treeView.showSelectedEntryInFileManager()
+      expect(atom.confirm.callCount).toBe 1

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2395,6 +2395,36 @@ describe "TreeView", ->
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
   describe "showSelectedEntryInFileManager()", ->
+    beforeEach ->
+      atom.notifications.clear()
+
+    it "displays the standard error output when the process fails", ->
+      {BufferedProcess} = require 'atom'
+      spyOn(BufferedProcess.prototype, 'spawn').andCallFake ->
+        EventEmitter = require 'events'
+        fakeProcess = new EventEmitter()
+        fakeProcess.send = ->
+        fakeProcess.kill = ->
+        fakeProcess.stdout = new EventEmitter()
+        fakeProcess.stdout.setEncoding = ->
+        fakeProcess.stderr = new EventEmitter()
+        fakeProcess.stderr.setEncoding = ->
+        @process = fakeProcess
+        process.nextTick ->
+          fakeProcess.stderr.emit('data', 'bad process')
+          fakeProcess.stderr.emit('close')
+          fakeProcess.stdout.emit('close')
+          fakeProcess.emit('exit')
+
+      treeView.showSelectedEntryInFileManager()
+
+      waitsFor ->
+        atom.notifications.getNotifications().length is 1
+
+      runs ->
+        expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder in Finder failed'
+        expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'bad process'
+
     it "handle errors thrown when spawning the OS file manager", ->
       spyOn(treeView, 'fileManagerCommandForPath').andReturn
         command: '/this/command/does/not/exist'
@@ -2408,3 +2438,4 @@ describe "TreeView", ->
 
       runs ->
         expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder in Finder failed'
+        expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'ENOENT'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2403,4 +2403,6 @@ describe "TreeView", ->
         args: ['foo']
 
       treeView.showSelectedEntryInFileManager()
-      expect(atom.confirm.callCount).toBe 1
+
+      waitsFor ->
+        atom.confirm.callCount is 1

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2395,7 +2395,7 @@ describe "TreeView", ->
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
   describe "showSelectedEntryInFileManager()", ->
-    it "handle errors throw when spawning the OS file manager", ->
+    it "handle errors thrown when spawning the OS file manager", ->
       spyOn(atom, 'confirm')
       spyOn(treeView, 'fileManagerCommandForPath').andReturn
         command: '/this/command/does/not/exist'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2405,4 +2405,7 @@ describe "TreeView", ->
       treeView.showSelectedEntryInFileManager()
 
       waitsFor ->
-        atom.confirm.callCount is 1
+        atom.notifications.getNotifications().length is 1
+
+      runs ->
+        expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder in Finder failed'


### PR DESCRIPTION
* Registers a `BufferedProcess.onWillThrowError` handle to catch any errors spawning
* Shows errors in a notification instead of a confirm dialog for an improved experience
* Adds spec for file manager code path

Closes https://github.com/atom/tree-view/issues/495