### PR TITLE
Add paste failure notification

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -12,6 +12,7 @@ realpathCache = {}
 module.exports =
 class Directory
   constructor: ({@name, fullPath, @symlink, @expansionState, @isRoot, @ignoredPatterns}) ->
+    @destroyed = false
     @emitter = new Emitter()
     @subscriptions = new CompositeDisposable()
 
@@ -35,6 +36,7 @@ class Directory
     @loadRealPath()
 
   destroy: ->
+    @destroyed = true
     @unwatch()
     @subscriptions.dispose()
     @emitter.emit('did-destroy')
@@ -53,6 +55,7 @@ class Directory
 
   loadRealPath: ->
     fs.realpath @path, realpathCache, (error, realPath) =>
+      return if @destroyed
       if realPath and realPath isnt @path
         @realPath = realPath
         @lowerCaseRealPath = @realPath.toLowerCase() if fs.isCaseInsensitive()

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -6,6 +6,7 @@ fs = require 'fs-plus'
 module.exports =
 class File
   constructor: ({@name, fullPath, @symlink, realpathCache}) ->
+    @destroyed = false
     @emitter = new Emitter()
     @subscriptions = new CompositeDisposable()
 
@@ -30,11 +31,13 @@ class File
     @updateStatus()
 
     fs.realpath @path, realpathCache, (error, realPath) =>
+      return if @destroyed
       if realPath and realPath isnt @path
         @realPath = realPath
         @updateStatus()
 
   destroy: ->
+    @destroyed = true
     @subscriptions.dispose()
     @emitter.emit('did-destroy')
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -562,39 +562,42 @@ class TreeView extends View
     copiedPaths = if LocalStorage['tree-view:copyPath'] then JSON.parse(LocalStorage['tree-view:copyPath']) else null
     initialPaths = copiedPaths or cutPaths
 
-    try
-      for initialPath in initialPaths ? []
-        initialPathIsDirectory = fs.isDirectorySync(initialPath)
-        if selectedEntry and initialPath and fs.existsSync(initialPath)
-          basePath = selectedEntry.getPath()
-          basePath = path.dirname(basePath) if selectedEntry instanceof FileView
-          newPath = path.join(basePath, path.basename(initialPath))
+    showNotificationForFileErrors = (operation) ->
+      try
+        operation()
+      catch error
+        atom.notifications.addWarning("Unable to paste paths: #{initialPaths}", detail: error.message)
 
-          if copiedPaths
-            # append a number to the file if an item with the same name exists
-            fileCounter = 0
-            originalNewPath = newPath
-            while fs.existsSync(newPath)
-              if initialPathIsDirectory
-                newPath = "#{originalNewPath}#{fileCounter.toString()}"
-              else
-                fileArr = originalNewPath.split('.')
-                newPath = "#{fileArr[0]}#{fileCounter.toString()}.#{fileArr[1]}"
-              fileCounter += 1
+    for initialPath in initialPaths ? []
+      initialPathIsDirectory = fs.isDirectorySync(initialPath)
+      if selectedEntry and initialPath and fs.existsSync(initialPath)
+        basePath = selectedEntry.getPath()
+        basePath = path.dirname(basePath) if selectedEntry instanceof FileView
+        newPath = path.join(basePath, path.basename(initialPath))
 
-            if fs.isDirectorySync(initialPath)
-              # use fs.copy to copy directories since read/write will fail for directories
-              fs.copySync(initialPath, newPath)
+        if copiedPaths
+          # append a number to the file if an item with the same name exists
+          fileCounter = 0
+          originalNewPath = newPath
+          while fs.existsSync(newPath)
+            if initialPathIsDirectory
+              newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
-              # read the old file and write a new one at target location
-              fs.writeFileSync(newPath, fs.readFileSync(initialPath))
-          else if cutPaths
-            # Only move the target if the cut target doesn't exists and if the newPath
-            # is not within the initial path
-            unless fs.existsSync(newPath) or !!newPath.match(new RegExp("^#{initialPath}"))
-              fs.moveSync(initialPath, newPath)
-    catch error
-      atom.notifications.addWarning("Unable to paste paths: #{initialPaths}", detail: error.message)
+              fileArr = originalNewPath.split('.')
+              newPath = "#{fileArr[0]}#{fileCounter.toString()}.#{fileArr[1]}"
+            fileCounter += 1
+
+          if fs.isDirectorySync(initialPath)
+            # use fs.copy to copy directories since read/write will fail for directories
+            showNotificationForFileErrors -> fs.copySync(initialPath, newPath)
+          else
+            # read the old file and write a new one at target location
+            showNotificationForFileErrors -> fs.writeFileSync(newPath, fs.readFileSync(initialPath))
+        else if cutPaths
+          # Only move the target if the cut target doesn't exists and if the newPath
+          # is not within the initial path
+          unless fs.existsSync(newPath) or !!newPath.match(new RegExp("^#{initialPath}"))
+            showNotificationForFileErrors -> fs.moveSync(initialPath, newPath)
 
   add: (isCreatingFile) ->
     selectedEntry = @selectedEntry() ? @roots[0]

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -562,7 +562,7 @@ class TreeView extends View
     copiedPaths = if LocalStorage['tree-view:copyPath'] then JSON.parse(LocalStorage['tree-view:copyPath']) else null
     initialPaths = copiedPaths or cutPaths
 
-    showNotificationForFileErrors = (operation) ->
+    catchAndShowFileErrors = (operation) ->
       try
         operation()
       catch error
@@ -589,15 +589,15 @@ class TreeView extends View
 
           if fs.isDirectorySync(initialPath)
             # use fs.copy to copy directories since read/write will fail for directories
-            showNotificationForFileErrors -> fs.copySync(initialPath, newPath)
+            catchAndShowFileErrors -> fs.copySync(initialPath, newPath)
           else
             # read the old file and write a new one at target location
-            showNotificationForFileErrors -> fs.writeFileSync(newPath, fs.readFileSync(initialPath))
+            catchAndShowFileErrors -> fs.writeFileSync(newPath, fs.readFileSync(initialPath))
         else if cutPaths
           # Only move the target if the cut target doesn't exists and if the newPath
           # is not within the initial path
           unless fs.existsSync(newPath) or !!newPath.match(new RegExp("^#{initialPath}"))
-            showNotificationForFileErrors -> fs.moveSync(initialPath, newPath)
+            catchAndShowFileErrors -> fs.moveSync(initialPath, newPath)
 
   add: (isCreatingFile) ->
     selectedEntry = @selectedEntry() ? @roots[0]

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1413,6 +1413,23 @@ describe "TreeView", ->
             expect(fs.existsSync(path.join(dirPath2, path.basename(filePath)))).toBeTruthy()
             expect(fs.existsSync(filePath)).toBeFalsy()
 
+      describe "when pasting the files fails", ->
+        it "shows a notification", ->
+          spyOn(fs, 'writeFileSync').andCallFake ->
+            writeError = new Error("ENOENT: no such file or directory, open '#{filePath}'")
+            writeError.code = 'ENOENT'
+            writeError.path = filePath
+            throw writeError
+
+          LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
+
+          fileView2.click()
+          atom.notifications.clear()
+          atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Unable to paste paths'
+          expect(atom.notifications.getNotifications()[0].getDetails()).toContain 'ENOENT: no such file or directory'
+
     describe "tree-view:add-file", ->
       [addPanel, addDialog] = []
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1414,7 +1414,7 @@ describe "TreeView", ->
             expect(fs.existsSync(filePath)).toBeFalsy()
 
       describe "when pasting the files fails", ->
-        it "shows a notification", ->
+        fit "shows a notification", ->
           spyOn(fs, 'writeFileSync').andCallFake ->
             writeError = new Error("ENOENT: no such file or directory, open '#{filePath}'")
             writeError.code = 'ENOENT'
@@ -1428,7 +1428,7 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, "tree-view:paste")
 
           expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Unable to paste paths'
-          expect(atom.notifications.getNotifications()[0].getDetails()).toContain 'ENOENT: no such file or directory'
+          expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'ENOENT: no such file or directory'
 
     describe "tree-view:add-file", ->
       [addPanel, addDialog] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1413,8 +1413,8 @@ describe "TreeView", ->
             expect(fs.existsSync(path.join(dirPath2, path.basename(filePath)))).toBeTruthy()
             expect(fs.existsSync(filePath)).toBeFalsy()
 
-      describe "when pasting the files fails", ->
-        fit "shows a notification", ->
+      describe "when pasting the file fails due to a filesystem error", ->
+        it "shows a notification", ->
           spyOn(fs, 'writeFileSync').andCallFake ->
             writeError = new Error("ENOENT: no such file or directory, open '#{filePath}'")
             writeError.code = 'ENOENT'


### PR DESCRIPTION
Write and rename errors were previously uncaught causing unpleasant notifications to be shown for various valid cases where pasting paths could fail, permission issues, no space on device, something else.

Closes #409
Closes #416 
Closes #419
Closes #425
Closes #436
Closes #448
Closes #465
Closes #470