### PR TITLE
Allow reordering project folders via drag and drop

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -49,6 +49,7 @@ class DirectoryView extends HTMLElement
 
     if @directory.isRoot
       @classList.add('project-root')
+      @header.classList.add('project-root-header')
     else
       @draggable = true
       @subscriptions.add @directory.onDidStatusChange => @updateStatus()

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -1,0 +1,174 @@
+BrowserWindow = null # Defer require until actually used
+RendererIpc = require 'ipc'
+
+{$, View} = require 'atom-space-pen-views'
+_ = require 'underscore-plus'
+
+module.exports =
+class ProjectFolderDragAndDropHandler
+  constructor: (@treeView) ->
+    @treeView.on 'dragstart', '.project-root-header', @onDragStart
+    @treeView.on 'dragend', '.project-root-header', @onDragEnd
+    @treeView.on 'dragleave', @onDragLeave
+    @treeView.on 'dragover', @onDragOver
+    @treeView.on 'drop', @onDrop
+
+    RendererIpc.on('tree-view:project-folder-dropped', @onDropOnOtherWindow)
+
+  # unused
+  unsubscribe: ->
+    RendererIpc.removeListener('tree-view:project-folder-dropped', @onDropOnOtherWindow)
+
+  onDragStart: (event) =>
+    event.originalEvent.dataTransfer.setData 'atom-event', 'true'
+
+    element = $(event.target).closest('.project-root-header')
+    projectRoot = $(event.target).closest('.project-root')
+    event.originalEvent.dataTransfer.setDragImage(projectRoot[0], 0, 0)
+    directory = projectRoot[0].directory
+
+    event.originalEvent.dataTransfer.setData 'project-root-index', projectRoot.index()
+
+    rootIndex = -1
+    _.find(@treeView.roots, (root, index) -> root.directory is directory and ((rootIndex = index) or true))
+    event.originalEvent.dataTransfer.setData 'from-root-index', rootIndex
+    event.originalEvent.dataTransfer.setData 'from-root-path', directory.path
+    event.originalEvent.dataTransfer.setData 'from-process-id', @getProcessId()
+    event.originalEvent.dataTransfer.setData 'from-routing-id', @getRoutingId()
+
+    event.originalEvent.dataTransfer.setData 'text/plain', directory.path
+
+    if process.platform is 'darwin'
+      pathUri = "file://#{directory.path}" unless @uriHasProtocol(directory.path)
+      event.originalEvent.dataTransfer.setData 'text/uri-list', pathUri
+
+  uriHasProtocol: (uri) ->
+    try
+      require('url').parse(uri).protocol?
+    catch error
+      false
+
+  onDragLeave: (event) =>
+    @removePlaceholder()
+
+  onDragEnd: (event) =>
+    @clearDropTarget()
+
+  onDragOver: (event) =>
+    unless event.originalEvent.dataTransfer.getData('atom-event') is 'true'
+      event.preventDefault()
+      event.stopPropagation()
+      return
+
+    event.preventDefault()
+    event.stopPropagation()
+    newDropTargetIndex = @getDropTargetIndex(event)
+    return unless newDropTargetIndex?
+
+    @removeDropTargetClasses()
+
+    projectRoots = $(@treeView.roots)
+
+    if newDropTargetIndex < projectRoots.length
+      element = projectRoots.eq(newDropTargetIndex).addClass 'is-drop-target'
+      @getPlaceholder().insertBefore(element)
+    else
+      element = projectRoots.eq(newDropTargetIndex - 1).addClass 'drop-target-is-after'
+      @getPlaceholder().insertAfter(element)
+
+  onDropOnOtherWindow: (fromItemIndex) =>
+    paths = atom.project.getPaths()
+    paths.splice(fromItemIndex, 1)
+    atom.project.setPaths(paths)
+
+    @clearDropTarget()
+
+  clearDropTarget: ->
+    element = @treeView.find(".is-dragging")
+    element.removeClass 'is-dragging'
+    element[0]?.updateTooltip()
+    @removeDropTargetClasses()
+    @removePlaceholder()
+
+  onDrop: (event) =>
+    event.preventDefault()
+    {dataTransfer} = event.originalEvent
+
+    return unless dataTransfer.getData('atom-event') is 'true'
+
+    fromProcessId = parseInt(dataTransfer.getData('from-process-id'))
+    fromRoutingId = parseInt(dataTransfer.getData('from-routing-id'))
+    fromRootPath  = dataTransfer.getData('from-root-path')
+    fromIndex     = parseInt(dataTransfer.getData('project-root-index'))
+    fromRootIndex = parseInt(dataTransfer.getData('from-root-index'))
+
+    toIndex = @getDropTargetIndex(event)
+
+    @clearDropTarget()
+
+    if fromProcessId is @getProcessId()
+      unless fromIndex is toIndex
+        projectPaths = atom.project.getPaths()
+        projectPaths.splice(fromIndex, 1)
+        if toIndex > fromIndex then toIndex -= 1
+        projectPaths.splice(toIndex, 0, fromRootPath)
+        atom.project.setPaths(projectPaths)
+    else
+      projectPaths = atom.project.getPaths()
+      projectPaths.splice(toIndex, 0, fromRootPath)
+      atom.project.setPaths(projectPaths)
+
+      if not isNaN(fromProcessId) and not isNaN(fromRoutingId)
+        # Let the window where the drag started know that the tab was dropped
+        browserWindow = @browserWindowForProcessIdAndRoutingId(fromProcessId, fromRoutingId)
+        browserWindow?.webContents.send('tree-view:project-folder-dropped', fromIndex)
+
+  removeDropTargetClasses: ->
+    workspaceElement = $(atom.views.getView(atom.workspace))
+    workspaceElement.find('.tree-view .is-drop-target').removeClass 'is-drop-target'
+    workspaceElement.find('.tree-view .drop-target-is-after').removeClass 'drop-target-is-after'
+
+  getDropTargetIndex: (event) ->
+    target = $(event.target)
+
+    return if @isPlaceholder(target)
+
+    projectRoots = $(@treeView.roots)
+    element = target.closest('.project-root')
+    element = projectRoots.last() if element.length is 0
+
+    return 0 unless element.length
+
+    elementCenter = element.offset().top + element.height() / 2
+
+    if event.originalEvent.pageY < elementCenter
+      projectRoots.index(element)
+    else if element.next('.project-root').length > 0
+      projectRoots.index(element.next('.project-root'))
+    else
+      projectRoots.index(element) + 1
+
+
+  getPlaceholder: ->
+    @placeholderEl ?= $('<li/>', class: 'placeholder')
+
+  removePlaceholder: ->
+    @placeholderEl?.remove()
+    @placeholderEl = null
+
+  isPlaceholder: (element) ->
+    element.is('.placeholder')
+
+  getProcessId: ->
+    @processId ?= atom.getCurrentWindow().getProcessId()
+
+  getRoutingId: ->
+    @routingId ?= atom.getCurrentWindow().getRoutingId()
+
+  browserWindowForProcessIdAndRoutingId: (processId, routingId) ->
+    BrowserWindow ?= require('remote').require('browser-window')
+    for browserWindow in BrowserWindow.getAllWindows()
+      if browserWindow.getProcessId() is processId and browserWindow.getRoutingId() is routingId
+        return browserWindow
+
+    return

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -33,7 +33,7 @@ class ProjectFolderDragAndDropHandler
 
     event.originalEvent.dataTransfer.setData 'text/plain', directory.path
 
-    if process.platform is 'darwin'
+    if process.platform in ['darwin', 'linux']
       pathUri = "file://#{directory.path}" unless @uriHasProtocol(directory.path)
       event.originalEvent.dataTransfer.setData 'text/uri-list', pathUri
 
@@ -90,6 +90,7 @@ class ProjectFolderDragAndDropHandler
     event.preventDefault()
     {dataTransfer} = event.originalEvent
 
+    # TODO: support dragging folders from the filesystem -- electron needs to add support first
     return unless dataTransfer.getData('atom-event') is 'true'
 
     fromWindowId = parseInt(dataTransfer.getData('from-window-id'))

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -129,19 +129,21 @@ class ProjectFolderDragAndDropHandler
     return if @isPlaceholder(target)
 
     projectRoots = $(@treeView.roots)
-    element = target.closest('.project-root')
-    element = projectRoots.last() if element.length is 0
+    projectRoot = target.closest('.project-root')
+    projectRoot = projectRoots.last() if projectRoot.length is 0
 
-    return 0 unless element.length
+    return 0 unless projectRoot.length
+
+    element = projectRoot.find('.project-root-header')
 
     elementCenter = element.offset().top + element.height() / 2
 
     if event.originalEvent.pageY < elementCenter
-      projectRoots.index(element)
-    else if element.next('.project-root').length > 0
-      projectRoots.index(element.next('.project-root'))
+      projectRoots.index(projectRoot)
+    else if projectRoot.next('.project-root').length > 0
+      projectRoots.index(projectRoot.next('.project-root'))
     else
-      projectRoots.index(element) + 1
+      projectRoots.index(projectRoot) + 1
 
   isMovingProjectFolders: (event) ->
     target = $(event.target)
@@ -150,8 +152,10 @@ class ProjectFolderDragAndDropHandler
     element = target.closest('.project-root-header')
     return false unless element.length
 
-    elementCenter = element.offset().top + element.height() / 2
-    return true if event.originalEvent.pageY < elementCenter
+    elementTop30 = element.offset().top + element.height() * 0.3
+    return true if event.originalEvent.pageY < elementTop30
+    elementBottom30 = element.offset().top + element.height() * 0.7
+    return true if event.originalEvent.pageY > elementBottom30
 
     false
 

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -26,7 +26,8 @@ class ProjectFolderDragAndDropHandler
     event.originalEvent.dataTransfer.setData 'project-root-index', projectRoot.index()
 
     rootIndex = -1
-    _.find(@treeView.roots, (root, index) -> root.directory is directory and ((rootIndex = index) or true))
+    (rootIndex = index; break) for root, index in @treeView.roots when root.directory is directory
+
     event.originalEvent.dataTransfer.setData 'from-root-index', rootIndex
     event.originalEvent.dataTransfer.setData 'from-root-path', directory.path
     event.originalEvent.dataTransfer.setData 'from-window-id', @getWindowId()

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -1,5 +1,6 @@
-BrowserWindow = null # Defer require until actually used
-{ipcRenderer} = require 'electron'
+url = require 'url'
+
+{ipcRenderer, remote} = require 'electron'
 
 {$, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
@@ -37,7 +38,7 @@ class ProjectFolderDragAndDropHandler
 
   uriHasProtocol: (uri) ->
     try
-      require('url').parse(uri).protocol?
+      url.parse(uri).protocol?
     catch error
       false
 
@@ -114,7 +115,7 @@ class ProjectFolderDragAndDropHandler
 
       if not isNaN(fromWindowId)
         # Let the window where the drag started know that the tab was dropped
-        browserWindow = @browserWindowForId(fromWindowId)
+        browserWindow = remote.BrowserWindow.fromId(fromWindowId)
         browserWindow?.webContents.send('tree-view:project-folder-dropped', fromIndex)
 
   removeDropTargetClasses: ->
@@ -162,7 +163,3 @@ class ProjectFolderDragAndDropHandler
 
   getWindowId: ->
     @processId ?= atom.getCurrentWindow().id
-
-  browserWindowForId: (id) ->
-    BrowserWindow ?= require('remote').require('browser-window')
-    BrowserWindow.fromId id

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -1,5 +1,5 @@
 BrowserWindow = null # Defer require until actually used
-RendererIpc = require 'ipc'
+{ipcRenderer} = require 'electron'
 
 {$, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
@@ -9,11 +9,11 @@ class ProjectFolderDragAndDropHandler
   constructor: (@treeView) ->
     @treeView.on 'dragend', '.project-root-header', @onDragEnd
 
-    RendererIpc.on('tree-view:project-folder-dropped', @onDropOnOtherWindow)
+    ipcRenderer.on('tree-view:project-folder-dropped', @onDropOnOtherWindow)
 
   # unused
   unsubscribe: ->
-    RendererIpc.removeListener('tree-view:project-folder-dropped', @onDropOnOtherWindow)
+    ipcRenderer.removeListener('tree-view:project-folder-dropped', @onDropOnOtherWindow)
 
   onDragStart: (event) =>
     event.originalEvent.dataTransfer.setData 'atom-event', 'true'
@@ -70,7 +70,7 @@ class ProjectFolderDragAndDropHandler
       element = projectRoots.eq(newDropTargetIndex - 1).addClass 'drop-target-is-after'
       @getPlaceholder().insertAfter(element)
 
-  onDropOnOtherWindow: (fromItemIndex) =>
+  onDropOnOtherWindow: (event, fromItemIndex) =>
     paths = atom.project.getPaths()
     paths.splice(fromItemIndex, 1)
     atom.project.setPaths(paths)

--- a/lib/project-folder-dnd-handler.coffee
+++ b/lib/project-folder-dnd-handler.coffee
@@ -16,9 +16,6 @@ class ProjectFolderDragAndDropHandler
     RendererIpc.removeListener('tree-view:project-folder-dropped', @onDropOnOtherWindow)
 
   onDragStart: (event) =>
-    unless $(event.target).closest('.project-root-header').size()
-      return
-
     event.originalEvent.dataTransfer.setData 'atom-event', 'true'
     projectRoot = $(event.target).closest('.project-root')
     directory = projectRoot[0].directory
@@ -147,19 +144,11 @@ class ProjectFolderDragAndDropHandler
     else
       projectRoots.index(projectRoot) + 1
 
-  isMovingProjectFolders: (event) ->
-    target = $(event.target)
-    return null if @isPlaceholder(target)
+  canDragStart: (event) ->
+    $(event.target).closest('.project-root-header').size() > 0
 
-    element = target.closest('.project-root-header')
-    return false unless element.length
-
-    elementTop30 = element.offset().top + element.height() * 0.3
-    return true if event.originalEvent.pageY < elementTop30
-    elementBottom30 = element.offset().top + element.height() * 0.7
-    return true if event.originalEvent.pageY > elementBottom30
-
-    false
+  isDragging: (event) ->
+    Boolean event.originalEvent.dataTransfer.getData 'from-root-path'
 
   getPlaceholder: ->
     @placeholderEl ?= $('<li/>', class: 'placeholder')

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -24,6 +24,7 @@ class RootDragAndDropHandler
     @treeView.on 'drop', '.tree-view', @onDrop
 
   onDragStart: (e) =>
+    @prevDropTargetIndex = null
     e.originalEvent.dataTransfer.setData 'atom-event', 'true'
     projectRoot = $(e.target).closest('.project-root')
     directory = projectRoot[0].directory
@@ -75,6 +76,8 @@ class RootDragAndDropHandler
 
     newDropTargetIndex = @getDropTargetIndex(e)
     return unless newDropTargetIndex?
+    return if @prevDropTargetIndex is newDropTargetIndex
+    @prevDropTargetIndex = newDropTargetIndex
 
     @removeDropTargetClasses()
 

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -49,7 +49,7 @@ class RootDragAndDropHandler
     catch error
       false
 
-  onDragEnter: (e) =>
+  onDragEnter: (e) ->
     e.stopPropagation()
 
   onDragLeave: (e) =>

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -25,7 +25,7 @@ class RootDragAndDropHandler
 
   onDragStart: (e) =>
     @prevDropTargetIndex = null
-    e.originalEvent.dataTransfer.setData 'atom-event', 'true'
+    e.originalEvent.dataTransfer.setData 'atom-tree-view-event', 'true'
     projectRoot = $(e.target).closest('.project-root')
     directory = projectRoot[0].directory
 
@@ -62,7 +62,7 @@ class RootDragAndDropHandler
     @clearDropTarget()
 
   onDragOver: (e) =>
-    unless e.originalEvent.dataTransfer.getData('atom-event') is 'true'
+    unless e.originalEvent.dataTransfer.getData('atom-tree-view-event') is 'true'
       return
 
     e.preventDefault()
@@ -110,7 +110,7 @@ class RootDragAndDropHandler
     {dataTransfer} = e.originalEvent
 
     # TODO: support dragging folders from the filesystem -- electron needs to add support first
-    return unless dataTransfer.getData('atom-event') is 'true'
+    return unless dataTransfer.getData('atom-tree-view-event') is 'true'
 
     fromWindowId = parseInt(dataTransfer.getData('from-window-id'))
     fromRootPath  = dataTransfer.getData('from-root-path')

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -149,11 +149,9 @@ class RootDragAndDropHandler
 
     return 0 unless projectRoot.length
 
-    element = projectRoot.find('.project-root-header')
+    center = projectRoot.offset().top + projectRoot.height() / 2
 
-    elementCenter = element.offset().top + element.height() / 2
-
-    if e.originalEvent.pageY < elementCenter
+    if e.originalEvent.pageY < center
       projectRoots.index(projectRoot)
     else if projectRoot.next('.project-root').length > 0
       projectRoots.index(projectRoot.next('.project-root'))

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -6,7 +6,7 @@ url = require 'url'
 _ = require 'underscore-plus'
 
 module.exports =
-class ProjectFolderDragAndDropHandler
+class RootDragAndDropHandler
   constructor: (@treeView) ->
     @treeView.on 'dragend', '.project-root-header', @onDragEnd
 

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -8,12 +8,12 @@ _ = require 'underscore-plus'
 module.exports =
 class RootDragAndDropHandler
   constructor: (@treeView) ->
-    @treeView.on 'dragend', '.project-root-header', @onDragEnd
-
     ipcRenderer.on('tree-view:project-folder-dropped', @onDropOnOtherWindow)
 
-  # unused
-  unsubscribe: ->
+    # will be cleaned up by tree view
+    @treeView.on 'dragend', '.project-root-header', @onDragEnd
+
+  dispose: ->
     ipcRenderer.removeListener('tree-view:project-folder-dropped', @onDropOnOtherWindow)
 
   onDragStart: (event) =>
@@ -65,10 +65,12 @@ class RootDragAndDropHandler
     projectRoots = $(@treeView.roots)
 
     if newDropTargetIndex < projectRoots.length
-      element = projectRoots.eq(newDropTargetIndex).addClass 'is-drop-target'
+      element = projectRoots.eq(newDropTargetIndex)
+      element.addClass 'is-drop-target'
       @getPlaceholder().insertBefore(element)
     else
-      element = projectRoots.eq(newDropTargetIndex - 1).addClass 'drop-target-is-after'
+      element = projectRoots.eq(newDropTargetIndex - 1)
+      element.addClass 'drop-target-is-after'
       @getPlaceholder().insertAfter(element)
 
   onDropOnOtherWindow: (event, fromItemIndex) =>

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -79,8 +79,6 @@ class RootDragAndDropHandler
     return if @prevDropTargetIndex is newDropTargetIndex
     @prevDropTargetIndex = newDropTargetIndex
 
-    @removeDropTargetClasses()
-
     projectRoots = $(@treeView.roots)
 
     if newDropTargetIndex < projectRoots.length
@@ -103,7 +101,6 @@ class RootDragAndDropHandler
     element = @treeView.find(".is-dragging")
     element.removeClass 'is-dragging'
     element[0]?.updateTooltip()
-    @removeDropTargetClasses()
     @removePlaceholder()
 
   onDrop: (e) =>
@@ -140,11 +137,6 @@ class RootDragAndDropHandler
         # Let the window where the drag started know that the tab was dropped
         browserWindow = remote.BrowserWindow.fromId(fromWindowId)
         browserWindow?.webContents.send('tree-view:project-folder-dropped', fromIndex)
-
-  removeDropTargetClasses: ->
-    workspaceElement = $(atom.views.getView(atom.workspace))
-    workspaceElement.find('.tree-view .is-drop-target').removeClass 'is-drop-target'
-    workspaceElement.find('.tree-view .drop-target-is-after').removeClass 'drop-target-is-after'
 
   getDropTargetIndex: (e) ->
     target = $(e.target)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -105,6 +105,8 @@ class TreeView extends View
     @on 'dragleave', '.entry.directory > .header', (e) => @onDragLeave(e)
     @on 'dragover', '.entry', (e) => @onDragOver(e)
     @on 'drop', '.entry', (e) => @onDrop(e)
+    @on 'dragover', '.tree-view', (e) => @onDragOverTree(e)
+    @on 'drop', '.tree-view', (e) => @onDropTree(e)
 
     atom.commands.add @element,
      'core:move-up': @moveUp.bind(this)
@@ -912,3 +914,18 @@ class TreeView extends View
       # Drop event from OS
       for file in e.originalEvent.dataTransfer.files
         @moveEntry(file.path, newDirectoryPath)
+
+  # handle drag over and drop on the empty space in which there are no entries
+  onDragOverTree: (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+
+    if @projectFolderDragAndDropHandler.isDragging(e)
+      return @projectFolderDragAndDropHandler.onDragOver(e)
+
+  onDropTree: (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+
+    if @projectFolderDragAndDropHandler.isDragging(e)
+      return @projectFolderDragAndDropHandler.onDrop(e)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -15,7 +15,7 @@ Minimatch = null  # Defer requiring until actually needed
 Directory = require './directory'
 DirectoryView = require './directory-view'
 FileView = require './file-view'
-ProjectFolderDragAndDropHandler = require './project-folder-dnd-handler'
+RootDragAndDrop = require './root-drag-and-drop'
 LocalStorage = window.localStorage
 
 toggleConfig = (keyPath) ->
@@ -43,7 +43,7 @@ class TreeView extends View
     @currentlyOpening = new Map
 
     @dragEventCounts = new WeakMap
-    @projectFolderDragAndDropHandler = new ProjectFolderDragAndDropHandler(this)
+    @rootDragAndDrop = new RootDragAndDrop(this)
 
     @handleEvents()
 
@@ -831,7 +831,7 @@ class TreeView extends View
   onDragEnter: (e) =>
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
+    if @rootDragAndDrop.isDragging(e)
       return
 
     entry = e.currentTarget.parentNode
@@ -842,8 +842,8 @@ class TreeView extends View
   onDragLeave: (e) =>
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
-      return @projectFolderDragAndDropHandler.onDragLeave(e)
+    if @rootDragAndDrop.isDragging(e)
+      return @rootDragAndDrop.onDragLeave(e)
 
     entry = e.currentTarget.parentNode
     @dragEventCounts.set(entry, @dragEventCounts.get(entry) - 1)
@@ -853,8 +853,8 @@ class TreeView extends View
   onDragStart: (e) ->
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.canDragStart(e)
-      return @projectFolderDragAndDropHandler.onDragStart(e)
+    if @rootDragAndDrop.canDragStart(e)
+      return @rootDragAndDrop.onDragStart(e)
 
     target = $(e.currentTarget).find(".name")
     initialPath = target.data("path")
@@ -882,8 +882,8 @@ class TreeView extends View
     e.preventDefault()
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
-      return @projectFolderDragAndDropHandler.onDragOver(e)
+    if @rootDragAndDrop.isDragging(e)
+      return @rootDragAndDrop.onDragOver(e)
 
     entry = e.currentTarget
     if @dragEventCounts.get(entry) > 0 and not entry.classList.contains('selected')
@@ -894,8 +894,8 @@ class TreeView extends View
     e.preventDefault()
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
-      return @projectFolderDragAndDropHandler.onDrop(e)
+    if @rootDragAndDrop.isDragging(e)
+      return @rootDragAndDrop.onDrop(e)
 
     entry = e.currentTarget
     entry.classList.remove('selected')
@@ -920,12 +920,12 @@ class TreeView extends View
     e.preventDefault()
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
-      return @projectFolderDragAndDropHandler.onDragOver(e)
+    if @rootDragAndDrop.isDragging(e)
+      return @rootDragAndDrop.onDragOver(e)
 
   onDropTree: (e) ->
     e.preventDefault()
     e.stopPropagation()
 
-    if @projectFolderDragAndDropHandler.isDragging(e)
-      return @projectFolderDragAndDropHandler.onDrop(e)
+    if @rootDragAndDrop.isDragging(e)
+      return @rootDragAndDrop.onDrop(e)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -106,8 +106,6 @@ class TreeView extends View
     @on 'dragleave', '.entry.directory > .header', (e) => @onDragLeave(e)
     @on 'dragover', '.entry', (e) => @onDragOver(e)
     @on 'drop', '.entry', (e) => @onDrop(e)
-    @on 'dragover', '.tree-view', (e) => @onDragOverTree(e)
-    @on 'drop', '.tree-view', (e) => @onDropTree(e)
 
     atom.commands.add @element,
      'core:move-up': @moveUp.bind(this)
@@ -830,10 +828,9 @@ class TreeView extends View
     @list[0].classList.contains('multi-select')
 
   onDragEnter: (e) =>
-    e.stopPropagation()
+    return if @rootDragAndDrop.isDragging(e)
 
-    if @rootDragAndDrop.isDragging(e)
-      return
+    e.stopPropagation()
 
     entry = e.currentTarget.parentNode
     @dragEventCounts.set(entry, 0) unless @dragEventCounts.get(entry)
@@ -841,10 +838,9 @@ class TreeView extends View
     @dragEventCounts.set(entry, @dragEventCounts.get(entry) + 1)
 
   onDragLeave: (e) =>
-    e.stopPropagation()
+    return if @rootDragAndDrop.isDragging(e)
 
-    if @rootDragAndDrop.isDragging(e)
-      return @rootDragAndDrop.onDragLeave(e)
+    e.stopPropagation()
 
     entry = e.currentTarget.parentNode
     @dragEventCounts.set(entry, @dragEventCounts.get(entry) - 1)
@@ -880,11 +876,10 @@ class TreeView extends View
 
   # Handle entry dragover event; reset default dragover actions
   onDragOver: (e) ->
+    return if @rootDragAndDrop.isDragging(e)
+
     e.preventDefault()
     e.stopPropagation()
-
-    if @rootDragAndDrop.isDragging(e)
-      return @rootDragAndDrop.onDragOver(e)
 
     entry = e.currentTarget
     if @dragEventCounts.get(entry) > 0 and not entry.classList.contains('selected')
@@ -892,11 +887,10 @@ class TreeView extends View
 
   # Handle entry drop event
   onDrop: (e) ->
+    return if @rootDragAndDrop.isDragging(e)
+
     e.preventDefault()
     e.stopPropagation()
-
-    if @rootDragAndDrop.isDragging(e)
-      return @rootDragAndDrop.onDrop(e)
 
     entry = e.currentTarget
     entry.classList.remove('selected')
@@ -915,18 +909,3 @@ class TreeView extends View
       # Drop event from OS
       for file in e.originalEvent.dataTransfer.files
         @moveEntry(file.path, newDirectoryPath)
-
-  # handle drag over and drop on the empty space in which there are no entries
-  onDragOverTree: (e) ->
-    e.preventDefault()
-    e.stopPropagation()
-
-    if @rootDragAndDrop.isDragging(e)
-      return @rootDragAndDrop.onDragOver(e)
-
-  onDropTree: (e) ->
-    e.preventDefault()
-    e.stopPropagation()
-
-    if @rootDragAndDrop.isDragging(e)
-      return @rootDragAndDrop.onDrop(e)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -87,6 +87,7 @@ class TreeView extends View
   deactivate: ->
     root.directory.destroy() for root in @roots
     @disposables.dispose()
+    @rootDragAndDrop.dispose()
     @detach() if @panel?
 
   handleEvents: ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -15,6 +15,7 @@ Minimatch = null  # Defer requiring until actually needed
 Directory = require './directory'
 DirectoryView = require './directory-view'
 FileView = require './file-view'
+ProjectFolderDragAndDropHandler = require './project-folder-dnd-handler'
 LocalStorage = window.localStorage
 
 toggleConfig = (keyPath) ->
@@ -40,6 +41,8 @@ class TreeView extends View
     @ignoredPatterns = []
 
     @dragEventCounts = new WeakMap
+    // TODO: use dragEventCounts & existing drag handlers
+    @projectFolderDragAndDropHandler = new ProjectFolderDragAndDropHandler(this)
 
     @handleEvents()
 

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -40,3 +40,39 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
     dropEvent.originalEvent.dataTransfer.files.push({path: filePath})
 
   dropEvent
+
+buildElementPositionalDragEvents = (el, dataTransfer) ->
+  if not el?
+    return {}
+  $el = $(el)
+  topEvent = $.Event()
+  topEvent.target = el
+  topEvent.currentTarget = el
+  topEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().top}
+
+  middleEvent = $.Event()
+  middleEvent.target = el
+  middleEvent.currentTarget = el
+  middleEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().top + $el.height() * 0.5}
+
+  bottomEvent = $.Event()
+  bottomEvent.target = el
+  bottomEvent.currentTarget = el
+  bottomEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().bottom}
+
+  {top: topEvent, middle: middleEvent, bottom: bottomEvent}
+
+
+module.exports.buildPositionalDragEvents = (dragged, target) ->
+  dataTransfer =
+    data: {}
+    setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
+    getData: (key) -> @data[key]
+    setDragImage: (@image) -> return
+
+  dragStartEvent = $.Event()
+  dragStartEvent.target = dragged
+  dragStartEvent.currentTarget = dragged
+  dragStartEvent.originalEvent = {dataTransfer, "atom-event": true}
+
+  [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer)]

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -41,29 +41,33 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
 
   dropEvent
 
-buildElementPositionalDragEvents = (el, dataTransfer) ->
+buildElementPositionalDragEvents = (el, dataTransfer, currentTargetSelector) ->
   if not el?
     return {}
   $el = $(el)
+
+  $currentTarget = if currentTargetSelector then $el.closest(currentTargetSelector) else $el
+  currentTarget = $currentTarget[0]
+
   topEvent = $.Event()
   topEvent.target = el
-  topEvent.currentTarget = el
+  topEvent.currentTarget = currentTarget
   topEvent.originalEvent = {dataTransfer, pageY: $el.offset().top}
 
   middleEvent = $.Event()
   middleEvent.target = el
-  middleEvent.currentTarget = el
+  middleEvent.currentTarget = currentTarget
   middleEvent.originalEvent = {dataTransfer, pageY: $el.offset().top + $el.height() * 0.5}
 
   bottomEvent = $.Event()
   bottomEvent.target = el
-  bottomEvent.currentTarget = el
+  bottomEvent.currentTarget = currentTarget
   bottomEvent.originalEvent = {dataTransfer, pageY: $el.offset().bottom}
 
   {top: topEvent, middle: middleEvent, bottom: bottomEvent}
 
 
-module.exports.buildPositionalDragEvents = (dragged, target) ->
+module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelector) ->
   dataTransfer =
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
@@ -80,4 +84,4 @@ module.exports.buildPositionalDragEvents = (dragged, target) ->
   dragEndEvent.currentTarget = dragged
   dragEndEvent.originalEvent = {dataTransfer}
 
-  [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer), dragEndEvent]
+  [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer, currentTargetSelector), dragEndEvent]

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -75,4 +75,9 @@ module.exports.buildPositionalDragEvents = (dragged, target) ->
   dragStartEvent.currentTarget = dragged
   dragStartEvent.originalEvent = {dataTransfer}
 
-  [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer)]
+  dragEndEvent = $.Event()
+  dragEndEvent.target = dragged
+  dragEndEvent.currentTarget = dragged
+  dragEndEvent.originalEvent = {dataTransfer}
+
+  [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer), dragEndEvent]

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -48,17 +48,17 @@ buildElementPositionalDragEvents = (el, dataTransfer) ->
   topEvent = $.Event()
   topEvent.target = el
   topEvent.currentTarget = el
-  topEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().top}
+  topEvent.originalEvent = {dataTransfer, pageY: $el.offset().top}
 
   middleEvent = $.Event()
   middleEvent.target = el
   middleEvent.currentTarget = el
-  middleEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().top + $el.height() * 0.5}
+  middleEvent.originalEvent = {dataTransfer, pageY: $el.offset().top + $el.height() * 0.5}
 
   bottomEvent = $.Event()
   bottomEvent.target = el
   bottomEvent.currentTarget = el
-  bottomEvent.originalEvent = {dataTransfer, "atom-event": true, pageY: $el.offset().bottom}
+  bottomEvent.originalEvent = {dataTransfer, pageY: $el.offset().bottom}
 
   {top: topEvent, middle: middleEvent, bottom: bottomEvent}
 
@@ -73,6 +73,6 @@ module.exports.buildPositionalDragEvents = (dragged, target) ->
   dragStartEvent = $.Event()
   dragStartEvent.target = dragged
   dragStartEvent.currentTarget = dragged
-  dragStartEvent.originalEvent = {dataTransfer, "atom-event": true}
+  dragStartEvent.originalEvent = {dataTransfer}
 
   [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer)]

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3521,7 +3521,7 @@ describe "TreeView", ->
         gammaDir = $(treeView).find('.project-root:contains(gamma):first')
         [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
         treeView.onDragStart(dragStartEvent)
-        treeView.projectFolderDragAndDropHandler.onDropOnOtherWindow(gammaDir.index())
+        treeView.projectFolderDragAndDropHandler.onDropOnOtherWindow({}, gammaDir.index())
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
         expect('.placeholder').not.toExist()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3042,8 +3042,8 @@ describe "TreeView", ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dragDropEvents.top)
           projectPaths = atom.project.getPaths()
-          expect(projectPaths[0]).toEqual(gammaDirPath);
-          expect(projectPaths[1]).toEqual(alphaDirPath);
+          expect(projectPaths[0]).toEqual(gammaDirPath)
+          expect(projectPaths[1]).toEqual(alphaDirPath)
 
           # Is removed when drag ends
           expect('.placeholder').not.toExist()
@@ -3059,9 +3059,9 @@ describe "TreeView", ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dragDropEvents.bottom)
           projectPaths = atom.project.getPaths()
-          expect(projectPaths[0]).toEqual(alphaDirPath);
-          expect(projectPaths[1]).toEqual(thetaDirPath);
-          expect(projectPaths[2]).toEqual(gammaDirPath);
+          expect(projectPaths[0]).toEqual(alphaDirPath)
+          expect(projectPaths[1]).toEqual(thetaDirPath)
+          expect(projectPaths[2]).toEqual(gammaDirPath)
 
           # Is removed when drag ends
           expect('.placeholder').not.toExist()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3410,24 +3410,6 @@ describe "TreeView", ->
           treeView.projectFolderDragAndDropHandler.onDragEnd()
           expect('.placeholder').not.toExist()
 
-      describe "when dragging on the middle part of the header", ->
-        it "should not add the placeholder", ->
-          # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-          [dragStartEvent, dragOverEvents] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
-
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDragEnter(dragOverEvents.middle)
-          treeView.onDragOver(dragOverEvents.middle)
-          expect(alphaDir).toHaveClass('selected')
-          expect('.placeholder').not.toExist()
-
-          # Is removed when drag ends
-          treeView.projectFolderDragAndDropHandler.onDragEnd()
-          expect('.placeholder').not.toExist()
-
       describe "when dragging on the bottom part of the header", ->
         it "should add the placeholder below the directory", ->
           # Dragging gammaDir onto alphaDir

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -4,6 +4,7 @@ fs = require 'fs-plus'
 path = require 'path'
 temp = require('temp').track()
 os = require 'os'
+{remote} = require 'electron'
 eventHelpers = require "./event-helpers"
 
 DefaultFileIcons = require '../lib/default-file-icons'
@@ -3503,7 +3504,7 @@ describe "TreeView", ->
 
         # mock browserWindowForId
         browserWindowMock = {webContents: {send: ->}}
-        treeView.projectFolderDragAndDropHandler.browserWindowForId = -> browserWindowMock
+        spyOn(remote.BrowserWindow, 'fromId').andReturn(browserWindowMock)
         spyOn(browserWindowMock.webContents, 'send')
 
         treeView.onDrop(dropEvent)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3426,6 +3426,25 @@ describe "TreeView", ->
           treeView.projectFolderDragAndDropHandler.onDragEnd()
           expect('.placeholder').not.toExist()
 
+      describe "when below all entries", ->
+        it "should add the placeholder below the last directory", ->
+          # Dragging gammaDir onto alphaDir
+          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
+          lastDir = $(treeView).find('.project-root:last')
+          [dragStartEvent, dragOverEvents] =
+            eventHelpers.buildPositionalDragEvents(alphaDir.find('.project-root-header')[0], treeView.find('.tree-view')[0])
+
+          expect(alphaDir[0]).not.toEqual(lastDir[0])
+
+          treeView.onDragStart(dragStartEvent)
+          treeView.onDragOver(dragOverEvents.bottom)
+          expect(lastDir[0].nextSibling).toHaveClass('placeholder')
+
+          # Is removed when drag ends
+          treeView.projectFolderDragAndDropHandler.onDragEnd()
+          expect('.placeholder').not.toExist()
+
+
     describe "when dropping a project root's header onto a different project root's header", ->
       describe "when dropping on the top part of the header", ->
         it "should add the placeholder above the directory", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3408,7 +3408,7 @@ describe "TreeView", ->
           expect(alphaDir[0].previousSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.projectFolderDragAndDropHandler.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd()
           expect('.placeholder').not.toExist()
 
       describe "when dragging on the bottom part of the header", ->
@@ -3424,7 +3424,7 @@ describe "TreeView", ->
           expect(alphaDir[0].nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.projectFolderDragAndDropHandler.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd()
           expect('.placeholder').not.toExist()
 
       describe "when below all entries", ->
@@ -3442,7 +3442,7 @@ describe "TreeView", ->
           expect(lastDir[0].nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.projectFolderDragAndDropHandler.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd()
           expect('.placeholder').not.toExist()
 
 
@@ -3499,7 +3499,7 @@ describe "TreeView", ->
 
         dropEvent = dragDropEvents.bottom
         dropEvent.originalEvent.dataTransfer.setData('atom-event', true)
-        dropEvent.originalEvent.dataTransfer.setData('from-window-id', treeView.projectFolderDragAndDropHandler.getWindowId() + 1)
+        dropEvent.originalEvent.dataTransfer.setData('from-window-id', treeView.rootDragAndDrop.getWindowId() + 1)
         dropEvent.originalEvent.dataTransfer.setData('from-root-path', etaDirPath)
 
         # mock browserWindowForId
@@ -3522,7 +3522,7 @@ describe "TreeView", ->
         gammaDir = $(treeView).find('.project-root:contains(gamma):first')
         [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
         treeView.onDragStart(dragStartEvent)
-        treeView.projectFolderDragAndDropHandler.onDropOnOtherWindow({}, gammaDir.index())
+        treeView.rootDragAndDrop.onDropOnOtherWindow({}, gammaDir.index())
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
         expect('.placeholder').not.toExist()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3394,14 +3394,14 @@ describe "TreeView", ->
     afterEach ->
       [alphaDirPath, gammaDirPath, thetaDirPath, etaDirPath] = []
 
-    describe "when dragging a project root's header onto a different project root's header", ->
-      describe "when dragging on the top part of the header", ->
+    describe "when dragging a project root's header onto a different project root", ->
+      describe "when dragging on the top part of the root", ->
         it "should add the placeholder above the directory", ->
           # Dragging gammaDir onto alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           gammaDir = $(treeView).find('.project-root:contains(gamma):first')
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
+            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.top)
@@ -3411,13 +3411,13 @@ describe "TreeView", ->
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
           expect('.placeholder').not.toExist()
 
-      describe "when dragging on the bottom part of the header", ->
+      describe "when dragging on the bottom part of the root", ->
         it "should add the placeholder below the directory", ->
           # Dragging gammaDir onto alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           gammaDir = $(treeView).find('.project-root:contains(gamma):first')
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
+            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
@@ -3446,14 +3446,14 @@ describe "TreeView", ->
           expect('.placeholder').not.toExist()
 
 
-    describe "when dropping a project root's header onto a different project root's header", ->
+    describe "when dropping a project root's header onto a different project root", ->
       describe "when dropping on the top part of the header", ->
         it "should add the placeholder above the directory", ->
           # dropping gammaDir above alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           gammaDir = $(treeView).find('.project-root:contains(gamma):first')
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
+            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.top)
@@ -3470,7 +3470,7 @@ describe "TreeView", ->
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           thetaDir = $(treeView).find('.project-root:contains(theta):first')
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(thetaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
+            eventHelpers.buildPositionalDragEvents(thetaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.bottom)
@@ -3495,7 +3495,7 @@ describe "TreeView", ->
     describe "when a root folder is dropped from another Atom window", ->
       it "adds the root folder to the window", ->
         alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.find('.project-root-header')[0])
+        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.find('.project-root-header')[0], '.tree-view')
 
         dropEvent = dragDropEvents.bottom
         dropEvent.originalEvent.dataTransfer.setData('atom-event', true)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3498,7 +3498,7 @@ describe "TreeView", ->
         [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.find('.project-root-header')[0], '.tree-view')
 
         dropEvent = dragDropEvents.bottom
-        dropEvent.originalEvent.dataTransfer.setData('atom-event', true)
+        dropEvent.originalEvent.dataTransfer.setData('atom-tree-view-event', true)
         dropEvent.originalEvent.dataTransfer.setData('from-window-id', treeView.rootDragAndDrop.getWindowId() + 1)
         dropEvent.originalEvent.dataTransfer.setData('from-root-path', etaDirPath)
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3400,15 +3400,15 @@ describe "TreeView", ->
           # Dragging gammaDir onto alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-          [dragStartEvent, dragOverEvents] =
+          [dragStartEvent, dragOverEvents, dragEndEvent] =
             eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
 
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDragOver(dragOverEvents.top)
+          treeView.rootDragAndDrop.onDragStart(dragStartEvent)
+          treeView.rootDragAndDrop.onDragOver(dragOverEvents.top)
           expect(alphaDir[0].previousSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.rootDragAndDrop.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
           expect('.placeholder').not.toExist()
 
       describe "when dragging on the bottom part of the header", ->
@@ -3416,15 +3416,15 @@ describe "TreeView", ->
           # Dragging gammaDir onto alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-          [dragStartEvent, dragOverEvents] =
+          [dragStartEvent, dragOverEvents, dragEndEvent] =
             eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
 
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDragOver(dragOverEvents.bottom)
+          treeView.rootDragAndDrop.onDragStart(dragStartEvent)
+          treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
           expect(alphaDir[0].nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.rootDragAndDrop.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
           expect('.placeholder').not.toExist()
 
       describe "when below all entries", ->
@@ -3432,17 +3432,17 @@ describe "TreeView", ->
           # Dragging gammaDir onto alphaDir
           alphaDir = $(treeView).find('.project-root:contains(alpha):first')
           lastDir = $(treeView).find('.project-root:last')
-          [dragStartEvent, dragOverEvents] =
+          [dragStartEvent, dragOverEvents, dragEndEvent] =
             eventHelpers.buildPositionalDragEvents(alphaDir.find('.project-root-header')[0], treeView.find('.tree-view')[0])
 
           expect(alphaDir[0]).not.toEqual(lastDir[0])
 
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDragOver(dragOverEvents.bottom)
+          treeView.rootDragAndDrop.onDragStart(dragStartEvent)
+          treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
           expect(lastDir[0].nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
-          treeView.rootDragAndDrop.onDragEnd()
+          treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
           expect('.placeholder').not.toExist()
 
 
@@ -3455,8 +3455,8 @@ describe "TreeView", ->
           [dragStartEvent, dragDropEvents] =
             eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
 
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDrop(dragDropEvents.top)
+          treeView.rootDragAndDrop.onDragStart(dragStartEvent)
+          treeView.rootDragAndDrop.onDrop(dragDropEvents.top)
           projectPaths = atom.project.getPaths()
           expect(projectPaths[0]).toEqual(gammaDirPath)
           expect(projectPaths[1]).toEqual(alphaDirPath)
@@ -3472,8 +3472,8 @@ describe "TreeView", ->
           [dragStartEvent, dragDropEvents] =
             eventHelpers.buildPositionalDragEvents(thetaDir.find('.project-root-header')[0], alphaDir.find('.project-root-header')[0])
 
-          treeView.onDragStart(dragStartEvent)
-          treeView.onDrop(dragDropEvents.bottom)
+          treeView.rootDragAndDrop.onDragStart(dragStartEvent)
+          treeView.rootDragAndDrop.onDrop(dragDropEvents.bottom)
           projectPaths = atom.project.getPaths()
           expect(projectPaths[0]).toEqual(alphaDirPath)
           expect(projectPaths[1]).toEqual(thetaDirPath)
@@ -3486,7 +3486,7 @@ describe "TreeView", ->
       it "should carry the folder's information", ->
         gammaDir = $(treeView).find('.project-root:contains(gamma):first')
         [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
-        treeView.onDragStart(dragStartEvent)
+        treeView.rootDragAndDrop.onDragStart(dragStartEvent)
 
         expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual gammaDirPath
         if process.platform in ['darwin', 'linux']
@@ -3507,7 +3507,7 @@ describe "TreeView", ->
         spyOn(remote.BrowserWindow, 'fromId').andReturn(browserWindowMock)
         spyOn(browserWindowMock.webContents, 'send')
 
-        treeView.onDrop(dropEvent)
+        treeView.rootDragAndDrop.onDrop(dropEvent)
 
         waitsFor ->
           browserWindowMock.webContents.send.callCount > 0
@@ -3521,7 +3521,7 @@ describe "TreeView", ->
       it "removes the root folder from the first window", ->
         gammaDir = $(treeView).find('.project-root:contains(gamma):first')
         [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
-        treeView.onDragStart(dragStartEvent)
+        treeView.rootDragAndDrop.onDragStart(dragStartEvent)
         treeView.rootDragAndDrop.onDropOnOtherWindow({}, gammaDir.index())
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -86,7 +86,7 @@
     height: 2px;
     margin: -1px; padding: 0;
 
-    width: 100%;
+    width: calc(~"100% -" @component-icon-padding);
     background: @background-color-info;
 
     list-style: none;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -50,7 +50,6 @@
   flex: 1;
   width: 100%;
   overflow: auto;
-  will-change: transform;
 }
 
 .tree-view {

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -50,6 +50,7 @@
   flex: 1;
   width: 100%;
   overflow: auto;
+  will-change: transform;
 }
 
 .tree-view {
@@ -93,21 +94,32 @@
   .placeholder {
     position: absolute;
     left: @component-icon-padding;
+    padding: 0;
     z-index: 999;
     display: inline-block;
-    height: 2px;
-    margin: -1px; padding: 0;
 
     width: calc(~"100% -" @component-icon-padding);
     background: @background-color-info;
 
     list-style: none;
+    pointer-events: none;
+
+    // bar
+    &:before {
+      content: "";
+      position: absolute;
+      height: 2px;
+      margin: -1px; padding: 0;
+      width: inherit;
+      background: inherit;
+    }
 
     &:after {
       content: "";
       position: absolute;
       left: 0;
-      margin: -1px;
+      margin-top: -2px;
+      margin-left: -1px;
       width: 4px;
       height: 4px;
       background: @background-color-info;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -114,6 +114,11 @@
       border-radius: 4px;
       border: 1px solid transparent;
     }
+
+    // ensure that placeholder doesn't disappear above the top of the view
+    &:first-child {
+      margin-top: 1px;
+    }
   }
 }
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -40,6 +40,10 @@
   }
 }
 
+.project-root-header {
+  -webkit-user-drag: element;
+}
+
 .tree-view-scroller {
   display: flex;
   flex-direction: column;
@@ -70,6 +74,33 @@
     &:before {
       content: '';
       position: absolute;
+    }
+  }
+
+  /* Drag and Drop */
+  .placeholder {
+    position: absolute;
+    left: @component-icon-padding;
+    z-index: 999;
+    display: inline-block;
+    height: 2px;
+    margin: -1px; padding: 0;
+
+    width: 100%;
+    background: @background-color-info;
+
+    list-style: none;
+
+    &:after {
+      content: "";
+      position: absolute;
+      left: 0;
+      margin: -1px;
+      width: 4px;
+      height: 4px;
+      background: @background-color-info;
+      border-radius: 4px;
+      border: 1px solid transparent;
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/atom/tree-view/issues/691

This uses the same logic that moving tabs uses to reposition project folders within the tree view.

![move-project-folders](http://i.imgur.com/bPgJOAh.gif)

* [x] implement
* [x] update to interoperate with file movement dragging
* [x] fix placeholder width
* [x] add tests

Future additions:
* reduce amount of duplicated code - needs coordination with tabs-view and drag-and-drop file moving
* allow dragging in folders from the filesystem - needs electron support first, unfortunately. Or it's just broken in kwin.

### Bugfixes

* [x] When dragging project folders, don't allow movement of the folder itself
* [x] Allow movement below last project folder (https://github.com/atom/tree-view/pull/525#issuecomment-252341762) - should also cover when dragging to an empty tree view
* [x] Make sure placeholder (blue bar) is visible when dragging above first project (https://github.com/atom/tree-view/pull/525#issuecomment-252702782)