### PR TITLE
Fix issue 555

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -39,6 +39,8 @@ class TreeView extends View
     @selectedPath = null
     @ignoredPatterns = []
 
+    @dragEventCounts = {}
+
     @handleEvents()
 
     process.nextTick =>
@@ -785,15 +787,26 @@ class TreeView extends View
   multiSelectEnabled: ->
     @list[0].classList.contains('multi-select')
 
-  onDragEnter: (e) ->
+  onDragEnter: (e) =>
     e.stopPropagation()
 
-    e.currentTarget.parentNode.classList.add('selected')
+    entry = e.currentTarget.parentNode
+    identifier = "#{entry.constructor.name}:#{entry.getPath()}"
 
-  onDragLeave: (e) ->
+    @dragEventCounts[identifier] ?= 0
+    @dragEventCounts[identifier]++
+
+    entry.classList.add('selected')
+
+  onDragLeave: (e) =>
     e.stopPropagation()
 
-    e.currentTarget.parentNode.classList.remove('selected')
+    entry = e.currentTarget.parentNode
+    identifier = "#{entry.constructor.name}:#{entry.getPath()}"
+
+    @dragEventCounts[identifier]--
+    if @dragEventCounts[identifier] is 0
+      entry.classList.remove('selected')
 
   # Handle entry name object dragstart event
   onDragStart: (e) ->

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -54,10 +54,6 @@
   }
 
   .entry {
-    .name {
-      pointer-events: none;
-    }
-
     // This fixes #110, see that issue for more details
     &:before {
       content: '';


### PR DESCRIPTION
#555 stated that some context menu didn't appear anymore after my drag and drop feature has been added. This was due to the fact that I removed pointer-events from the .name element, for the following reason:

Whenever you hover an entry, a dragEnter event is called. When you hover the .name element inside this entry, it triggers another dragEnter event and a dragLeave event immediately after that, which results in the entry not being highlighted.

I fixed this by counting the events of all entries in a global dragEventCounts hash. The dragLeave event handler only removes the selected class if the count is 0.