### PR TITLE
:bug: Fix transparent dragging background with themes

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -15,3 +15,11 @@ module.exports =
       camelizedAttr = property.replace /\-([a-z])/g, (a, b) -> b.toUpperCase()
       styleObject[camelizedAttr] = value
     styleObject
+
+  ensureOpaqueBackground: (styleObject) ->
+    propName = if styleObject.backgroundColor then 'backgroundColor' else 'background'
+    if (match = /((?:rgb|hsl)a\s*\(\s*[0-9.]+\s*,\s*[0-9.%]+\s*,\s*[0-9.%]+\s*,\s*)([0-9.]+)(\s*\).*)/.exec(styleObject[propName]))
+      opacity = Number(match[2])
+      if opacity < 0.4
+        styleObject[propName] = match[1] + 1.0 + match[3]
+    styleObject

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -3,7 +3,7 @@ shell = require 'shell'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable} = require 'atom'
-{repoForPath, getStyleObject} = require "./helpers"
+{repoForPath, getStyleObject, ensureOpaqueBackground} = require "./helpers"
 {$, View} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 
@@ -802,6 +802,7 @@ class TreeView extends View
     initialPath = target.data("path")
 
     style = getStyleObject(target[0])
+    ensureOpaqueBackground(style)
 
     fileNameElement = target.clone()
       .css(style)


### PR DESCRIPTION
On my theme, since the background of individual tree view icons have a transparent background, the drag indicator is unreadable. This fixes that issue. I can provide a gif upon request. I'm also fine with documenting the regex, since it is kinda hairy.
