### PR TITLE
Avoid using a hardcoded display value when forcing a redraw

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -696,7 +696,7 @@ class TreeView extends View
     # Force a redraw so the scrollbars are styled correctly based on the theme
     @element.style.display = 'none'
     @element.offsetWidth
-    @element.style.display = 'block'
+    @element.style.display = ''
 
   onMouseDown: (e) ->
     e.stopPropagation()


### PR DESCRIPTION
Simply removing the previously defined display is enough to make it
visible again and it won’t override what the stylesheet or themes may
have defined for the tree-view resizer div.