### PR TITLE
Use a flex layout for the tree-view-resized div

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -26,7 +26,7 @@ class TreeView extends View
 
   @content: ->
     @div class: 'tree-view-resizer tool-panel', 'data-show-on-right-side': atom.config.get('tree-view.showOnRightSide'), =>
-      @div class: 'tree-view-scroller', outlet: 'scroller', =>
+      @div class: 'tree-view-scroller order--center', outlet: 'scroller', =>
         @ol class: 'tree-view full-menu list-tree has-collapsable-children focusable-panel', tabindex: -1, outlet: 'list'
       @div class: 'tree-view-resize-handle', outlet: 'resizeHandle'
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -9,6 +9,8 @@
   min-width: 100px;
   width: 200px;
   z-index: 2;
+  display: flex;
+  flex-direction: column;
 
   .tree-view-resize-handle {
     position: absolute;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -12,6 +12,12 @@
   display: flex;
   flex-direction: column;
 
+  // use these classes to re-order
+  // using a value in-between is fine too, e.g. order: -3;
+  & > .order--start  { order: -10; }
+  & > .order--center { order:   0; }
+  & > .order--end    { order:  10; }
+
   .tree-view-resize-handle {
     position: absolute;
     top: 0;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -35,7 +35,7 @@
 }
 
 .tree-view-scroller {
-  height: 100%;
+  flex: 1;
   width: 100%;
   overflow: auto;
 }


### PR DESCRIPTION
This change does not impact how the tree-view render, but will allow
other packages to insert new content in the `tree-view-resizer` div
without having to worry about the layout being broken or the list not
scrolling to the last item (as the list can be pushed by the additional
content).

For instance `autohide-tree-view` sets the height using something like
`calc(100% - 29px)` which maybe fine if it’s the only package. But it
starts to get ugly when different packages insert content in the
tree-view with different methods (see
abe33/atom-tree-view-breadcrumb#19 for instance).


##  :-1: Broken Packages

- [ ] `tree-view-open-files` But it seems already broken before

## :wave: "Ok, but could be improved" Packages

- [x] `opened-files`: Still works, but the inline (auto) height could be replaced with flex so that other packages can be added. https://github.com/paulpflug/opened-files/issues/16
- [x] `tree-view-breadcrumb`: Could use official classes or update the `order`

## :+1: Unaffected Packages

- [x] `autohide-tree-view` (except the pin could clash with other stuff at the top)

__Note__: The above is only true if each package gets added alone. There are more (sometimes unrelated) issues when enabling multiple packages together.