### PR TITLE
Add option to always open existing view

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -396,6 +396,11 @@ class TreeView extends View
       item = activePane?.itemForURI(uri)
       if item? and not options.pending
         activePane.clearPendingItem() if activePane.getPendingItem() is item
+
+      if atom.config.get('tree-view.alwaysOpenExisting')
+        options.activatePane = true
+        options.searchAllPanes = true
+
       atom.workspace.open(uri, options)
 
   openSelectedEntrySplit: (orientation, side) ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -398,7 +398,6 @@ class TreeView extends View
         activePane.clearPendingItem() if activePane.getPendingItem() is item
 
       if atom.config.get('tree-view.alwaysOpenExisting')
-        options.activatePane = true
         options.searchAllPanes = true
 
       atom.workspace.open(uri, options)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -209,11 +209,12 @@ class TreeView extends View
       return false
     else if entry instanceof FileView
       detail = e.originalEvent?.detail ? 1
+      alwaysOpenExisting = atom.config.get('tree-view.alwaysOpenExisting')
       if detail is 1
         if atom.config.get('core.allowPendingPaneItems')
-          atom.workspace.open(entry.getPath(), pending: true, activatePane: false)
+          atom.workspace.open(entry.getPath(), pending: true, activatePane: false, searchAllPanes: alwaysOpenExisting)
       else if detail is 2
-        atom.workspace.open(entry.getPath())
+        atom.workspace.open(entry.getPath(), searchAllPanes: alwaysOpenExisting)
 
     false
 
@@ -398,7 +399,7 @@ class TreeView extends View
         activePane.clearPendingItem() if activePane.getPendingItem() is item
 
       if atom.config.get('tree-view.alwaysOpenExisting')
-        options.searchAllPanes = true
+        options = Object.assign searchAllPanes: true, options
 
       atom.workspace.open(uri, options)
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
       "type": "boolean",
       "default": true,
       "description": "Focus the tree view when revealing entries."
+    },
+    "alwaysOpenExisting": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -18,6 +18,20 @@ clickEvent = (properties) ->
   _.extend(event, properties) if properties?
   event
 
+setupPaneFiles = ->
+  rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
+
+  dirPath = path.join(rootDirPath, "test-dir")
+
+  fs.makeTreeSync(dirPath)
+  [1..9].forEach (index) ->
+    filePath = path.join(dirPath, "test-file-#{index}.txt")
+    fs.writeFileSync(filePath, "#{index}. Some text.")
+
+  return dirPath
+
+getPaneFileName = (index) -> "test-file-#{index}.txt"
+
 describe "TreeView", ->
   [treeView, path1, path2, root1, root2, sampleJs, sampleTxt, workspaceElement] = []
 
@@ -1281,6 +1295,39 @@ describe "TreeView", ->
             item = atom.workspace.getActivePaneItem()
             expect(atom.views.getView(pane)).toHaveFocus()
             expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
+
+  xdescribe "opening existing opened files in existing split panes", ->
+    beforeEach ->
+      projectPath = setupPaneFiles()
+      atom.project.setPaths([projectPath])
+
+      jasmine.attachToDOM(workspaceElement)
+      [1..9].forEach (index) ->
+        waitsForFileToOpen ->
+          selectEntry getPaneFileName(index)
+          atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-right')
+
+    it "should have opened all windows", ->
+      expect(atom.workspace.getPanes().length).toBe 9
+
+    [0..8].forEach (index) ->
+      paneNumber = index + 1
+      command = "tree-view:open-selected-entry-in-pane-#{paneNumber}"
+
+      describe command, ->
+        [1..9].forEach (fileIndex) ->
+          fileName = getPaneFileName(fileIndex)
+          describe "when a file is selected that is already open in pane #{fileIndex}", ->
+            beforeEach ->
+              selectEntry fileName
+              waitsForFileToOpen ->
+                atom.commands.dispatch treeView.element, command
+
+            it "opens the file in pane #{paneNumber} and focuses it", ->
+              pane = atom.workspace.getPanes()[index]
+              item = atom.workspace.getActivePaneItem()
+              expect(atom.views.getView(pane)).toHaveFocus()
+              expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)
 
   describe "removing a project folder", ->
     it "removes the folder from the project", ->
@@ -3055,3 +3102,87 @@ describe "TreeView", ->
 
         runs ->
           expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 4
+
+  describe "the alwaysOpenExisting config option", ->
+    it "defaults to unset", ->
+      expect(atom.config.get("tree-view.alwaysOpenExisting")).toBeFalsy()
+
+    describe "when a file is single-clicked", ->
+      beforeEach ->
+        atom.config.set "tree-view.alwaysOpenExisting", true
+        jasmine.attachToDOM(workspaceElement)
+
+      it "selects the files and opens it in the active editor, without changing focus", ->
+        treeView.focus()
+
+        waitsForFileToOpen ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+
+        runs ->
+          expect(sampleJs).toHaveClass 'selected'
+          expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+          expect(treeView.list).toHaveFocus()
+
+        waitsForFileToOpen ->
+          sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+
+        runs ->
+          expect(sampleTxt).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+          expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
+          expect(treeView.list).toHaveFocus()
+
+    describe "opening existing opened files in existing split panes", ->
+      beforeEach ->
+        projectPath = setupPaneFiles()
+        atom.project.setPaths([projectPath])
+
+        jasmine.attachToDOM(workspaceElement)
+        [1..9].forEach (index) ->
+          waitsForFileToOpen ->
+            selectEntry getPaneFileName(index)
+            atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-right')
+
+      it "should have opened all windows", ->
+        expect(atom.workspace.getPanes().length).toBe 9
+
+      describe "tree-view:open-selected-entry", ->
+        beforeEach ->
+          atom.config.set "tree-view.alwaysOpenExisting", true
+        [1..9].forEach (fileIndex) ->
+          paneIndex = fileIndex - 1
+          fileName = getPaneFileName(fileIndex)
+          describe "when a file is selected that is already open in pane #{fileIndex}", ->
+            beforeEach ->
+              firstPane = atom.workspace.getPanes()[0]
+              firstPane.activate()
+              selectEntry fileName
+              waitsForFileToOpen ->
+                atom.commands.dispatch treeView.element, "tree-view:open-selected-entry"
+
+            it "opens the file in pane #{fileIndex} and focuses it", ->
+              pane = atom.workspace.getPanes()[paneIndex]
+              item = atom.workspace.getActivePaneItem()
+              expect(atom.views.getView(pane)).toHaveFocus()
+              expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)
+
+      describe "tree-view:open-selected-entry (alwaysOpenExisting off)", ->
+        beforeEach ->
+          atom.config.set "tree-view.alwaysOpenExisting", false
+
+        [2..9].forEach (fileIndex) ->
+          paneIndex = fileIndex - 1
+          fileName = getPaneFileName(fileIndex)
+          describe "when a file is selected that is already open in pane #{fileIndex}", ->
+            [firstPane] = []
+            beforeEach ->
+              firstPane = atom.workspace.getPanes()[0]
+              firstPane.activate()
+              selectEntry fileName
+              waitsForFileToOpen ->
+                atom.commands.dispatch treeView.element, "tree-view:open-selected-entry"
+
+            it "opens the file in pane #{fileIndex} in pane 1", ->
+              item = atom.workspace.getActivePaneItem()
+              expect(atom.views.getView(firstPane)).toHaveFocus()
+              expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1296,7 +1296,7 @@ describe "TreeView", ->
             expect(atom.views.getView(pane)).toHaveFocus()
             expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
 
-  xdescribe "opening existing opened files in existing split panes", ->
+  describe "opening existing opened files in existing split panes", ->
     beforeEach ->
       projectPath = setupPaneFiles()
       atom.project.setPaths([projectPath])


### PR DESCRIPTION
If the file is already open, by default, if it's not open in the current pane, tree view will open a new view onto that file in the current pane.

This option, when set, will open the existing view of a selected file.