### PR TITLE
Fix instanceof check on doubleclick on an entry

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -207,7 +207,7 @@ class TreeView extends View
       when 2
         if entry instanceof FileView
           @unfocus()
-        else if DirectoryView
+        else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 
     false


### PR DESCRIPTION
It would always call `entry.toggleExpansion` because `DirectoryView` is always truthy