### PR TITLE
:bug: Disallow moving root directories

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -9,8 +9,6 @@ class DirectoryView extends HTMLElement
     @subscriptions.add @directory.onDidDestroy => @subscriptions.dispose()
     @subscribeToDirectory()
 
-    @draggable = not @directory.isRoot
-
     @classList.add('directory', 'entry',  'list-nested-item',  'collapsed')
 
     @header = document.createElement('div')
@@ -41,6 +39,7 @@ class DirectoryView extends HTMLElement
     if @directory.isRoot
       @classList.add('project-root')
     else
+      @draggable = true
       @subscriptions.add @directory.onDidStatusChange => @updateStatus()
       @updateStatus()
 

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -9,7 +9,7 @@ class DirectoryView extends HTMLElement
     @subscriptions.add @directory.onDidDestroy => @subscriptions.dispose()
     @subscribeToDirectory()
 
-    @draggable = true
+    @draggable = not @directory.isRoot
 
     @classList.add('directory', 'entry',  'list-nested-item',  'collapsed')
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -76,7 +76,7 @@ describe "TreeView", ->
       expect(treeView.selectedEntry()).toEqual(treeView.roots[0])
 
     it "makes the root folder non-draggable", ->
-      expect(treeView.roots[0]).not.toHaveClass('draggable')
+      expect(treeView.roots[0].hasAttribute('draggable')).toBe(true)
 
     describe "when the project has no path", ->
       beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -75,6 +75,9 @@ describe "TreeView", ->
     it "selects the root folder", ->
       expect(treeView.selectedEntry()).toEqual(treeView.roots[0])
 
+    it "makes the root folder non-draggable", ->
+      expect(treeView.roots[0]).not.toHaveClass('draggable')
+
     describe "when the project has no path", ->
       beforeEach ->
         atom.project.setPaths([])

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -76,7 +76,7 @@ describe "TreeView", ->
       expect(treeView.selectedEntry()).toEqual(treeView.roots[0])
 
     it "makes the root folder non-draggable", ->
-      expect(treeView.roots[0].hasAttribute('draggable')).toBe(true)
+      expect(treeView.roots[0].hasAttribute('draggable')).toBe(false)
 
     describe "when the project has no path", ->
       beforeEach ->


### PR DESCRIPTION
Moving a root directory can cause the tree view to become invalid as the
project remains but does not correctly map to a directory on the file system.
It also provides a bad UX as it's very easy to accidentally move a project
directory.

Fixes #590