### PR TITLE
Expand tree-view to full or auto height

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -41,12 +41,16 @@
 }
 
 .tree-view-scroller {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   width: 100%;
   overflow: auto;
 }
 
 .tree-view {
+  flex-grow: 1;
+  flex-shrink: 0;
   min-width: -webkit-min-content;
   min-height: 100%;
   padding-left: @component-icon-padding;


### PR DESCRIPTION
This PR fixes the issue that the context menu didn't work when the tree-view wasn't taking up the whole height.

Fixes #595