### PR TITLE
:bug: :apple: :penguin: Fix pasting files containing asterisks

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -597,7 +597,7 @@ class TreeView extends View
         else if cutPaths
           # Only move the target if the cut target doesn't exists and if the newPath
           # is not within the initial path
-          unless fs.existsSync(newPath) or !!newPath.match(new RegExp("^#{initialPath}"))
+          unless fs.existsSync(newPath) or newPath.startsWith(initialPath)
             catchAndShowFileErrors -> fs.moveSync(initialPath, newPath)
 
   add: (isCreatingFile) ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1330,7 +1330,7 @@ describe "TreeView", ->
         describe "when pasting a file with an asterisk char '*' in to different directory", ->
           it "should successfully move the file", ->
             # Files cannot contain asterisks on Windows
-            return if process.platform.startsWith("win")
+            return if process.platform is "win32"
             asteriskFilePath = path.join(dirPath, "test-file-**.txt")
             fs.writeFileSync(asteriskFilePath, "doesn't matter *")
             LocalStorage['tree-view:copyPath'] = JSON.stringify([asteriskFilePath])

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 {$, $$} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 path = require 'path'
+process = require 'process'
 temp = require('temp').track()
 os = require 'os'
 {buildDragEvents} = require "./event-helpers"
@@ -1325,6 +1326,17 @@ describe "TreeView", ->
             dirView2.click()
             atom.commands.dispatch(treeView.element, "tree-view:paste")
             expect(fs.existsSync(path.join(dirPath2, path.basename(filePath4)))).toBeTruthy()
+
+        describe "when pasting a file with an asterisk char '*' in to different directory", ->
+          it "should successfully move the file", ->
+            # Files cannot contain asterisks on Windows
+            return if process.platform.startsWith("win")
+            asteriskFilePath = path.join(dirPath, "test-file-**.txt")
+            fs.writeFileSync(asteriskFilePath, "doesn't matter *")
+            LocalStorage['tree-view:copyPath'] = JSON.stringify([asteriskFilePath])
+            dirView2.click()
+            atom.commands.dispatch(treeView.element, "tree-view:paste")
+            expect(fs.existsSync(path.join(dirPath2, path.basename(asteriskFilePath)))).toBeTruthy()
 
       describe "when nothing has been copied", ->
         it "does not paste anything", ->


### PR DESCRIPTION
A regex was testing to ensure that the pasted file's new path is not part of
the file's original path. Move to use String.prototype.startsWith instead of
trying to sanitize the path as a regex.

Fixes #547 