### PR TITLE
Add setting to squash directories

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -14,15 +14,12 @@ class DirectoryView extends HTMLElement
     @classList.add('directory', 'entry',  'list-nested-item',  'collapsed')
 
     @header = document.createElement('div')
-    @appendChild(@header)
     @header.classList.add('header', 'list-item')
 
     @directoryName = document.createElement('span')
-    @header.appendChild(@directoryName)
     @directoryName.classList.add('name', 'icon')
 
     @entries = document.createElement('ol')
-    @appendChild(@entries)
     @entries.classList.add('entries', 'list-tree')
 
     if @directory.symlink
@@ -34,9 +31,22 @@ class DirectoryView extends HTMLElement
       else
         iconClass = 'icon-file-submodule' if @directory.submodule
     @directoryName.classList.add(iconClass)
-    @directoryName.textContent = @directory.name
     @directoryName.dataset.name = @directory.name
     @directoryName.dataset.path = @directory.path
+
+    if @directory.squashedName?
+      @squashedDirectoryName = document.createElement('span')
+      @squashedDirectoryName.classList.add('squashed-dir')
+      @squashedDirectoryName.textContent = @directory.squashedName
+
+    directoryNameTextNode = document.createTextNode(@directory.name)
+
+    @appendChild(@header)
+    if @squashedDirectoryName?
+      @directoryName.appendChild(@squashedDirectoryName)
+    @directoryName.appendChild(directoryNameTextNode)
+    @header.appendChild(@directoryName)
+    @appendChild(@entries)
 
     if @directory.isRoot
       @classList.add('project-root')

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -16,6 +16,9 @@ class Directory
     @emitter = new Emitter()
     @subscriptions = new CompositeDisposable()
 
+    if atom.config.get('tree-view.squashDirectoryNames')
+      fullPath = @squashDirectoryNames(fullPath)
+
     @path = fullPath
     @realPath = @path
     if fs.isCaseInsensitive()
@@ -257,3 +260,19 @@ class Directory
     for name, entry of @entries when entry.expansionState?
       expansionState.entries[name] = entry.serializeExpansionState()
     expansionState
+
+  squashDirectoryNames: (fullPath) ->
+    squashedDirs = [@name]
+    loop
+      contents = fs.listSync fullPath
+      break if contents.length isnt 1
+      break if not fs.isDirectorySync(contents[0])
+      relativeDir = path.relative(fullPath, contents[0])
+      squashedDirs.push relativeDir
+      fullPath = path.join(fullPath, relativeDir)
+
+    if squashedDirs.length > 1
+      @squashedName = squashedDirs[0..squashedDirs.length - 2].join(path.sep) + path.sep
+    @name = squashedDirs[squashedDirs.length - 1]
+
+    return fullPath

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,7 +8,8 @@ module.exports =
     squashDirectoryNames:
       type: 'boolean'
       default: false
-      title: 'Collapse directories that contain only a single directory'
+      title: 'Collapse directories'
+      description: 'Collapse directories that only contain a single directory.'
     hideVcsIgnoredFiles:
       type: 'boolean'
       default: false

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,10 @@ FileIcons = require './file-icons'
 
 module.exports =
   config:
+    squashDirectoryNames:
+      type: 'boolean'
+      default: false
+      title: 'Collapse directories that contain only a single directory'
     hideVcsIgnoredFiles:
       type: 'boolean'
       default: false

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -149,6 +149,8 @@ class TreeView extends View
       @onSideToggled(newValue)
     @disposables.add atom.config.onDidChange 'tree-view.sortFoldersBeforeFiles', =>
       @updateRoots()
+    @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>
+      @updateRoots()
 
   toggle: ->
     if @isVisible()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2164,7 +2164,7 @@ describe "TreeView", ->
         expect(zetaEntries).toEqual(["zeta.txt"])
 
       it "squashes two dir names when the first only contains a single dir", ->
-        betaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha/beta):first')
+        betaDir = $(treeView.roots[0].entries).find(".directory:contains(alpha#{path.sep}beta):first")
         betaDir[0].expand()
         betaEntries = [].slice.call(betaDir[0].children[1].children).map (element) ->
           element.innerText
@@ -2172,7 +2172,7 @@ describe "TreeView", ->
         expect(betaEntries).toEqual(["beta.txt"])
 
       it "squashes three dir names when the first and second only contain single dirs", ->
-        epsilonDir = $(treeView.roots[0].entries).find('.directory:contains(gamma/delta/epsilon):first')
+        epsilonDir = $(treeView.roots[0].entries).find(".directory:contains(gamma#{path.sep}delta#{path.sep}epsilon):first")
         epsilonDir[0].expand()
         epsilonEntries = [].slice.call(epsilonDir[0].children[1].children).map (element) ->
           element.innerText

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2110,6 +2110,83 @@ describe "TreeView", ->
       expect(treeView.find('.directory .name:contains(test.js)').length).toBe 1
       expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
 
+  describe "the squashedDirectoryName config option", ->
+    beforeEach ->
+      rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
+
+      zetaDirPath = path.join(rootDirPath, "zeta")
+      zetaFilePath = path.join(zetaDirPath, "zeta.txt")
+
+      alphaDirPath = path.join(rootDirPath, "alpha")
+      betaDirPath = path.join(alphaDirPath, "beta")
+      betaFilePath = path.join(betaDirPath, "beta.txt")
+
+      gammaDirPath = path.join(rootDirPath, "gamma")
+      deltaDirPath = path.join(gammaDirPath, "delta")
+      epsilonDirPath = path.join(deltaDirPath, "epsilon")
+      thetaFilePath = path.join(epsilonDirPath, "theta.txt")
+
+      lambdaDirPath = path.join(rootDirPath, "lambda")
+      iotaDirPath = path.join(lambdaDirPath, "iota")
+      kappaDirPath = path.join(lambdaDirPath, "kappa")
+
+      fs.makeTreeSync(zetaDirPath)
+      fs.writeFileSync(zetaFilePath, "doesn't matter")
+
+      fs.makeTreeSync(alphaDirPath)
+      fs.makeTreeSync(betaDirPath)
+      fs.writeFileSync(betaFilePath, "doesn't matter")
+
+      fs.makeTreeSync(gammaDirPath)
+      fs.makeTreeSync(deltaDirPath)
+      fs.makeTreeSync(epsilonDirPath)
+      fs.writeFileSync(thetaFilePath, "doesn't matter")
+
+      fs.makeTreeSync(lambdaDirPath)
+      fs.makeTreeSync(iotaDirPath)
+      fs.makeTreeSync(kappaDirPath)
+
+      atom.project.setPaths([rootDirPath])
+
+    it "defaults to disabled", ->
+      expect(atom.config.get("tree-view.squashDirectoryNames")).toBeFalsy()
+
+    describe "when enabled", ->
+      beforeEach ->
+        atom.config.set('tree-view.squashDirectoryNames', true)
+
+      it "does not squash a file in to a DirectoryViews", ->
+        zetaDir = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')
+        zetaDir[0].expand()
+        zetaEntries = [].slice.call(zetaDir[0].children[1].children).map (element) ->
+          element.innerText
+
+        expect(zetaEntries).toEqual(["zeta.txt"])
+
+      it "squashes two dir names when the first only contains a single dir", ->
+        betaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha/beta):first')
+        betaDir[0].expand()
+        betaEntries = [].slice.call(betaDir[0].children[1].children).map (element) ->
+          element.innerText
+
+        expect(betaEntries).toEqual(["beta.txt"])
+
+      it "squashes three dir names when the first and second only contain single dirs", ->
+        epsilonDir = $(treeView.roots[0].entries).find('.directory:contains(gamma/delta/epsilon):first')
+        epsilonDir[0].expand()
+        epsilonEntries = [].slice.call(epsilonDir[0].children[1].children).map (element) ->
+          element.innerText
+
+        expect(epsilonEntries).toEqual(["theta.txt"])
+
+      it "does not squash a dir name when there are two child dirs ", ->
+        lambdaDir = $(treeView.roots[0].entries).find('.directory:contains(lambda):first')
+        lambdaDir[0].expand()
+        lambdaEntries = [].slice.call(lambdaDir[0].children[1].children).map (element) ->
+          element.innerText
+
+        expect(lambdaEntries).toEqual(["iota", "kappa"])
+
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []
 


### PR DESCRIPTION
A new setting tree-view.squashDirectoryNames that squashes directories
together when a directory only contains a single directory. Take the following
directory structure:

- foo
  - bar
    - file.txt

foo and bar would be merged in to a single DirectoryView:

- foo/bar
  - file.txt

Notes:
- Squashing occurs recursively so multiple directories can be merged together.
- There is a loss of functionality when the squash is enabled since the
  directories on the left are no longer available to right click. The
  DirectoryView is treated as if it's the full directory.
- The style .squashed-dir was added to allow styling of the left portion of the
  squashed directory ('foo/' in the above example).
- This feature is disabled by default.

Fixes #125