### PR TITLE
Add tooltips to files in tree view

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -17,6 +17,7 @@ class FileView extends HTMLElement
     @fileName.textContent = @file.name
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
+    @setupTooltip();
 
     @fileName.classList.add(FileIcons.getService().iconClassForPath(@file.path))
 
@@ -32,5 +33,23 @@ class FileView extends HTMLElement
 
   isPathEqual: (pathToCompare) ->
     @file.isPathEqual(pathToCompare)
+
+  setupTooltip: ->
+    onMouseEnter = =>
+      @mouseEnterSubscription.dispose()
+      @tooltip = atom.tooltips.add this,
+        title: @file.name
+        html: false
+        delay:
+          show: 1000
+          hide: 100
+        placement: 'bottom'
+      @dispatchEvent(new CustomEvent('mouseenter', bubbles: true))
+
+    @mouseEnterSubscription = dispose: =>
+      @removeEventListener('mouseenter', onMouseEnter)
+      @mouseEnterSubscription = null
+
+    @addEventListener('mouseenter', onMouseEnter)
 
 module.exports = document.registerElement('tree-view-file', prototype: FileView.prototype, extends: 'li')


### PR DESCRIPTION
![tooltips](https://cloud.githubusercontent.com/assets/1640136/10558773/0bdafe50-750f-11e5-9dd7-730cc7f19bb3.gif)

https://github.com/atom/tree-view/issues/557

Some points where it can be improved:
 - Add config option to disable tooltips
 - Bind tool tip to a different element so that when the side bar is to small the tooltip doesn't float over text editor
- Make tooltip appear on the right hand side, blocked by the previous point