### PR TITLE
Reflect git changes at root level

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -40,9 +40,8 @@ class DirectoryView extends HTMLElement
 
     if @directory.isRoot
       @classList.add('project-root')
-    else
-      @subscriptions.add @directory.onDidStatusChange => @updateStatus()
-      @updateStatus()
+    @subscriptions.add @directory.onDidStatusChange => @updateStatus()
+    @updateStatus()
 
     @expand() if @directory.expansionState.isExpanded
 

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -86,6 +86,10 @@ class Directory
       else if repo.isStatusNew(status)
         newStatus = 'added'
 
+    if (not newStatus?) and @isRoot
+      newStatus = 'modified' if (status for apath, status of repo.statuses).some (s) ->
+        repo.isStatusModified(s) or repo.isStatusNew(s)
+
     if newStatus isnt @status
       @status = newStatus
       @emitter.emit('did-status-change', newStatus)


### PR DESCRIPTION
Beginner fix for #564. This change seems to work in interactive testing, but `apm test` reports one failure. I don't know how to rectify this. Any suggestions?

```
 TreeView
  Git status decorations
    when the project is a symbolic link to the repository root
      when a file loses its modified status
        it updates its and its parent directories' styles
```
