### PR TITLE
:racehorse: revert natural sort

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -3,7 +3,6 @@ _ = require 'underscore-plus'
 {CompositeDisposable, Emitter} = require 'event-kit'
 fs = require 'fs-plus'
 PathWatcher = require 'pathwatcher'
-NaturalSort = require 'javascript-natural-sort'
 File = require './file'
 {repoForPath} = require './helpers'
 
@@ -160,9 +159,8 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-    NaturalSort.insensitive = true
-    names.sort(NaturalSort)
-
+    names.sort (name1, name2) -> name1.toLowerCase().localeCompare(name2.toLowerCase())
+    
     files = []
     directories = []
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "atom-space-pen-views": "^2.0.0",
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
-    "javascript-natural-sort": "^0.7.1",
     "minimatch": "~0.3.0",
     "pathwatcher": "^6.2",
     "temp": "~0.8.1",

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -397,13 +397,13 @@ describe "TreeView", ->
 
       it 'scrolls the selected file into the visible view', ->
         # Open file at bottom
-        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-20.txt'))
+        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-9.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
           expect(treeView.scrollTop()).toBeGreaterThan 400
 
         # Open file in the middle, should be centered in scroll
-        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-10.txt'))
+        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-19.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
           expect(treeView.scrollTop()).toBeLessThan 400


### PR DESCRIPTION
fixes:
 -https://github.com/atom/tree-view/issues/612
 -https://github.com/atom/tree-view/issues/491
 -https://github.com/atom/tree-view/issues/449 (tested with 9000folders, it was performant. should still make this async to increase cap)