### PR TITLE
add option for click to focus editor

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -216,9 +216,10 @@ class TreeView extends View
     filePath = e.currentTarget.getPath()
     detail = e.originalEvent?.detail ? 1
     alwaysOpenExisting = atom.config.get('tree-view.alwaysOpenExisting')
+    activateOnClick = atom.config.get('tree-view.clickFocusesEditor')
     if detail is 1
       if atom.config.get('core.allowPendingPaneItems')
-        openPromise = atom.workspace.open(filePath, pending: true, activatePane: false, searchAllPanes: alwaysOpenExisting)
+        openPromise = atom.workspace.open(filePath, pending: true, activatePane: activateOnClick, searchAllPanes: alwaysOpenExisting)
         @currentlyOpening.set(filePath, openPromise)
         openPromise.then => @currentlyOpening.delete(filePath)
     else if detail is 2

--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
     "alwaysOpenExisting": {
       "type": "boolean",
       "default": false
+    },
+    "clickFocusesEditor": {
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Often I use the mouse to navigate between files – I point to the file, click on it, look at it, and expect to be editing it but the focus is on tree-view. This PR adds an option that a single click on a file focuses the new text editor.

Comments welcome – would others like this option?