### PR TITLE
Adds a fast implementation of natural sort

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -5,7 +5,7 @@ fs = require 'fs-plus'
 PathWatcher = require 'pathwatcher'
 File = require './file'
 {repoForPath} = require './helpers'
-
+naturalCompare = require 'natural-compare-lite'
 realpathCache = {}
 
 module.exports =
@@ -159,8 +159,9 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-    names.sort (name1, name2) -> name1.toLowerCase().localeCompare(name2.toLowerCase())
-    
+
+    names.sort(naturalCompare)
+
     files = []
     directories = []
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
     "minimatch": "~0.3.0",
+    "natural-compare-lite": "^1.4.0",
     "pathwatcher": "^6.2",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0"

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -397,13 +397,13 @@ describe "TreeView", ->
 
       it 'scrolls the selected file into the visible view', ->
         # Open file at bottom
-        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-9.txt'))
+        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-20.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
           expect(treeView.scrollTop()).toBeGreaterThan 400
 
         # Open file in the middle, should be centered in scroll
-        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-19.txt'))
+        waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-10.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
           expect(treeView.scrollTop()).toBeLessThan 400
@@ -414,7 +414,6 @@ describe "TreeView", ->
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
           expect(treeView.scrollTop()).toEqual 0
-
 
   describe "when tool-panel:unfocus is triggered on the tree view", ->
     it "surrenders focus to the workspace but remains open", ->


### PR DESCRIPTION
I am, currently using a git url in `package.json`, because, i made some modifications and would prefer to get my pr merged into the master repo, rather then creating a whole new npm package. https://github.com/litejs/natural-compare-lite/pull/7
 
The implementation is only concerned with alphanumeric sorting.

ie.
```
file1.txt
file2.txt
file100.txt
```
over
```
file1.txt
file100.txt
file2.txt
```
The commit also adds an option to use the old sort function, incase
this one doesn't work with other locales, or if users prefer posix style
sorting.