### PR TITLE
Select first sub-entry on expand-directory if already expanded

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -330,7 +330,7 @@ class TreeView extends View
     @selectEntry(@entryForPath(entryPath))
 
   moveDown: (event) ->
-    event.stopImmediatePropagation()
+    event?.stopImmediatePropagation()
     selectedEntry = @selectedEntry()
     if selectedEntry?
       if selectedEntry instanceof DirectoryView
@@ -363,7 +363,13 @@ class TreeView extends View
     @scrollToEntry(@selectedEntry())
 
   expandDirectory: (isRecursive=false) ->
-    @selectedEntry()?.expand?(isRecursive)
+    selectedEntry = @selectedEntry()
+    return unless selectedEntry?
+
+    if isRecursive is false and selectedEntry.isExpanded
+      @moveDown() if selectedEntry.directory.getEntries().length > 0
+    else
+      selectedEntry.expand?(isRecursive)
 
   collapseDirectory: (isRecursive=false) ->
     selectedEntry = @selectedEntry()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -898,6 +898,33 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:expand-directory')
           expect(subdir).toHaveClass 'expanded'
 
+        describe "when the directory is already expanded", ->
+          describe "when the directory is empty", ->
+            it "does nothing", ->
+              rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
+              fs.mkdirSync(path.join(rootDirPath, "empty-dir"))
+              atom.project.setPaths([rootDirPath])
+              rootView = $(treeView.roots[0])
+
+              subdir = rootView.find('.directory:first')
+              subdir.click()
+              subdir[0].expand()
+              expect(subdir).toHaveClass('expanded')
+              expect(subdir).toHaveClass('selected')
+
+              atom.commands.dispatch(treeView.element, 'tree-view:expand-directory')
+              expect(subdir).toHaveClass('expanded')
+              expect(subdir).toHaveClass('selected')
+
+          describe "when the directory has entries", ->
+            it "moves the cursor down to the first sub-entry", ->
+              subdir = root1.find('.directory:first')
+              subdir.click()
+              subdir[0].expand()
+
+              atom.commands.dispatch(treeView.element, 'tree-view:expand-directory')
+              expect(subdir.find('.entry:first')).toHaveClass('selected')
+
       describe "when a file entry is selected", ->
         it "does nothing", ->
           waitsForFileToOpen ->


### PR DESCRIPTION
Enable faster, more natural navigation by having the tree-view.expand-directory
command select the first sub-entry when the directory is already expanded. This
new behavior applies only when a non-recursive directory expand is triggered
from the tree-view.

Fixes #561