### PR TITLE
Use asynchronous repo

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -30,9 +30,12 @@ class DirectoryView extends HTMLElement
     else
       iconClass = 'icon-file-directory'
       if @directory.isRoot
-        iconClass = 'icon-repo' if repoForPath(@directory.path)?.isProjectAtRoot()
+        repoForPath(@directory.path)?.isProjectAtRoot().then (projectAtRoot) =>
+          @directoryName.classList.add('icon-repo') if projectAtRoot
       else
-        iconClass = 'icon-file-submodule' if @directory.submodule
+        repoForPath(@directory.path)?.isSubmodule(@directory.path).then (isSubmodule) =>
+          @directoryName.classList.add('icon-file-submodule') if isSubmodule
+
     @directoryName.classList.add(iconClass)
     @directoryName.textContent = @directory.name
     @directoryName.dataset.name = @directory.name

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -44,14 +44,17 @@ class DirectoryView extends HTMLElement
     if @directory.isRoot
       @classList.add('project-root')
     else
-      @subscriptions.add @directory.onDidStatusChange => @updateStatus()
+      @subscriptions.add @directory.onDidStatusChange => @updateStatus(arguments[0])
       @updateStatus()
 
     @expand() if @directory.expansionState.isExpanded
 
-  updateStatus: ->
+  updateStatus: (status) ->
     @classList.remove('status-ignored', 'status-modified', 'status-added')
-    @classList.add("status-#{@directory.status}") if @directory.status?
+    if status?
+      @classList.add("status-#{status}")
+    else
+      @classList.add("status-#{@directory.status}") if @directory.status?
 
   subscribeToDirectory: ->
     @subscriptions.add @directory.onDidAddEntries (addedEntries) =>

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -125,6 +125,15 @@ class DirectoryView extends HTMLElement
 
     false
 
+  # Non-recursive ::expand that returns the promise from the model, for use in
+  # recursively revealing the active file
+  expandAsync: ->
+    unless @isExpanded
+      @isExpanded = true
+      @classList.add('expanded')
+      @classList.remove('collapsed')
+      return @directory.expand()
+
   collapse: (isRecursive=false) ->
     @isExpanded = false
 

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -70,7 +70,7 @@ class Directory
   # Update the status property of this directory using the repo.
   updateStatus: ->
     repo = repoForPath(@path)
-    repo.isPathIgnored(@path).then (isIgnored) =>
+    repo?.isPathIgnored(@path).then (isIgnored) =>
       if isIgnored
         return repo.Git.Status.STATUS.IGNORED
       else

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -188,7 +188,13 @@ class Directory
               return [localName, 'directory']
             else
               expansionState = @expansionState.entries[localName]
-              return [localName, new Directory({localName, fullPath, symlink, expansionState, @ignoredPatterns})]
+              return [localName, new Directory({
+                  name: localName,
+                  fullPath: fullPath,
+                  symlink: symlink,
+                  expansionState: expansionState,
+                  ignoredPatterns: @ignoredPatterns
+                  })]
           else if stat.isFile?()
             if @entries.hasOwnProperty(localName)
               # push a placeholder since this entry already exists but this helps
@@ -206,9 +212,9 @@ class Directory
       console.log values
       for value in values
         if value[1] instanceof File
-          files.push value[0]
+          files.push value[1]
         else if value[1] instanceof Directory
-          directories.push value[0]
+          directories.push value[1]
       @sortEntries(directories.concat(files))
 
     failure = (reason) =>

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -99,11 +99,11 @@ class Directory
       if repo? and repo.isProjectAtRoot()
         # repo.isPathIgnored also returns a promise that resolves to a Boolean
         return repo.isPathIgnored(filePath)
-      else if atom.config.get('tree-view.hideIgnoredNames')
-        for ignoredPattern in @ignoredPatterns
-          return Promise.resolve(true) if ignoredPattern.match(filePath)
-      else
-        return Promise.resolve(false)
+    else if atom.config.get('tree-view.hideIgnoredNames')
+      for ignoredPattern in @ignoredPatterns
+        return Promise.resolve(true) if ignoredPattern.match(filePath)
+
+    return Promise.resolve(false)
 
   # Does given full path start with the given prefix?
   isPathPrefixOf: (prefix, fullPath) ->

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -209,7 +209,7 @@ class Directory
                 })]
       namePromises.push f()
 
-    success = (values) =>
+    Promise.all(namePromises).then (values) =>
       console.log 'all success'
       directories = []
       files = []
@@ -221,10 +221,6 @@ class Directory
         else if value[1] instanceof Directory
           directories.push value[1]
       @sortEntries(directories.concat(files))
-
-    failure = (reason) =>
-      console.log reasons
-    Promise.all(namePromises).then(success, failure).catch(() -> console.log arguments)
 
   normalizeEntryName: (value) ->
     normalizedValue = value.name

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -201,7 +201,12 @@ class Directory
               # track the insertion index for the created views
               return [localName, 'file']
             else
-              return [localName, new File({localName, fullPath, symlink, realpathCache})]
+              return [localName, new File({
+                name: localName,
+                fullPath: fullPath,
+                symlink: symlink,
+                realpathCache: realpathCache
+                })]
       namePromises.push f()
 
     success = (values) =>

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -193,9 +193,7 @@ class Directory
                 })]
         else if stat.isFile?()
           if @entries.hasOwnProperty(localName)
-            # push a placeholder since this entry already exists but this helps
-            # track the insertion index for the created views
-            return [localName, 'file']
+            return [localName, @entries[localName]]
           else
             return [localName, new File({
               name: localName,

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -280,8 +280,8 @@ class Directory
   # changes.
   expand: ->
     @expansionState.isExpanded = true
-    @reload()
-    @watch()
+    @reload().then =>
+      @watch()
 
   serializeExpansionState: ->
     expansionState = {}

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -6,6 +6,7 @@ PathWatcher = require 'pathwatcher'
 NaturalSort = require 'javascript-natural-sort'
 File = require './file'
 {repoForPath} = require './helpers'
+{GitRepositoryAsync} = require 'atom'
 
 realpathCache = {}
 
@@ -72,12 +73,12 @@ class Directory
     repo = repoForPath(@path)
     repo?.isPathIgnored(@path).then (isIgnored) =>
       if isIgnored
-        return repo.Git.Status.STATUS.IGNORED
+        return GitRepositoryAsync.Git.Status.STATUS.IGNORED
       else
         return repo.getDirectoryStatus(@path)
     .then (status) =>
       newStatus = null
-      if status is repo.Git.Status.STATUS.IGNORED
+      if status is GitRepositoryAsync.Git.Status.STATUS.IGNORED
         newStatus = 'ignored'
       else if repo.isStatusModified(status)
         newStatus = 'modified'
@@ -87,6 +88,7 @@ class Directory
       if newStatus isnt @status
         @status = newStatus
         @emitter.emit('did-status-change', newStatus)
+      newStatus
 
   # Is the given path ignored?
   isPathIgnored: (filePath) ->

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -217,6 +217,10 @@ class Directory
           files.push value[1]
         else if value[1] instanceof Directory
           directories.push value[1]
+        else if value[1] is 'file'
+          files.push value[0]
+        else if value[1] is 'directory'
+          directories.push value[0]
       @sortEntries(directories.concat(files))
 
   normalizeEntryName: (value) ->

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -180,7 +180,6 @@ class Directory
           stat = fs.lstatSyncNoException(fullPath)
           symlink = stat.isSymbolicLink?()
           stat = fs.statSyncNoException(fullPath) if symlink
-          console.log 'in promise', fullPath
           if stat.isDirectory?()
             if @entries.hasOwnProperty(localName)
               # push a placeholder since this entry already exists but this helps
@@ -210,11 +209,9 @@ class Directory
       namePromises.push f()
 
     Promise.all(namePromises).then (values) =>
-      console.log 'all success'
       directories = []
       files = []
       values = values.filter (v) -> v isnt undefined
-      console.log values
       for value in values
         if value[1] instanceof File
           files.push value[1]
@@ -244,9 +241,7 @@ class Directory
     newEntries = []
     removedEntries = _.clone(@entries)
     index = 0
-    console.log 'reloading'
     @getEntries().then (entries) =>
-      console.log 'got entries in reload', entries
       for entry in entries
         if @entries.hasOwnProperty(entry)
           delete removedEntries[entry]

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -193,7 +193,9 @@ class Directory
                 })]
         else if stat.isFile?()
           if @entries.hasOwnProperty(localName)
-            return [localName, @entries[localName]]
+            # push a placeholder since this entry already exists but this helps
+            # track the insertion index for the created views
+            return [localName, 'file']
           else
             return [localName, new File({
               name: localName,

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -49,12 +49,14 @@ class File
       if isIgnored
         newStatus = 'ignored'
       else
-        # These are all sync methods
-        status = repo.getCachedPathStatus(@path)
-        if repo.isStatusModified(status)
-          newStatus = 'modified'
-        else if repo.isStatusNew(status)
-          newStatus = 'added'
+        return repo.getCachedPathStatus(@path)
+    .then (status) =>
+      if status is 'ignored'
+        newStatus = 'ignored'
+      else if repo.isStatusModified(status)
+        newStatus = 'modified'
+      else if repo.isStatusNew(status)
+        newStatus = 'added'
 
       if newStatus isnt @status
         @status = newStatus

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -35,32 +35,31 @@ class File
 
   # Subscribe to the project' repo for changes to the Git status of this file.
   subscribeToRepo: ->
-    repo = repoForPath(@path)
-    return unless repo?
-
-    @subscriptions.add repo.onDidChangeStatus (event) =>
-      @updateStatus(repo) if @isPathEqual(event.path)
-    @subscriptions.add repo.onDidChangeStatuses =>
-      @updateStatus(repo)
+    if repo = repoForPath(@path)
+      @subscriptions.add repo.onDidChangeStatus (event) =>
+        @updateStatus(repo) if @isPathEqual(event.path)
+      @subscriptions.add repo.onDidChangeStatuses =>
+        @updateStatus(repo)
 
   # Update the status property of this directory using the repo.
   updateStatus: ->
     repo = repoForPath(@path)
-    return unless repo?
+    repo.isPathIgnored(@path).then (isIgnored) =>
+      newStatus = null
+      if isIgnored
+        newStatus = 'ignored'
+      else
+        # These are all sync methods
+        status = repo.getCachedPathStatus(@path)
+        if repo.isStatusModified(status)
+          newStatus = 'modified'
+        else if repo.isStatusNew(status)
+          newStatus = 'added'
 
-    newStatus = null
-    if repo.isPathIgnored(@path)
-      newStatus = 'ignored'
-    else
-      status = repo.getCachedPathStatus(@path)
-      if repo.isStatusModified(status)
-        newStatus = 'modified'
-      else if repo.isStatusNew(status)
-        newStatus = 'added'
+      if newStatus isnt @status
+        @status = newStatus
+        @emitter.emit('did-status-change', newStatus)
 
-    if newStatus isnt @status
-      @status = newStatus
-      @emitter.emit('did-status-change', newStatus)
 
   isPathEqual: (pathToCompare) ->
     @path is pathToCompare or @realPath is pathToCompare

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -44,7 +44,7 @@ class File
   # Update the status property of this directory using the repo.
   updateStatus: ->
     repo = repoForPath(@path)
-    repo.isPathIgnored(@path).then (isIgnored) =>
+    repo?.isPathIgnored(@path).then (isIgnored) =>
       newStatus = null
       if isIgnored
         newStatus = 'ignored'

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,7 +4,7 @@ module.exports =
   repoForPath: (goalPath) ->
     for projectPath, i in atom.project.getPaths()
       if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
-        return atom.project.getRepositories()[i]
+        return atom.project.getRepositories()[i]?.async
     null
 
   getStyleObject: (el) ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -72,7 +72,6 @@ class TreeView extends View
         nodeLists = mutationRecords.map((m) -> m.addedNodes)
         for nodeList in nodeLists
           for entry in nodeList
-            console.log entry.getPath() if entry.getPath
             if entry.getPath() is state.selectedPath
               @selectEntry(entry)
               @initialSelectionMutationObserver.disconnect()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -684,6 +684,8 @@ class TreeView extends View
       fs.moveSync(initialPath, newPath)
 
       if repo = repoForPath(newPath)
+        # The return values of this are thrown away, they are called for emiiter
+        # side effects only.
         repo.getPathStatus(initialPath)
         repo.getPathStatus(newPath)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -652,8 +652,7 @@ class TreeView extends View
     AddDialog ?= require './add-dialog'
     dialog = new AddDialog(selectedPath, isCreatingFile)
     dialog.on 'directory-created', (event, createdPath) =>
-      @entryForPath(createdPath)?.reload()
-      @selectEntryForPath(createdPath)
+      @entryForPath(createdPath)?.reload().then => @selectEntryForPath(createdPath)
       false
     dialog.on 'file-created', (event, createdPath) ->
       atom.workspace.open(createdPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -728,10 +728,8 @@ class TreeView extends View
       fs.moveSync(initialPath, newPath)
 
       if repo = repoForPath(newPath)
-        # The return values of this are thrown away, they are called for emiiter
-        # side effects only.
-        repo.getPathStatus(initialPath)
-        repo.getPathStatus(newPath)
+        repo.refreshStatusForPath(initialPath)
+        repo.refreshStatusForPath(newPath)
 
     catch error
       atom.notifications.addWarning("Failed to move entry #{initialPath} to #{newDirectoryPath}", detail: error.message)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2427,10 +2427,13 @@ describe "TreeView", ->
 
     describe "when the project is a symbolic link to the repository root", ->
       beforeEach ->
-        symlinkPath = temp.path('tree-view-project')
+        symlinkPath = temp.path('tree-view-project-symlink')
         fs.symlinkSync(projectPath, symlinkPath)
         atom.project.setPaths([symlinkPath])
-        $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
+        waitsFor ->
+          $(treeView.roots[0].entries).find('.directory:contains(dir)').length > 0
+        waitsForPromise ->
+          $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expandAsync()
 
         waitsFor (done) ->
           disposable = atom.project.getRepositories()[0].onDidChangeStatuses ->
@@ -2439,8 +2442,11 @@ describe "TreeView", ->
 
       describe "when a file is modified", ->
         it "updates its and its parent directories' styles", ->
-          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+          waitsFor 'the directory status to update', ->
+            treeView.find('.directory:contains(dir)').hasClass('status-modified')
+          runs ->
+            expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+            expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
 
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -416,12 +416,18 @@ describe "TreeView", ->
         waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-20.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        waitsFor ->
+          treeView.scrollTop() > 400
+        runs ->
           expect(treeView.scrollTop()).toBeGreaterThan 400
 
         # Open file in the middle, should be centered in scroll
         waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-10.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        waitsFor 'tree view to scroll back to middle', ->
+          treeView.scrollTop() < 400
+        runs ->
           expect(treeView.scrollTop()).toBeLessThan 400
           expect(treeView.scrollTop()).toBeGreaterThan 0
 
@@ -429,6 +435,9 @@ describe "TreeView", ->
         waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-1.txt'))
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        waitsFor 'scroll to return', ->
+          treeView.scrollTop() is 0
+        runs ->
           expect(treeView.scrollTop()).toEqual 0
 
   describe "when tool-panel:unfocus is triggered on the tree view", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -799,13 +799,14 @@ describe "TreeView", ->
         it "selects the last entry in the expanded directory", ->
           lastDir = root1.find('.directory:last')
           fileAfterDir = lastDir.next()
-          lastDir[0].expand()
-          waitsForFileToOpen ->
-            fileAfterDir.click()
-
+          waitsForPromise ->
+            lastDir[0].expandAsync()
           runs ->
-            atom.commands.dispatch(treeView.element, 'core:move-up')
-            expect(lastDir.find('.entry:last')).toHaveClass 'selected'
+            waitsForFileToOpen ->
+              fileAfterDir.click()
+            runs ->
+              atom.commands.dispatch(treeView.element, 'core:move-up')
+              expect(lastDir.find('.entry:last')).toHaveClass 'selected'
 
       describe "when there is an entry before the currently selected entry", ->
         it "selects the previous entry", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -500,20 +500,24 @@ describe "TreeView", ->
 
     it "when collapsing a directory, removes change subscriptions from the collapsed directory and its descendants", ->
       child = root1.find('li:contains(dir1)')
+      grandchild = null
       child.click()
 
-      grandchild = child.find('li:contains(sub-dir1)')
-      grandchild.click()
+      waitsFor ->
+        child.find('li:contains(sub-dir1)').length > 0
+      runs ->
+        grandchild = child.find('li:contains(sub-dir1)')
+        grandchild.click()
 
-      expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
-      expect(child[0].directory.watchSubscription).toBeTruthy()
-      expect(grandchild[0].directory.watchSubscription).toBeTruthy()
+      runs ->
+        expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
+        expect(child[0].directory.watchSubscription).toBeTruthy()
+        expect(grandchild[0].directory.watchSubscription).toBeTruthy()
+        root1.click()
 
-      root1.click()
-
-      expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
-      expect(child[0].directory.watchSubscription).toBeFalsy()
-      expect(grandchild[0].directory.watchSubscription).toBeFalsy()
+        expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
+        expect(child[0].directory.watchSubscription).toBeFalsy()
+        expect(grandchild[0].directory.watchSubscription).toBeFalsy()
 
   describe "when mouse down fires on a file or directory", ->
     it "selects the entry", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -514,7 +514,7 @@ describe "TreeView", ->
         child.find('.entries > li:contains(sub-dir1)').click()
         root1.click()
       waitsFor ->
-        !treeView.roots[0].classList.contains('expanded')
+        not treeView.roots[0].classList.contains('expanded')
       runs ->
         root1.click()
 
@@ -547,7 +547,7 @@ describe "TreeView", ->
         expect(grandchild[0].directory.watchSubscription).toBeTruthy()
         root1.click()
       waitsFor ->
-        !treeView.roots[0].directory.watchSubscription
+        not treeView.roots[0].directory.watchSubscription
       runs ->
         expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
         expect(child[0].directory.watchSubscription).toBeFalsy()
@@ -695,7 +695,7 @@ describe "TreeView", ->
         root1.click()
         treeView.roots[0].collapse()
         waitsFor ->
-          !treeView.roots[0].classList.contains('expanded')
+          not treeView.roots[0].classList.contains('expanded')
         runs ->
           root1.trigger clickEvent({altKey: true})
         waitsFor ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -533,11 +533,16 @@ describe "TreeView", ->
       dir = root1.find('li:contains(dir1)')
       expect(dir).not.toHaveClass 'selected'
       dir.mousedown()
-      expect(dir).toHaveClass 'selected'
-
-      expect(sampleJs).not.toHaveClass 'selected'
-      sampleJs.mousedown()
-      expect(sampleJs).toHaveClass 'selected'
+      waitsFor ->
+        dir.hasClass('selected')
+      runs ->
+        expect(dir).toHaveClass 'selected'
+        expect(sampleJs).not.toHaveClass 'selected'
+        sampleJs.mousedown()
+      waitsFor ->
+        sampleJs.hasClass('selected')
+      runs ->
+        expect(sampleJs).toHaveClass 'selected'
 
   describe "when a file is single-clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2142,7 +2142,10 @@ describe "TreeView", ->
 
     describe "when the project is the repository root", ->
       it "adds a custom style", ->
-        expect(treeView.find('.icon-repo').length).toBe 1
+        waitsFor ->
+          treeView.find('.icon-repo').length == 1
+        runs ->
+          expect(treeView.find('.icon-repo').length).toBe 1
 
     describe "when a file is modified", ->
       it "adds a custom style", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -498,18 +498,25 @@ describe "TreeView", ->
       child = root1.find('.entries > li:contains(dir1)')
       child.click()
 
-      grandchild = child.find('.entries > li:contains(sub-dir1)')
-      grandchild.click()
+      grandchild = null
+      waitsFor ->
+        child.find('.entries > li:contains(sub-dir1)').length > 0
+      runs ->
+        child.find('.entries > li:contains(sub-dir1)').click()
+        root1.click()
+      waitsFor ->
+        !treeView.roots[0].classList.contains('expanded')
+      runs ->
+        root1.click()
 
-      root1.click()
-      expect(treeView.roots[0]).not.toHaveClass('expanded')
-      root1.click()
+      waitsFor ->
+        root1.find('> .entries > li:contains(dir1) > .entries > li:contains(sub-dir1) > .entries').length > 0
+      runs ->
+        # previously expanded descendants remain expanded
+        expect(root1.find('> .entries > li:contains(dir1) > .entries > li:contains(sub-dir1) > .entries').length).toBe 1
 
-      # previously expanded descendants remain expanded
-      expect(root1.find('> .entries > li:contains(dir1) > .entries > li:contains(sub-dir1) > .entries').length).toBe 1
-
-      # collapsed descendants remain collapsed
-      expect(root1.find('> .entries > li:contains(dir2) > .entries')).not.toHaveClass('expanded')
+        # collapsed descendants remain collapsed
+        expect(root1.find('> .entries > li:contains(dir2) > .entries')).not.toHaveClass('expanded')
 
     it "when collapsing a directory, removes change subscriptions from the collapsed directory and its descendants", ->
       child = root1.find('li:contains(dir1)')
@@ -525,9 +532,14 @@ describe "TreeView", ->
       runs ->
         expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
         expect(child[0].directory.watchSubscription).toBeTruthy()
+      waitsFor ->
+        grandchild[0].directory.watchSubscription
+      runs ->
         expect(grandchild[0].directory.watchSubscription).toBeTruthy()
         root1.click()
-
+      waitsFor ->
+        !treeView.roots[0].directory.watchSubscription
+      runs ->
         expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
         expect(child[0].directory.watchSubscription).toBeFalsy()
         expect(grandchild[0].directory.watchSubscription).toBeFalsy()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2150,24 +2150,39 @@ describe "TreeView", ->
     describe "when a file is modified", ->
       it "adds a custom style", ->
         $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
-        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+        waitsFor ->
+          treeView.find('.file:contains(b.txt)').hasClass('status-modified')
+        runs ->
+          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
 
-    describe "when a directory if modified", ->
+    describe "when a directory is modified", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+        waitsFor ->
+          treeView.find('.directory:contains(dir)').hasClass('status-modified')
+        runs ->
+          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
 
     describe "when a file is new", ->
       it "adds a custom style", ->
         $(treeView.roots[0].entries).find('.directory:contains(dir2)')[0].expand()
-        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
+        waitsFor ->
+          treeView.find('.file:contains(new2)').hasClass('status-added')
+        runs ->
+          expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+        waitsFor ->
+          treeView.find('.directory:contains(dir2)').hasClass 'status-added'
+        runs ->
+          expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
 
     describe "when a file is ignored", ->
       it "adds a custom style", ->
-        expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
+        waitsFor ->
+          treeView.find('.file:contains(ignored.txt)').hasClass 'status-ignored'
+        runs ->
+          expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
 
     describe "when the project is a symbolic link to the repository root", ->
       beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2330,7 +2330,9 @@ describe "TreeView", ->
 
       newFile = path.join(newDir, 'new2')
       fs.writeFileSync(newFile, '')
-      atom.project.getRepositories()[0].getPathStatus(newFile)
+
+      waitsForPromise ->
+        atom.project.getRepositories()[0].async.getPathStatus(newFile)
 
       ignoreFile = path.join(projectPath, '.gitignore')
       fs.writeFileSync(ignoreFile, 'ignored.txt')
@@ -2340,7 +2342,9 @@ describe "TreeView", ->
       modifiedFile = path.join(projectPath, 'dir', 'b.txt')
       originalFileContent = fs.readFileSync(modifiedFile, 'utf8')
       fs.writeFileSync modifiedFile, 'ch ch changes'
-      atom.project.getRepositories()[0].getPathStatus(modifiedFile)
+
+      waitsForPromise ->
+        atom.project.getRepositories()[0].async.getPathStatus(modifiedFile)
 
       treeView.updateRoots()
       dir = null

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -352,6 +352,10 @@ describe "TreeView", ->
 
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+
+        waitsFor ->
+          !!treeView.selectedEntry().getPath().match(/file1/)
+        runs ->
           expect(treeView.hasParent()).toBeTruthy()
           expect(treeView.focus).toHaveBeenCalled()
           expect(treeView.selectedEntry().getPath()).toContain(path.join("dir1", "file1"))
@@ -362,6 +366,11 @@ describe "TreeView", ->
 
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+
+        waitsFor ->
+          !!treeView.selectedEntry().getPath().match(/file3/)
+
+        runs ->
           expect(treeView.hasParent()).toBeTruthy()
           expect(treeView.focus).toHaveBeenCalled()
           expect(treeView.selectedEntry().getPath()).toContain(path.join("dir3", "file3"))

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -924,17 +924,21 @@ describe "TreeView", ->
     describe "tree-view:recursive-expand-directory", ->
       describe "when an collapsed root is recursively expanded", ->
         it "expands the root and all subdirectories", ->
+          children = null
           root1.click()
           treeView.roots[0].collapse()
 
           expect(treeView.roots[0]).not.toHaveClass 'expanded'
           atom.commands.dispatch(treeView.element, 'tree-view:recursive-expand-directory')
-          expect(treeView.roots[0]).toHaveClass 'expanded'
+          waitsFor ->
+            root1.find('.directory').length > 0 and treeView.roots[0].classList.contains('expanded')
+          runs ->
+            expect(treeView.roots[0]).toHaveClass 'expanded'
 
-          children = root1.find('.directory')
-          expect(children.length).toBeGreaterThan 0
-          children.each (index, child) ->
-            expect(child).toHaveClass 'expanded'
+            children = root1.find('.directory')
+            expect(children.length).toBeGreaterThan 0
+            children.each (index, child) ->
+              expect(child).toHaveClass 'expanded'
 
     describe "tree-view:collapse-directory", ->
       subdir = null

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2404,9 +2404,12 @@ describe "TreeView", ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
         element.expand() for element in treeView.find('.directory')
-        fileView = treeView.find('.file:contains(new2)')
-        expect(fileView).not.toBeNull()
-        fileView.click()
+        fileView = null
+        waitsFor 'fileView to be displayed', ->
+          fileView = treeView.find('.file:contains(new2)')
+          fileView.length > 0
+        runs ->
+          fileView.click()
 
       describe "when the file is deleted", ->
         it "updates the style of the directory", ->
@@ -2417,7 +2420,10 @@ describe "TreeView", ->
           spyOn(atom, 'confirm').andCallFake (dialog) ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
-          expect(dirView[0].directory.updateStatus).toHaveBeenCalled()
+          waitsFor ->
+            dirView[0].directory.updateStatus.callCount > 0
+          runs ->
+            expect(dirView[0].directory.updateStatus).toHaveBeenCalled()
 
     describe "when the project is a symbolic link to the repository root", ->
       beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2204,10 +2204,12 @@ describe "TreeView", ->
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
-          atom.project.getRepositories()[0].getPathStatus(modifiedFile)
-
-          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
+          atom.project.getRepositories()[0].async.getPathStatus(modifiedFile)
+          waitsFor ->
+            not treeView.find('.file:contains(b.txt)').hasClass('status-modified')
+          runs ->
+            expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
+            expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -202,6 +202,10 @@ describe "TreeView", ->
       runs ->
         treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
         expect(treeView).toExist()
+
+      waitsFor ->
+        treeView.selectedEntry()?.getPath().match(/tree-view.js/)
+      runs ->
         expect($(treeView.selectedEntry())).toMatchSelector(".file:contains(tree-view.js)")
         root1 = $(treeView.roots[0])
         expect(root1.find(".directory:contains(dir1)")).toHaveClass("expanded")

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2143,7 +2143,7 @@ describe "TreeView", ->
     describe "when the project is the repository root", ->
       it "adds a custom style", ->
         waitsFor ->
-          treeView.find('.icon-repo').length == 1
+          treeView.find('.icon-repo').length is 1
         runs ->
           expect(treeView.find('.icon-repo').length).toBe 1
 


### PR DESCRIPTION
tree-view is the best candidate for exercising the new async repo class we’re working on in https://github.com/atom/atom/pull/9213

This depends on that branch of atom/atom. The plan is to merge the async repo after it proves sufficient for tree-view’s consumption, then merge this.
