### PR TITLE
Remove height on the tree-view-resizer

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -2,7 +2,6 @@
 
 .tree-view-resizer {
   position: relative;
-  height: 100%;
   overflow: hidden;
   cursor: default;
   -webkit-user-select: none;


### PR DESCRIPTION
:warning: This PR depends on https://github.com/atom/atom/pull/9274

This lets the `height` be changed by the parent flexbox added in https://github.com/atom/atom/pull/9274.