### PR TITLE
:bug: Natural sort should be I18n compatible

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -5,7 +5,6 @@ fs = require 'fs-plus'
 PathWatcher = require 'pathwatcher'
 File = require './file'
 {repoForPath} = require './helpers'
-naturalCompare = require 'natural-compare-lite'
 realpathCache = {}
 
 module.exports =
@@ -162,8 +161,7 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-
-    names.sort(naturalCompare)
+    names.sort(new Intl.Collator(undefined, {numeric: true, sensitivity: "base"}).compare)
 
     files = []
     directories = []

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
     "minimatch": "~0.3.0",
-    "natural-compare-lite": "^1.4.0",
     "pathwatcher": "^6.2",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0"


### PR DESCRIPTION
I initially added a faster implementation of natural sort https://github.com/atom/tree-view/pull/621, but it was not I18n compatible.

the users locale is derived with `(new Intl.Collator()).resolvedOptions().locale` because electron's implementation of `navigator.langauge` https://github.com/atom/electron/pull/363 does not return a BCP 47 language tag.

this implementation is also faster then `natural-sort-lite` and `String.localeCompare`

ping @nathansobo @jeancroy
