### PR TITLE
Delete entry from expansion state property

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -230,10 +230,10 @@ class Directory
       entriesRemoved = true
       entry.destroy()
 
-      if @entries.hasOwnProperty(entry)
+      if @entries.hasOwnProperty(name)
         delete @entries[name]
 
-      if @expansionState.entries.hasOwnProperty(entry)
+      if @expansionState.entries.hasOwnProperty(name)
         delete @expansionState.entries[name]
 
     @emitter.emit('did-remove-entries', removedEntries) if entriesRemoved

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -229,8 +229,13 @@ class Directory
     for name, entry of removedEntries
       entriesRemoved = true
       entry.destroy()
-      delete @entries[name]
-      delete @expansionState[name]
+
+      if @entries.hasOwnProperty(entry)
+        delete @entries[name]
+
+      if @expansionState.entries.hasOwnProperty(entry)
+        delete @expansionState.entries[name]
+
     @emitter.emit('did-remove-entries', removedEntries) if entriesRemoved
 
     if newEntries.length > 0

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2657,6 +2657,21 @@ describe "TreeView", ->
         expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Opening folder in Finder failed'
         expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'ENOENT'
 
+  describe "when reloading a directory with deletions and additions", ->
+    it "does not throw an error (regression)", ->
+      projectPath = temp.mkdirSync('atom-project')
+      entriesPath = path.join(projectPath, 'entries')
+
+      fs.mkdirSync(entriesPath)
+      atom.project.setPaths([projectPath])
+      treeView.roots[0].expand()
+
+      fs.removeSync(entriesPath)
+      treeView.roots[0].reload()
+
+      fs.mkdirSync(path.join(projectPath, 'other'))
+      treeView.roots[0].reload()
+
   describe "Dragging and dropping files", ->
     beforeEach ->
       rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2665,17 +2665,21 @@ describe "TreeView", ->
       fs.mkdirSync(entriesPath)
       atom.project.setPaths([projectPath])
       treeView.roots[0].expand()
+      expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
+        isExpanded: true
+        entries:
+          entries:
+            isExpanded: false
+            entries: {}
 
       fs.removeSync(entriesPath)
       treeView.roots[0].reload()
-
       expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
         isExpanded: true
         entries: {}
 
       fs.mkdirSync(path.join(projectPath, 'other'))
       treeView.roots[0].reload()
-
       expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
         isExpanded: true
         entries:

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2669,8 +2669,19 @@ describe "TreeView", ->
       fs.removeSync(entriesPath)
       treeView.roots[0].reload()
 
+      expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
+        isExpanded: true
+        entries: {}
+
       fs.mkdirSync(path.join(projectPath, 'other'))
       treeView.roots[0].reload()
+
+      expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
+        isExpanded: true
+        entries:
+          other:
+            isExpanded: false
+            entries: {}
 
   describe "Dragging and dropping files", ->
     beforeEach ->


### PR DESCRIPTION
Previously entries were deleted from `@expansionState` instead of `@expansionState.entries` which would cause uncaught exceptions when the project contained an `entries` folder that was deleted.

Fixes #641