### PR TITLE
Fix copy/pasting files under certain scenarios

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -17,9 +17,8 @@ module.exports =
     styleObject
 
   getFullExtension: (filePath) ->
-    nextExtension = path.extname(filePath)
     fullExtension = ''
-    while nextExtension isnt ''
-      fullExtension = nextExtension.concat(fullExtension)
-      nextExtension = path.extname(path.basename(filePath, fullExtension))
+    while extension = path.extname(filePath)
+      fullExtension = extension + fullExtension
+      filePath = path.basename(filePath, extension)
     fullExtension

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -15,3 +15,11 @@ module.exports =
       camelizedAttr = property.replace /\-([a-z])/g, (a, b) -> b.toUpperCase()
       styleObject[camelizedAttr] = value
     styleObject
+
+  getFullExtension: (filePath) ->
+    nextExtension = path.extname(filePath)
+    fullExtension = ''
+    while nextExtension isnt ''
+      fullExtension = nextExtension.concat(fullExtension)
+      nextExtension = path.extname(path.basename(filePath, fullExtension))
+    fullExtension

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -588,8 +588,15 @@ class TreeView extends View
             if initialPathIsDirectory
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
-              fileArr = originalNewPath.split('.')
-              newPath = "#{fileArr[0]}#{fileCounter.toString()}.#{fileArr[1]}"
+              if process.platform is 'win32'
+                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(originalNewPath)
+              else
+                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(originalNewPath)
+
+              if fileArr?
+                newPath = "#{fileArr[1]}#{fileCounter.toString()}.#{fileArr[2]}"
+              else # File didn't have an extension so don't attempt to append a nonexistent one
+                newPath = "#{originalNewPath}#{fileCounter.toString()}"
             fileCounter += 1
 
           if fs.isDirectorySync(initialPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -611,7 +611,7 @@ class TreeView extends View
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
               extension = getFullExtension(originalNewPath)
-              filePath = path.join(path.dirname(originalNewPath), path.basename(originalNewPath, fullExtension))
+              filePath = path.join(path.dirname(originalNewPath), path.basename(originalNewPath, extension))
               newPath = "#{filePath}#{fileCounter.toString()}#{extension}"
             fileCounter += 1
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable} = require 'atom'
-{repoForPath, getStyleObject} = require "./helpers"
+{repoForPath, getStyleObject, getFullExtension} = require "./helpers"
 {$, View} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 
@@ -610,15 +610,9 @@ class TreeView extends View
             if initialPathIsDirectory
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
-              nextExtension = path.extname(originalNewPath)
-              fullExtension = ''
-              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
-                fullExtension = nextExtension.concat(fullExtension)
-                nextExtension = path.extname(path.basename(originalNewPath, fullExtension))
-
-              filePath = path.dirname(originalNewPath) + path.sep + path.basename(originalNewPath, fullExtension)
-
-              newPath = "#{filePath}#{fileCounter.toString()}#{fullExtension}"
+              extension = getFullExtension(originalNewPath)
+              filePath = path.dirname(originalNewPath) + path.sep + path.basename(originalNewPath, extension)
+              newPath = "#{filePath}#{fileCounter.toString()}#{extension}"
             fileCounter += 1
 
           if fs.isDirectorySync(initialPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -625,9 +625,9 @@ class TreeView extends View
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
               if process.platform is 'win32'
-                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(originalNewPath)
+                fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(originalNewPath)
               else
-                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(originalNewPath)
+                fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(originalNewPath)
 
               if fileArr?
                 newPath = "#{fileArr[1]}#{fileCounter.toString()}.#{fileArr[2]}"

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -610,15 +610,10 @@ class TreeView extends View
             if initialPathIsDirectory
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
-              if process.platform is 'win32'
-                fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(originalNewPath)
-              else
-                fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(originalNewPath)
+              extension = path.extname(originalNewPath)
+              filePath = path.dirname(originalNewPath) + path.sep + path.basename(originalNewPath, extension)
 
-              if fileArr?
-                newPath = "#{fileArr[1]}#{fileCounter.toString()}.#{fileArr[2]}"
-              else # File didn't have an extension so don't attempt to append a nonexistent one
-                newPath = "#{originalNewPath}#{fileCounter.toString()}"
+              newPath = "#{filePath}#{fileCounter.toString()}#{extension}"
             fileCounter += 1
 
           if fs.isDirectorySync(initialPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -608,11 +608,11 @@ class TreeView extends View
           originalNewPath = newPath
           while fs.existsSync(newPath)
             if initialPathIsDirectory
-              newPath = "#{originalNewPath}#{fileCounter.toString()}"
+              newPath = "#{originalNewPath}#{fileCounter}"
             else
               extension = getFullExtension(originalNewPath)
               filePath = path.join(path.dirname(originalNewPath), path.basename(originalNewPath, extension))
-              newPath = "#{filePath}#{fileCounter.toString()}#{extension}"
+              newPath = "#{filePath}#{fileCounter}#{extension}"
             fileCounter += 1
 
           if fs.isDirectorySync(initialPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -610,10 +610,15 @@ class TreeView extends View
             if initialPathIsDirectory
               newPath = "#{originalNewPath}#{fileCounter.toString()}"
             else
-              extension = path.extname(originalNewPath)
-              filePath = path.dirname(originalNewPath) + path.sep + path.basename(originalNewPath, extension)
+              nextExtension = path.extname(originalNewPath)
+              fullExtension = ''
+              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
+                fullExtension = nextExtension.concat(fullExtension)
+                nextExtension = path.extname(path.basename(originalNewPath, fullExtension))
 
-              newPath = "#{filePath}#{fileCounter.toString()}#{extension}"
+              filePath = path.dirname(originalNewPath) + path.sep + path.basename(originalNewPath, fullExtension)
+
+              newPath = "#{filePath}#{fileCounter.toString()}#{fullExtension}"
             fileCounter += 1
 
           if fs.isDirectorySync(initialPath)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-view",
-  "version": "0.197.0",
+  "version": "0.198.0",
   "main": "./lib/main",
   "description": "Explore and open files in the current project.",
   "repository": "https://github.com/atom/tree-view",

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1424,7 +1424,7 @@ describe "TreeView", ->
             fs.makeTreeSync(dotDirPath)
             LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
-            dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir):first')
+            dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir)')
             dotDirView.click()
             console.log dotDirView
             atom.commands.dispatch(treeView.element, "tree-view:paste")
@@ -1440,7 +1440,7 @@ describe "TreeView", ->
               fs.writeFileSync(dotFilePath, "doesn't matter .")
               LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
 
-              dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir):last')
+              dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir)')
               dotDirView.click()
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1281,20 +1281,61 @@ describe "TreeView", ->
             expect(fs.existsSync(path.join(dirPath2, path.basename(filePath)))).toBeTruthy()
             expect(fs.existsSync(filePath)).toBeTruthy()
 
-          describe 'when target already exists', ->
-            it 'appends a number to the destination name', ->
+          describe "when the target already exists", ->
+            it "appends a number to the destination name", ->
               LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
               fileView.click()
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              fileArr = filePath.split(path.sep).pop().split('.')
-              numberedFileName0 = path.join(dirPath, "#{fileArr[0]}0.#{fileArr[1]}")
-              numberedFileName1 = path.join(dirPath, "#{fileArr[0]}1.#{fileArr[1]}")
+              if process.platform is 'win32'
+                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(filePath)
+              else
+                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(filePath)
+
+              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
+              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
+
+        xdescribe "when a file containing two or more periods is selected", ->
+          describe "when a file is selected", ->
+            it "creates a copy of the original file in the selected file's parent directory", ->
+              dotFilePath = path.join(dirPath, "test.file.txt")
+              fs.writeFileSync(dotFilePath, "doesn't matter .")
+              LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
+
+              treeView.find('.file:contains(test.file.txt)').click()
+              atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+              fileView2.click()
+              atom.commands.dispatch(treeView.element, "tree-view:paste")
+              expect(fs.existsSync(path.join(dirPath, path.basename(dotFilePath)))).toBeTruthy()
+              expect(fs.existsSync(dotFilePath)).toBeTruthy()
+
+            describe "when the target already exists", ->
+              it "appends a number to the destination name", ->
+                dotFilePath = path.join(dirPath, "test.file.txt")
+                fs.writeFileSync(dotFilePath, "doesn't matter .")
+                LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
+
+                dotFileView = treeView.find('.file:contains(test.file.txt)')
+                dotFileView.click()
+                atom.commands.dispatch(treeView.element, "tree-view:paste")
+                atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+                if process.platform is 'win32'
+                  fileArr = /(.+)\.(?!.*\\)(.+)/.exec(dotFilePath)
+                else
+                  fileArr = /(.+)\.(?!.*\/)(.+)/.exec(dotFilePath)
+
+                numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
+                numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
+                expect(fs.existsSync(numberedFileName0)).toBeTruthy()
+                expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+                expect(fs.existsSync(dotFilePath)).toBeTruthy()
 
         describe "when a directory is selected", ->
           it "creates a copy of the original file in the selected directory", ->
@@ -1306,20 +1347,58 @@ describe "TreeView", ->
             expect(fs.existsSync(path.join(dirPath2, path.basename(filePath)))).toBeTruthy()
             expect(fs.existsSync(filePath)).toBeTruthy()
 
-          describe 'when target already exists', ->
-            it 'appends a number to the destination directory name', ->
+          describe "when the target already exists", ->
+            it "appends a number to the destination directory name", ->
               LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
               dirView.click()
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              fileArr = filePath.split(path.sep).pop().split('.')
-              numberedFileName0 = path.join(dirPath, "#{fileArr[0]}0.#{fileArr[1]}")
-              numberedFileName1 = path.join(dirPath, "#{fileArr[0]}1.#{fileArr[1]}")
+              if process.platform is 'win32'
+                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(filePath)
+              else
+                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(filePath)
+
+              numberedFileName0 = "#{fileArr[0]}0.#{fileArr[1]}"
+              numberedFileName1 = "#{fileArr[0]}1.#{fileArr[1]}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
+
+        xdescribe "when a directory with a period is selected", ->
+          it "creates a copy of the original file in the selected directory", ->
+            dotFilePath = path.join(dirPath, "test.file.txt")
+            fs.writeFileSync(dotFilePath, "doesn't matter .")
+            LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
+
+            dirView2.click()
+            atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+            expect(fs.existsSync(path.join(dirPath2, path.basename(dotFilePath)))).toBeTruthy()
+            expect(fs.existsSync(dotFilePath)).toBeTruthy()
+
+          describe "when the target already exists", ->
+            it "appends a number to the destination directory name", ->
+              dotFilePath = path.join(dirPath, "test.file.txt")
+              fs.writeFileSync(dotFilePath, "doesn't matter .")
+              LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
+
+              dirView.click()
+              atom.commands.dispatch(treeView.element, "tree-view:paste")
+              atom.commands.dispatch(treeView.element, "tree-view:paste")
+
+              if process.platform is 'win32'
+                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(dotFilePath)
+              else
+                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(dotFilePath)
+
+              numberedFileName0 = "#{fileArr[0]}0.#{fileArr[1]}"
+              numberedFileName1 = "#{fileArr[0]}1.#{fileArr[1]}"
+              expect(fs.existsSync(numberedFileName0)).toBeTruthy()
+              expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+              expect(fs.existsSync(dotFilePath)).toBeTruthy()
+
 
         describe "when pasting into a different root directory", ->
           it "creates the file", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1353,7 +1353,7 @@ describe "TreeView", ->
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
 
-        xdescribe "when a file containing two or more periods is selected", ->
+        describe "when a file containing two or more periods has been copied", ->
           describe "when a file is selected", ->
             it "creates a copy of the original file in the selected file's parent directory", ->
               dotFilePath = path.join(dirPath, "test.file.txt")
@@ -1374,8 +1374,7 @@ describe "TreeView", ->
                 fs.writeFileSync(dotFilePath, "doesn't matter .")
                 LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
 
-                dotFileView = treeView.find('.file:contains(test.file.txt)')
-                dotFileView.click()
+                fileView.click()
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
@@ -1413,31 +1412,36 @@ describe "TreeView", ->
               else
                 fileArr = /(.+)\.(?!.*\/)(.+)/.exec(filePath)
 
-              numberedFileName0 = "#{fileArr[0]}0.#{fileArr[1]}"
-              numberedFileName1 = "#{fileArr[0]}1.#{fileArr[1]}"
+              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
+              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
 
         xdescribe "when a directory with a period is selected", ->
           it "creates a copy of the original file in the selected directory", ->
-            dotFilePath = path.join(dirPath, "test.file.txt")
-            fs.writeFileSync(dotFilePath, "doesn't matter .")
-            LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
+            dotDirPath = path.join(rootDirPath, "test.dir")
+            fs.makeTreeSync(dotDirPath)
+            LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
-            dirView2.click()
+            dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir):first')
+            dotDirView.click()
+            console.log dotDirView
             atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-            expect(fs.existsSync(path.join(dirPath2, path.basename(dotFilePath)))).toBeTruthy()
-            expect(fs.existsSync(dotFilePath)).toBeTruthy()
+            expect(fs.existsSync(path.join(dotDirPath, path.basename(filePath)))).toBeTruthy()
+            expect(fs.existsSync(filePath)).toBeTruthy()
 
           describe "when the target already exists", ->
             it "appends a number to the destination directory name", ->
-              dotFilePath = path.join(dirPath, "test.file.txt")
+              dotDirPath = path.join(rootDirPath, "test.dir")
+              dotFilePath = path.join(dotDirPath, "test.file.txt")
+              fs.makeTreeSync(dotDirPath)
               fs.writeFileSync(dotFilePath, "doesn't matter .")
               LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
 
-              dirView.click()
+              dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir):last')
+              dotDirView.click()
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
@@ -1446,12 +1450,11 @@ describe "TreeView", ->
               else
                 fileArr = /(.+)\.(?!.*\/)(.+)/.exec(dotFilePath)
 
-              numberedFileName0 = "#{fileArr[0]}0.#{fileArr[1]}"
-              numberedFileName1 = "#{fileArr[0]}1.#{fileArr[1]}"
+              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
+              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(dotFilePath)).toBeTruthy()
-
 
         describe "when pasting into a different root directory", ->
           it "creates the file", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -5,6 +5,7 @@ path = require 'path'
 temp = require('temp').track()
 os = require 'os'
 eventHelpers = require "./event-helpers"
+{getFullExtension} = require "../lib/helpers"
 
 waitsForFileToOpen = (causeFileToOpen) ->
   waitsFor (done) ->
@@ -1465,16 +1466,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              nextExtension = path.extname(filePath)
-              fullExtension = ''
-              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
-                fullExtension = nextExtension.concat(fullExtension)
-                nextExtension = path.extname(path.basename(filePath, fullExtension))
+              extension = getFullExtension(filePath)
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
 
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, fullExtension)
-
-              numberedFileName0 = "#{file}0#{fullExtension}"
-              numberedFileName1 = "#{file}1#{fullExtension}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1504,16 +1500,11 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-                nextExtension = path.extname(dotFilePath)
-                fullExtension = ''
-                while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
-                  fullExtension = nextExtension.concat(fullExtension)
-                  nextExtension = path.extname(path.basename(dotFilePath, fullExtension))
+                extension = getFullExtension(dotFilePath)
+                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
 
-                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, fullExtension)
-
-                numberedFileName0 = "#{file}0#{fullExtension}"
-                numberedFileName1 = "#{file}1#{fullExtension}"
+                numberedFileName0 = "#{file}0#{extension}"
+                numberedFileName1 = "#{file}1#{extension}"
                 expect(fs.existsSync(numberedFileName0)).toBeTruthy()
                 expect(fs.existsSync(numberedFileName1)).toBeTruthy()
                 expect(fs.existsSync(dotFilePath)).toBeTruthy()
@@ -1536,16 +1527,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              nextExtension = path.extname(filePath)
-              fullExtension = ''
-              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
-                fullExtension = nextExtension.concat(fullExtension)
-                nextExtension = path.extname(path.basename(filePath, fullExtension))
+              extension = getFullExtension(filePath)
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
 
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, fullExtension)
-
-              numberedFileName0 = "#{file}0#{fullExtension}"
-              numberedFileName1 = "#{file}1#{fullExtension}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1580,16 +1566,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              nextExtension = path.extname(dotFilePath)
-              fullExtension = ''
-              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
-                fullExtension = nextExtension.concat(fullExtension)
-                nextExtension = path.extname(path.basename(dotFilePath, fullExtension))
+              extension = getFullExtension(dotFilePath)
+              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
 
-              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, fullExtension)
-
-              numberedFileName0 = "#{file}0#{fullExtension}"
-              numberedFileName1 = "#{file}1#{fullExtension}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(dotFilePath)).toBeTruthy()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1465,13 +1465,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              if process.platform is 'win32'
-                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(filePath)
-              else
-                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(filePath)
+              extension = path.extname(filePath)
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
 
-              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
-              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1501,13 +1499,11 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-                if process.platform is 'win32'
-                  fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(dotFilePath)
-                else
-                  fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(dotFilePath)
+                extension = path.extname(dotFilePath)
+                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
 
-                numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
-                numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
+                numberedFileName0 = "#{file}0#{extension}"
+                numberedFileName1 = "#{file}1#{extension}"
                 expect(fs.existsSync(numberedFileName0)).toBeTruthy()
                 expect(fs.existsSync(numberedFileName1)).toBeTruthy()
                 expect(fs.existsSync(dotFilePath)).toBeTruthy()
@@ -1530,13 +1526,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              if process.platform is 'win32'
-                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(filePath)
-              else
-                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(filePath)
+              extension = path.extname(filePath)
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
 
-              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
-              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1571,13 +1565,11 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              if process.platform is 'win32'
-                fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(dotFilePath)
-              else
-                fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(dotFilePath)
+              extension = path.extname(dotFilePath)
+              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
 
-              numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
-              numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"
+              numberedFileName0 = "#{file}0#{extension}"
+              numberedFileName1 = "#{file}1#{extension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(dotFilePath)).toBeTruthy()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1465,11 +1465,16 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = path.extname(filePath)
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
+              nextExtension = path.extname(filePath)
+              fullExtension = ''
+              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
+                fullExtension = nextExtension.concat(fullExtension)
+                nextExtension = path.extname(path.basename(filePath, fullExtension))
 
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, fullExtension)
+
+              numberedFileName0 = "#{file}0#{fullExtension}"
+              numberedFileName1 = "#{file}1#{fullExtension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1499,11 +1504,16 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-                extension = path.extname(dotFilePath)
-                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
+                nextExtension = path.extname(dotFilePath)
+                fullExtension = ''
+                while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
+                  fullExtension = nextExtension.concat(fullExtension)
+                  nextExtension = path.extname(path.basename(dotFilePath, fullExtension))
 
-                numberedFileName0 = "#{file}0#{extension}"
-                numberedFileName1 = "#{file}1#{extension}"
+                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, fullExtension)
+
+                numberedFileName0 = "#{file}0#{fullExtension}"
+                numberedFileName1 = "#{file}1#{fullExtension}"
                 expect(fs.existsSync(numberedFileName0)).toBeTruthy()
                 expect(fs.existsSync(numberedFileName1)).toBeTruthy()
                 expect(fs.existsSync(dotFilePath)).toBeTruthy()
@@ -1526,11 +1536,16 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = path.extname(filePath)
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
+              nextExtension = path.extname(filePath)
+              fullExtension = ''
+              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
+                fullExtension = nextExtension.concat(fullExtension)
+                nextExtension = path.extname(path.basename(filePath, fullExtension))
 
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
+              file = path.dirname(filePath) + path.sep + path.basename(filePath, fullExtension)
+
+              numberedFileName0 = "#{file}0#{fullExtension}"
+              numberedFileName1 = "#{file}1#{fullExtension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
@@ -1565,11 +1580,16 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = path.extname(dotFilePath)
-              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
+              nextExtension = path.extname(dotFilePath)
+              fullExtension = ''
+              while nextExtension isnt '' # This is for files with multiple extensions since extname only returns the last extension
+                fullExtension = nextExtension.concat(fullExtension)
+                nextExtension = path.extname(path.basename(dotFilePath, fullExtension))
 
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
+              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, fullExtension)
+
+              numberedFileName0 = "#{file}0#{fullExtension}"
+              numberedFileName1 = "#{file}1#{fullExtension}"
               expect(fs.existsSync(numberedFileName0)).toBeTruthy()
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(dotFilePath)).toBeTruthy()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1449,7 +1449,7 @@ describe "TreeView", ->
             expect(fs.existsSync(filePath)).toBeTruthy()
 
           describe "when the target already exists", ->
-            it "appends a number to the destination directory name", ->
+            it "appends a number to the destination file name", ->
               LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
               dirView.click()
@@ -1467,25 +1467,28 @@ describe "TreeView", ->
               expect(fs.existsSync(numberedFileName1)).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
 
-        xdescribe "when a directory with a period is selected", ->
-          it "creates a copy of the original file in the selected directory", ->
+        describe "when a directory with a period is selected", ->
+          [dotDirPath] = []
+
+          beforeEach ->
             dotDirPath = path.join(rootDirPath, "test.dir")
             fs.makeTreeSync(dotDirPath)
+
+            atom.project.setPaths([rootDirPath]) # Force test.dir to show up
+
+          it "creates a copy of the original file in the selected directory", ->
             LocalStorage['tree-view:copyPath'] = JSON.stringify([filePath])
 
             dotDirView = $(treeView.roots[0].entries).find('.directory:contains(test\\.dir)')
             dotDirView.click()
-            console.log dotDirView
             atom.commands.dispatch(treeView.element, "tree-view:paste")
 
             expect(fs.existsSync(path.join(dotDirPath, path.basename(filePath)))).toBeTruthy()
             expect(fs.existsSync(filePath)).toBeTruthy()
 
           describe "when the target already exists", ->
-            it "appends a number to the destination directory name", ->
-              dotDirPath = path.join(rootDirPath, "test.dir")
+            it "appends a number to the destination file name", ->
               dotFilePath = path.join(dotDirPath, "test.file.txt")
-              fs.makeTreeSync(dotDirPath)
               fs.writeFileSync(dotFilePath, "doesn't matter .")
               LocalStorage['tree-view:copyPath'] = JSON.stringify([dotFilePath])
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1467,7 +1467,7 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
               extension = getFullExtension(filePath)
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
+              file = path.join(path.dirname(filePath), path.basename(filePath, extension))
 
               numberedFileName0 = "#{file}0#{extension}"
               numberedFileName1 = "#{file}1#{extension}"
@@ -1501,7 +1501,7 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
                 extension = getFullExtension(dotFilePath)
-                file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
+                file = path.join(path.dirname(dotFilePath), path.basename(dotFilePath, extension))
 
                 numberedFileName0 = "#{file}0#{extension}"
                 numberedFileName1 = "#{file}1#{extension}"
@@ -1528,7 +1528,7 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
               extension = getFullExtension(filePath)
-              file = path.dirname(filePath) + path.sep + path.basename(filePath, extension)
+              file = path.join(path.dirname(filePath), path.basename(filePath, extension))
 
               numberedFileName0 = "#{file}0#{extension}"
               numberedFileName1 = "#{file}1#{extension}"
@@ -1567,7 +1567,7 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
               extension = getFullExtension(dotFilePath)
-              file = path.dirname(dotFilePath) + path.sep + path.basename(dotFilePath, extension)
+              file = path.join(path.dirname(dotFilePath), path.basename(dotFilePath, extension))
 
               numberedFileName0 = "#{file}0#{extension}"
               numberedFileName1 = "#{file}1#{extension}"

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1502,9 +1502,9 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
                 if process.platform is 'win32'
-                  fileArr = /(.+)\.(?!.*\\)(.+)/.exec(dotFilePath)
+                  fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(dotFilePath)
                 else
-                  fileArr = /(.+)\.(?!.*\/)(.+)/.exec(dotFilePath)
+                  fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(dotFilePath)
 
                 numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
                 numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -5,7 +5,6 @@ path = require 'path'
 temp = require('temp').track()
 os = require 'os'
 eventHelpers = require "./event-helpers"
-{getFullExtension} = require "../lib/helpers"
 
 waitsForFileToOpen = (causeFileToOpen) ->
   waitsFor (done) ->
@@ -1466,13 +1465,8 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = getFullExtension(filePath)
-              file = path.join(path.dirname(filePath), path.basename(filePath, extension))
-
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
-              expect(fs.existsSync(numberedFileName0)).toBeTruthy()
-              expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+              expect(fs.existsSync(path.join(path.dirname(filePath), "test-file0.txt"))).toBeTruthy()
+              expect(fs.existsSync(path.join(path.dirname(filePath), "test-file1.txt"))).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
 
         describe "when a file containing two or more periods has been copied", ->
@@ -1500,13 +1494,8 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
                 atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-                extension = getFullExtension(dotFilePath)
-                file = path.join(path.dirname(dotFilePath), path.basename(dotFilePath, extension))
-
-                numberedFileName0 = "#{file}0#{extension}"
-                numberedFileName1 = "#{file}1#{extension}"
-                expect(fs.existsSync(numberedFileName0)).toBeTruthy()
-                expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+                expect(fs.existsSync(path.join(dirPath, 'test0.file.txt'))).toBeTruthy()
+                expect(fs.existsSync(path.join(dirPath, 'test1.file.txt'))).toBeTruthy()
                 expect(fs.existsSync(dotFilePath)).toBeTruthy()
 
         describe "when a directory is selected", ->
@@ -1527,13 +1516,8 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = getFullExtension(filePath)
-              file = path.join(path.dirname(filePath), path.basename(filePath, extension))
-
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
-              expect(fs.existsSync(numberedFileName0)).toBeTruthy()
-              expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+              expect(fs.existsSync(path.join(path.dirname(filePath), "test-file0.txt"))).toBeTruthy()
+              expect(fs.existsSync(path.join(path.dirname(filePath), "test-file1.txt"))).toBeTruthy()
               expect(fs.existsSync(filePath)).toBeTruthy()
 
         describe "when a directory with a period is selected", ->
@@ -1566,13 +1550,8 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-              extension = getFullExtension(dotFilePath)
-              file = path.join(path.dirname(dotFilePath), path.basename(dotFilePath, extension))
-
-              numberedFileName0 = "#{file}0#{extension}"
-              numberedFileName1 = "#{file}1#{extension}"
-              expect(fs.existsSync(numberedFileName0)).toBeTruthy()
-              expect(fs.existsSync(numberedFileName1)).toBeTruthy()
+              expect(fs.existsSync(path.join(dotDirPath, "test0.file.txt"))).toBeTruthy()
+              expect(fs.existsSync(path.join(dotDirPath, "test1.file.txt"))).toBeTruthy()
               expect(fs.existsSync(dotFilePath)).toBeTruthy()
 
         describe "when pasting into a different root directory", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1572,9 +1572,9 @@ describe "TreeView", ->
               atom.commands.dispatch(treeView.element, "tree-view:paste")
 
               if process.platform is 'win32'
-                fileArr = /(.+)\.(?!.*\\)(.+)/.exec(dotFilePath)
+                fileArr = /(.+?)\.(?!.*\\)(.+)/.exec(dotFilePath)
               else
-                fileArr = /(.+)\.(?!.*\/)(.+)/.exec(dotFilePath)
+                fileArr = /(.+?)\.(?!.*\/)(.+)/.exec(dotFilePath)
 
               numberedFileName0 = "#{fileArr[1]}0.#{fileArr[2]}"
               numberedFileName1 = "#{fileArr[1]}1.#{fileArr[2]}"


### PR DESCRIPTION
This probably should have 2 separate commits, but oh well.

The two issues that have been fixed:
1) If the absolute filepath you were copying had additional periods in it (eg `/Users/John.Doe/test.txt`), the Tree View would interpret the file to be pasted as `/Users/John0.Doe`.  This would usually fail (for pretty obvious reasons, you're trying to create a new user), especially on Windows.
2) If the file you were copying did not have an extension (eg `test`), the pasted file would be `test0.undefined` because the extension was undefined, and Tree View didn't care.

The fix for 1) involved moving away from `.split()` and switching to a similar regex that captures only the *last* period instead of the first.  This naturally led to 2): by adding a check to make sure there are no file separators after the period, the captured regex will always be undefined if the filename doesn't have an extension.  Tree View now detects this and acts appropriately.

~~This *somewhat* addresses #581 in that the last extension will no longer be stripped as per 1).  HOWEVER, the second-to-last extension and not the true filename will have the file counter appended to it: `style.min.css` -> `style.min0.css`.  On the other hand, #397 (which I just realized #581 is a duplicate of) is asking for the functionality implemented in this PR. :confused:~~
This PR now fixes #581 in the manner requested which I feel is more natural than #397.

Specs might take me a while.  I'll see what I can do.

Fixes #464, fixes #648, fixes #581, closes #397