### PR TITLE
add contextual search for selected item

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -8,12 +8,14 @@
   'ctrl-\\': 'tree-view:toggle'
   'ctrl-k ctrl-b': 'tree-view:toggle'
   'ctrl-|': 'tree-view:reveal-active-file'
+  'ctrl-f': 'tree-view:search-selected-entry'
   'alt-\\': 'tree-view:toggle-focus'
 
 '.platform-darwin .tree-view':
   'cmd-c': 'tree-view:copy'
   'cmd-x': 'tree-view:cut'
   'cmd-v': 'tree-view:paste'
+  'cmd-f': 'tree-view:search-selected-entry'
   'ctrl-f': 'tree-view:expand-item'
   'ctrl-b': 'tree-view:collapse-directory'
   'cmd-k right': 'tree-view:open-selected-entry-right'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -426,7 +426,6 @@ class TreeView
 
     @scrollToEntry(@selectedEntry())
 
-
   nextEntry: (entry) ->
     currentEntry = entry
     while currentEntry?

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -137,6 +137,7 @@ class TreeView
      'core:move-to-top': => @scrollToTop()
      'core:move-to-bottom': => @scrollToBottom()
      'tree-view:expand-item': => @openSelectedEntry(pending: true, true)
+     'tree-view:search-selected-entry': => @searchSelectedEntry()
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
@@ -425,6 +426,7 @@ class TreeView
 
     @scrollToEntry(@selectedEntry())
 
+
   nextEntry: (entry) ->
     currentEntry = entry
     while currentEntry?
@@ -444,6 +446,11 @@ class TreeView
       if currentEntry?.matches('.entry')
         return currentEntry
     return null
+
+  searchSelectedEntry: ->
+    selectedEntry = @selectedEntry()
+    command = if selectedEntry.directory then 'project-find:show-in-current-directory' else 'find-and-replace:show'
+    atom.commands.dispatch(selectedEntry, command)
 
   expandDirectory: (isRecursive=false) ->
     selectedEntry = @selectedEntry()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3126,21 +3126,21 @@ describe "TreeView", ->
       fs.writeFileSync(filePath, "doesn't matter")
 
       atom.project.setPaths([rootDirPath])
-      spyOn(atom.commands, 'dispatch').andCallThrough();
+      spyOn(atom.commands, 'dispatch').andCallThrough()
 
     describe 'when a file is selected', ->
       it 'dispatches the command to show the `find and replace` dialog', ->
         fileView = findFileContainingText(treeView.roots[0], 'a-file.txt')
         fileView.click()
         atom.commands.dispatch(treeView.element, 'tree-view:search-selected-entry')
-        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('find-and-replace:show');
+        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('find-and-replace:show')
 
     describe 'when a directory is selected', ->
       it 'dispatches the command to show the `find in project` dialog', ->
         dirView = findDirectoryContainingText(treeView.roots[0], 'a-directory')
         dirView.click()
         atom.commands.dispatch(treeView.element, 'tree-view:search-selected-entry')
-        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('project-find:show-in-current-directory');
+        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('project-find:show-in-current-directory')
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2946,6 +2946,8 @@ describe "TreeView", ->
 
       expect(parseInt(treeView.element.style.width)).toBe(150)
 
+
+
   describe "selecting items", ->
     [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []
 
@@ -3113,6 +3115,34 @@ describe "TreeView", ->
               expect(fileView3).toHaveClass('selected')
               expect(treeView.list).toHaveClass('full-menu')
               expect(treeView.list).not.toHaveClass('multi-select')
+
+  describe "search based on selected items", ->
+    [rootDirPath] = []
+
+    beforeEach ->
+      rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
+      dirPath = path.join(rootDirPath, 'a-directory')
+      filePath = path.join(rootDirPath, "a-file.txt")
+
+      fs.makeTreeSync(dirPath)
+      fs.writeFileSync(filePath, "doesn't matter")
+
+      atom.project.setPaths([rootDirPath])
+      spyOn(atom.commands, 'dispatch').andCallThrough();
+
+    describe 'when a file is selected', ->
+      it 'dispatches the command to show the `find and replace` dialog', ->
+        fileView = findFileContainingText(treeView.roots[0], 'a-file.txt')
+        fileView.click()
+        atom.commands.dispatch(treeView.element, 'tree-view:search-selected-entry')
+        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('find-and-replace:show');
+
+    describe 'when a directory is selected', ->
+      it 'dispatches the command to show the `find in project` dialog', ->
+        dirView = findDirectoryContainingText(treeView.roots[0], 'a-directory')
+        dirView.click()
+        atom.commands.dispatch(treeView.element, 'tree-view:search-selected-entry')
+        expect(atom.commands.dispatch.calls[1].args[1]).toEqual('project-find:show-in-current-directory');
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2946,8 +2946,6 @@ describe "TreeView", ->
 
       expect(parseInt(treeView.element.style.width)).toBe(150)
 
-
-
   describe "selecting items", ->
     [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []
 


### PR DESCRIPTION
for issue #407, still trying to figure out how to test this, any tips?

I originally thought I could target a detailed selector with a keymap: `.tree-view li.directory,` but I couldn't get that to work. I need to dive a bit deeper into `atom-keymap` to figure out why.
