### PR TITLE
(WIP) Open file in pending state on single click

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -113,7 +113,7 @@ class TreeView extends View
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
-     'tree-view:open-selected-entry': => @openSelectedEntry(true)
+     'tree-view:open-selected-entry': => @openSelectedEntry()
      'tree-view:open-selected-entry-right': => @openSelectedEntryRight()
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
      'tree-view:open-selected-entry-up': => @openSelectedEntryUp()
@@ -204,11 +204,11 @@ class TreeView extends View
     switch e.originalEvent?.detail ? 1
       when 1
         @selectEntry(entry)
-        @openSelectedEntry(false) if entry instanceof FileView
+        @openSelectedEntry(pending: true) if entry instanceof FileView
         entry.toggleExpansion(isRecursive) if entry instanceof DirectoryView
       when 2
         if entry instanceof FileView
-          @unfocus()
+          atom.workspace.getActivePane().activateItem(atom.workspace.getActivePaneItem())
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 
@@ -375,12 +375,12 @@ class TreeView extends View
       directory.collapse(isRecursive)
       @selectEntry(directory)
 
-  openSelectedEntry: (activatePane) ->
+  openSelectedEntry: (options) ->
     selectedEntry = @selectedEntry()
     if selectedEntry instanceof DirectoryView
       selectedEntry.toggleExpansion()
     else if selectedEntry instanceof FileView
-      atom.workspace.open(selectedEntry.getPath(), {activatePane})
+      atom.workspace.open(selectedEntry.getPath(), options)
 
   openSelectedEntrySplit: (orientation, side) ->
     selectedEntry = @selectedEntry()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -530,31 +530,7 @@ describe "TreeView", ->
     beforeEach ->
       jasmine.attachToDOM(workspaceElement)
 
-    it "selects the files and opens it in the active editor, without changing focus", ->
-      treeView.focus()
-
-      waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-
-      runs ->
-        expect(sampleJs).toHaveClass 'selected'
-        expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-        expect(treeView.list).toHaveFocus()
-
-      waitsForFileToOpen ->
-        sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
-
-      runs ->
-        expect(sampleTxt).toHaveClass 'selected'
-        expect(treeView.find('.selected').length).toBe 1
-        expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-        expect(treeView.list).toHaveFocus()
-
-  describe "when a file is double-clicked", ->
-    beforeEach ->
-      jasmine.attachToDOM(workspaceElement)
-
-    it "selects the file and opens it in the active editor on the first click, then changes focus to the active editor on the second", ->
+    it "selects the file and opens it in the active editor in pending state and changes focus to file", ->
       treeView.focus()
 
       waitsForFileToOpen ->
@@ -564,9 +540,42 @@ describe "TreeView", ->
         expect(sampleJs).toHaveClass 'selected'
         item = atom.workspace.getActivePaneItem()
         expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+        expect(atom.views.getView(item)).toHaveFocus()
+        expect(atom.workspace.getActivePane().isActiveItemPending()).toBe true
+
+      waitsForFileToOpen ->
+        sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+
+      runs ->
+        expect(sampleTxt).toHaveClass 'selected'
+        expect(treeView.find('.selected').length).toBe 1
+        item = atom.workspace.getActivePaneItem()
+        expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
+        expect(atom.views.getView(item)).toHaveFocus()
+        expect(atom.workspace.getActivePane().isActiveItemPending()).toBe true
+
+  describe "when a file is double-clicked", ->
+    beforeEach ->
+      jasmine.attachToDOM(workspaceElement)
+
+    it "selects the file and opens it in the active editor as pending and changes focus on the first click, then confirms pending item on the second click", ->
+      treeView.focus()
+
+      waitsForFileToOpen ->
+        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+
+      runs ->
+        expect(sampleJs).toHaveClass 'selected'
+        item = atom.workspace.getActivePaneItem()
+        expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+        expect(atom.views.getView(item)).toHaveFocus()
+        expect(atom.workspace.getActivePane().isActiveItemPending()).toBe true
 
         sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+        item = atom.workspace.getActivePaneItem()
+        expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
         expect(atom.views.getView(item)).toHaveFocus()
+        expect(atom.workspace.getActivePane().isActiveItemPending()).toBe false
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->


### PR DESCRIPTION
Work in progress, just starting a conversation here.

See corresponding pull requests for core and tree-view packages:
- [atom core #10171](https://github.com/atom/atom/pull/10171)
- [tabs #244](https://github.com/atom/tabs/pull/244)

Updated tests for single and double clicking a file. Need to troubleshoot failing test.