### PR TITLE
Open file in pending state on single click

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -211,6 +211,7 @@ class TreeView extends View
       when 2
         if entry instanceof FileView
           atom.workspace.getActivePaneItem().terminatePendingState?()
+          @unfocus()
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -113,7 +113,7 @@ class TreeView extends View
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
-     'tree-view:open-selected-entry': => @openSelectedEntry(true)
+     'tree-view:open-selected-entry': => @openSelectedEntry()
      'tree-view:open-selected-entry-right': => @openSelectedEntryRight()
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
      'tree-view:open-selected-entry-up': => @openSelectedEntryUp()
@@ -204,11 +204,13 @@ class TreeView extends View
     switch e.originalEvent?.detail ? 1
       when 1
         @selectEntry(entry)
-        @openSelectedEntry(false) if entry instanceof FileView
-        entry.toggleExpansion(isRecursive) if entry instanceof DirectoryView
+        if entry instanceof FileView
+          @openSelectedEntry(pending: true)
+        else if entry instanceof DirectoryView
+          entry.toggleExpansion(isRecursive)
       when 2
         if entry instanceof FileView
-          @unfocus()
+          atom.workspace.getActivePaneItem().confirmPendingState?()
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 
@@ -375,12 +377,12 @@ class TreeView extends View
       directory.collapse(isRecursive)
       @selectEntry(directory)
 
-  openSelectedEntry: (activatePane) ->
+  openSelectedEntry: (options) ->
     selectedEntry = @selectedEntry()
     if selectedEntry instanceof DirectoryView
       selectedEntry.toggleExpansion()
     else if selectedEntry instanceof FileView
-      atom.workspace.open(selectedEntry.getPath(), {activatePane})
+      atom.workspace.open(selectedEntry.getPath(), options)
 
   openSelectedEntrySplit: (orientation, side) ->
     selectedEntry = @selectedEntry()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -210,7 +210,7 @@ class TreeView extends View
           entry.toggleExpansion(isRecursive)
       when 2
         if entry instanceof FileView
-          atom.workspace.getActivePaneItem().confirmPendingState?()
+          atom.workspace.getActivePaneItem().terminatePendingState?()
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -47,8 +47,9 @@ describe "TreeView", ->
       expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
 
   afterEach ->
-    waits 10 # The async nature of specs causes uncaught exceptions, so wait a little bit before we cleanup
+    waits 50 # The async nature of specs causes uncaught exceptions, so wait a little bit before we cleanup
     temp.cleanup()
+
 
   describe ".initialize(project)", ->
     it "renders the root directories of the project and their contents alphabetically with subdirectories first, in a collapsed state", ->
@@ -527,86 +528,87 @@ describe "TreeView", ->
       sampleJs.mousedown()
       expect(sampleJs).toHaveClass 'selected'
 
-  describe "when a file is single-clicked", ->
+  describe "when files are clicked", ->
     beforeEach ->
       jasmine.attachToDOM(workspaceElement)
 
-    it "selects the file and opens it in the active editor in pending state (replacing other files open in pending state), and changes focus to the file", ->
-      treeView.focus()
+    afterEach ->
+      waits 10 # The click specs cause uncaught exceptions because of their async nature, so wait a little bit before we cleanup
 
-      waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+    describe "when a file is single-clicked", ->
 
-      runs ->
-        expect(sampleJs).toHaveClass 'selected'
-        activePaneItem = atom.workspace.getActivePaneItem()
-        expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-        expect(atom.views.getView(activePaneItem)).toHaveFocus()
-        expect(activePaneItem.isPending()).toBe true
-        expect(atom.workspace.getActivePane().getItems().length).toBe 1
+      it "selects the file and opens it in the active editor in pending state (replacing other files open in pending state), and changes focus to the file", ->
+        treeView.focus()
 
-      waitsForFileToOpen ->
-        sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+        waitsForFileToOpen ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
 
-      runs ->
-        expect(sampleTxt).toHaveClass 'selected'
-        expect(treeView.find('.selected').length).toBe 1
-        activePaneItem = atom.workspace.getActivePaneItem()
-        expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-        expect(atom.views.getView(activePaneItem)).toHaveFocus()
-        expect(activePaneItem.isPending()).toBe true
-        expect(atom.workspace.getActivePane().getItems().length).toBe 1
+        runs ->
+          expect(sampleJs).toHaveClass 'selected'
+          activePaneItem = atom.workspace.getActivePaneItem()
+          expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+          expect(atom.views.getView(activePaneItem)).toHaveFocus()
+          expect(activePaneItem.isPending()).toBe true
+          expect(atom.workspace.getActivePane().getItems().length).toBe 1
 
-  describe "when a file is double-clicked", ->
-    beforeEach ->
-      jasmine.attachToDOM(workspaceElement)
+        waitsForFileToOpen ->
+          sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
 
-    it "selects the file and opens it in the active editor on the first click in pending state, then terminates pending state on the second", ->
-      treeView.focus()
+        runs ->
+          expect(sampleTxt).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+          activePaneItem = atom.workspace.getActivePaneItem()
+          expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
+          expect(atom.views.getView(activePaneItem)).toHaveFocus()
+          expect(activePaneItem.isPending()).toBe true
+          expect(atom.workspace.getActivePane().getItems().length).toBe 1
 
-      waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+    describe "when a file is double-clicked", ->
 
-      runs ->
-        expect(sampleJs).toHaveClass 'selected'
-        item = atom.workspace.getActivePaneItem()
-        expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-        expect(atom.views.getView(item)).toHaveFocus()
-        expect(item.isPending()).toBe true
+      it "selects the file and opens it in the active editor on the first click in pending state, then terminates pending state on the second", ->
+        treeView.focus()
 
-        sampleJs.trigger clickEvent(originalEvent: {detail: 2})
-        expect(atom.views.getView(item)).toHaveFocus()
-        expect(item.isPending()).toBe false
+        waitsForFileToOpen ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
 
-        # single-clicking again does not change the status to pending
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-        expect(item.isPending()).toBe false
+        runs ->
+          expect(sampleJs).toHaveClass 'selected'
+          item = atom.workspace.getActivePaneItem()
+          expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+          expect(atom.views.getView(item)).toHaveFocus()
+          expect(item.isPending()).toBe true
 
-  describe "when a file is single-clicked, then double-clicked", ->
-    beforeEach ->
-      jasmine.attachToDOM(workspaceElement)
+          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          expect(atom.views.getView(item)).toHaveFocus()
+          expect(item.isPending()).toBe false
 
-    it "selects the file and opens it in the active editor on the single-click in pending state, then terminates pending state on the double-click", ->
-      treeView.focus()
+          # single-clicking again does not change the status to pending
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          expect(item.isPending()).toBe false
 
-      waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+    describe "when a file is single-clicked, then double-clicked", ->
 
-      runs ->
-        expect(sampleJs).toHaveClass 'selected'
-        item = atom.workspace.getActivePaneItem()
-        expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-        expect(atom.views.getView(item)).toHaveFocus()
-        expect(item.isPending()).toBe true
+      it "selects the file and opens it in the active editor on the single-click in pending state, then terminates pending state on the double-click", ->
+        treeView.focus()
 
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-        sampleJs.trigger clickEvent(originalEvent: {detail: 2})
-        expect(atom.views.getView(item)).toHaveFocus()
-        expect(item.isPending()).toBe false
+        waitsForFileToOpen ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
 
-        sampleJs.trigger 'dblclick'
-        expect(atom.views.getView(item)).toHaveFocus()
-        expect(item.isPending()).toBe false
+        runs ->
+          expect(sampleJs).toHaveClass 'selected'
+          item = atom.workspace.getActivePaneItem()
+          expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+          expect(atom.views.getView(item)).toHaveFocus()
+          expect(item.isPending()).toBe true
+
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          expect(atom.views.getView(item)).toHaveFocus()
+          expect(item.isPending()).toBe false
+
+          sampleJs.trigger 'dblclick'
+          expect(atom.views.getView(item)).toHaveFocus()
+          expect(item.isPending()).toBe false
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -47,6 +47,7 @@ describe "TreeView", ->
       expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
 
   afterEach ->
+    waits 10 # The async nature of specs causes uncaught exceptions, so wait a little bit before we cleanup
     temp.cleanup()
 
   describe ".initialize(project)", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -617,13 +617,13 @@ describe "TreeView", ->
   describe "when a directory is double-clicked", ->
     it "toggles the directory expansion state and does not change the focus to the editor", ->
       jasmine.attachToDOM(workspaceElement)
-      treeView.focus()
 
       subdir = null
       waitsForFileToOpen ->
         sampleJs.trigger clickEvent(originalEvent: {detail: 1})
 
       runs ->
+        treeView.focus()
         subdir = root1.find('.directory:first')
         subdir.trigger clickEvent(originalEvent: {detail: 1})
         expect(subdir).toHaveClass 'selected'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -530,7 +530,7 @@ describe "TreeView", ->
     beforeEach ->
       jasmine.attachToDOM(workspaceElement)
 
-    it "selects the files and opens it in the active editor, without changing focus", ->
+    it "selects the files and opens it in the active editor, and changes focus to the file", ->
       treeView.focus()
 
       waitsForFileToOpen ->
@@ -538,8 +538,9 @@ describe "TreeView", ->
 
       runs ->
         expect(sampleJs).toHaveClass 'selected'
-        expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-        expect(treeView.list).toHaveFocus()
+        activePaneItem = atom.workspace.getActivePaneItem()
+        expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
+        expect(atom.views.getView(activePaneItem)).toHaveFocus()
 
       waitsForFileToOpen ->
         sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
@@ -547,8 +548,9 @@ describe "TreeView", ->
       runs ->
         expect(sampleTxt).toHaveClass 'selected'
         expect(treeView.find('.selected').length).toBe 1
-        expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-        expect(treeView.list).toHaveFocus()
+        activePaneItem = atom.workspace.getActivePaneItem()
+        expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
+        expect(atom.views.getView(activePaneItem)).toHaveFocus()
 
   describe "when a file is double-clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -47,9 +47,7 @@ describe "TreeView", ->
       expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
 
   afterEach ->
-    waits 50 # The async nature of specs causes uncaught exceptions, so wait a little bit before we cleanup
     temp.cleanup()
-
 
   describe ".initialize(project)", ->
     it "renders the root directories of the project and their contents alphabetically with subdirectories first, in a collapsed state", ->


### PR DESCRIPTION
Single-clicking opens a file in pending state and double-clicking opens a file regularly (in a non-pending state).

See corresponding changes in [atom/atom/pull/10178](https://github.com/atom/atom/pull/10178)
Addresses atom/atom/issues/9165