### PR TITLE
Make 'Move in trash' more verbose on failure, add a note for Linux

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -509,7 +509,7 @@ class TreeView extends View
     else if activePath = @getActivePath()
       selectedPaths = [activePath]
 
-    return unless selectedPaths
+    return unless selectedPaths and selectedPaths.length > 0
 
     for root in @roots
       if root.getPath() in selectedPaths
@@ -524,7 +524,10 @@ class TreeView extends View
       buttons:
         "Move to Trash": ->
           for selectedPath in selectedPaths
-            shell.moveItemToTrash(selectedPath)
+            if not shell.moveItemToTrash(selectedPath)
+              atom.notifications.addError "The file couldn't be removed#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
+                detail: "Error while moving '#{selectedPath}' to trash"
+                dismissable: true
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)
         "Cancel": null

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -523,13 +523,16 @@ class TreeView extends View
       detailedMessage: "You are deleting:\n#{selectedPaths.join('\n')}"
       buttons:
         "Move to Trash": ->
+          failedDeletions = []
           for selectedPath in selectedPaths
             if not shell.moveItemToTrash(selectedPath)
-              atom.notifications.addError "The file couldn't be removed#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
-                detail: "Error while moving '#{selectedPath}' to trash"
-                dismissable: true
+              failedDeletions.push "#{selectedPath}"
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)
+          if failedDeletions.length > 0
+            atom.notifications.addError "The following #{if failedDeletions.length > 1 then 'files' else 'file'} couldn't be moved to trash#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
+              detail: "#{failedDeletions.join('\n')}"
+              dismissable: true
         "Cancel": null
 
   # Public: Copy the path of the selected entry element.

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2028,9 +2028,8 @@ describe "TreeView", ->
           expect(notificationsNumber).toBe 1
           if notificationsNumber is 1
             notification = atom.notifications.getNotifications()[0]
-            expect(notification.getMessage()).toContain 'The file couldn\'t be removed'
-            expect(notification.getDetail()).toContain 'Error while moving'
-            expect(notification.getDetail()).toContain 'to trash'
+            expect(notification.getMessage()).toContain 'The following file couldn\'t be moved to trash'
+            expect(notification.getDetail()).toContain 'test-file.txt'
 
       it "does nothing when no file is selected", ->
         atom.notifications.clear()


### PR DESCRIPTION
Add an alert to warn the user when a file couldn't be moved to trash correctly instead of silently failing.

Add a note for Linux to ask the user to check if 'gvfs-trash' is installed (the command-line utility used by electron to move files to trash).

![screenshot_2016-01-12_11-31-43](https://cloud.githubusercontent.com/assets/7120871/12261242/1f3d5088-b920-11e5-85f4-d84102da032a.png)
