### PR TITLE
Add package level ignoredNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ or delete files and folders.
 
 ![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)
 
+This package uses both the `core.ignoredNames` and `tree-view.ignoredNames`
+config settings to filter out files and folders that will not be shown.
+Both of those config settings are interpreted as arrays of
+[minimatch](https://github.com/isaacs/minimatch) glob patterns.
+
 ## API
 
 The Tree View displays icons next to files. These icons are customizable by installing a package that provides an `atom.file-icons` service.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,6 +19,10 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Don\'t show items matched by the `Ignored Names` core config setting.'
+    ignoredNames:
+      type: 'array'
+      default: []
+      description: 'List of string glob patterns. Files and directories matching these patterns will be ignored. This list is merged with the list defined by the core `Ignored Names` config setting, if the `Hide Ignored Names` setting is on. Example: `.git, ._*, Thumbs.db`.'
     showOnRightSide:
       type: 'boolean'
       default: false

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -143,6 +143,8 @@ class TreeView extends View
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideIgnoredNames', =>
       @updateRoots()
+    @disposables.add atom.config.onDidChange 'tree-view.ignoredNames', =>
+      @updateRoots() if atom.config.get('tree-view.hideIgnoredNames')
     @disposables.add atom.config.onDidChange 'core.ignoredNames', =>
       @updateRoots() if atom.config.get('tree-view.hideIgnoredNames')
     @disposables.add atom.config.onDidChange 'tree-view.showOnRightSide', ({newValue}) =>
@@ -241,8 +243,9 @@ class TreeView extends View
 
     Minimatch ?= require('minimatch').Minimatch
 
-    ignoredNames = atom.config.get('core.ignoredNames') ? []
-    ignoredNames = [ignoredNames] if typeof ignoredNames is 'string'
+    ignoredNames = atom.config.get('tree-view.ignoredNames') ? []
+    ignoredNames = ignoredNames.concat(atom.config.get('core.ignoredNames') ? [])
+
     for ignoredName in ignoredNames when ignoredName
       try
         @ignoredPatterns.push(new Minimatch(ignoredName, matchBase: true, dot: true))

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2124,6 +2124,11 @@ describe "TreeView", ->
       expect(treeView.find('.directory .name:contains(test.js)').length).toBe 1
       expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 1
 
+    it "ignores paths that match entries in config.tree-view.ignoredNames"
+      atom.config.set("tree-view.ignoredNames", ["sample.js", "*.txt"])
+      expect(treeView.find('.directory .name:contains(sample.js)').length).toBe 0
+      expect(treeView.find('.directory .name:contains(test.txt)').length).toBe 0
+
   describe "the squashedDirectoryName config option", ->
     beforeEach ->
       rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))


### PR DESCRIPTION
See #128
This PR adds a package level ignoredNames configuration setting which gets merged in with the core ignoredNames setting, akin to what’s done in the fuzzy finder package.