### PR TITLE
(WIP) Open file in pending state on right arrow

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -57,7 +57,6 @@
   'ctrl-9': 'tree-view:open-selected-entry-in-pane-9'
 
 '.tree-view':
-  'right': 'tree-view:expand-directory'
   'ctrl-]': 'tree-view:expand-directory'
   'l': 'tree-view:expand-directory'
   'left': 'tree-view:collapse-directory'
@@ -81,6 +80,12 @@
   'i': 'tree-view:toggle-vcs-ignored-files'
   'home': 'core:move-to-top'
   'end': 'core:move-to-bottom'
+
+'.tree-view .directory':
+  'right': 'tree-view:expand-directory'
+
+'.tree-view .file':
+  'right': 'tree-view:open-pending-file'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -110,6 +110,7 @@ class TreeView extends View
      'core:move-to-top': => @scrollToTop()
      'core:move-to-bottom': => @scrollToBottom()
      'tree-view:expand-directory': => @expandDirectory()
+     'tree-view:open-pending-file': => @openSelectedEntry(pending: true)
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)


### PR DESCRIPTION
Currently the key-bindings are funky. I suspect I don't have the selectors quite right in `tree-view.cson`. Help figuring out what to do differently would be much appreciated :smile: 

Changed this:
```javascript
'.tree-view':
    'right': 'tree-view:expand-directory'
```
to this:

```javascript
'.tree-view .directory':
    'right': 'tree-view:expand-directory'

'.tree-view .file':
    'right': 'tree-view:open-pending-file'
```

Original key binding resolving:
<img width="839" alt="screen shot 2016-01-24 at 10 40 45 pm" src="https://cloud.githubusercontent.com/assets/7910250/12543428/a19e3aa8-c2ec-11e5-931a-8220c813403d.png">
<img width="836" alt="screen shot 2016-01-24 at 10 41 11 pm" src="https://cloud.githubusercontent.com/assets/7910250/12543430/a6187c38-c2ec-11e5-8e3f-f494eec557de.png">

New key binding resolving (note that both `.tree-view .directory` and `.tree-view .file` show up in both cases...):
<img width="840" alt="screen shot 2016-01-24 at 10 38 49 pm" src="https://cloud.githubusercontent.com/assets/7910250/12543433/b05acbd8-c2ec-11e5-92fd-fc7469a4de19.png">
<img width="840" alt="screen shot 2016-01-24 at 10 39 16 pm" src="https://cloud.githubusercontent.com/assets/7910250/12543434/b3a47e06-c2ec-11e5-84b4-83257f4236b6.png">
