### PR TITLE
feat: add two new reveal options for the tree-view

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -27,6 +27,14 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'When listing directory items, list subdirectories before listing files.'
+    focusOnReveal:
+      type: 'boolean'
+      default: true
+      description: 'When a file is revealed in the sidebar, switch the focus to the sidebar'
+    autoReveal:
+      type: 'boolean'
+      default: false
+      description: 'Reveal files as they are opened or switched-to in the editor panes'
 
   treeView: null
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -137,6 +137,9 @@ class TreeView extends View
 
     @disposables.add atom.workspace.onDidChangeActivePaneItem =>
       @selectActiveFile()
+      if atom.config.get('tree-view.autoReveal')
+        @revealActiveFile()
+
     @disposables.add atom.project.onDidChangePaths =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>
@@ -293,7 +296,8 @@ class TreeView extends View
     return if _.isEmpty(atom.project.getPaths())
 
     @attach()
-    @focus()
+    if atom.config.get('tree-view.focusOnReveal')
+      @focus()
 
     return unless activeFilePath = @getActivePath()
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2663,6 +2663,78 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
+  fdescribe "the focusOnReveal config option", ->
+    beforeEach ->
+      treeView.detach()
+      spyOn(treeView, 'focus')
+
+    it "switches focus to sidebar on changing files when focusOnReveal option is set", ->
+      atom.config.set "tree-view.focusOnReveal", true
+
+      waitsForPromise ->
+        atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).toHaveBeenCalled()
+
+      waitsForPromise ->
+        treeView.focus.reset()
+        atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).toHaveBeenCalled()
+
+    it "does not switch focus to sidebar on changing files when focusOnReveal option is unset", ->
+      atom.config.set "tree-view.focusOnReveal", false
+
+      waitsForPromise ->
+        atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).not.toHaveBeenCalled()
+
+      waitsForPromise ->
+        treeView.focus.reset()
+        atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).not.toHaveBeenCalled()
+
+  describe "the autoReveal config option", ->
+    beforeEach ->
+      atom.config.set "tree-view.autoReveal", true
+
+    describe "when the item has a path", ->
+      it "selects the entry with that path in the tree view if it is visible", ->
+        waitsForFileToOpen ->
+          sampleJs.click()
+
+        waitsForPromise ->
+          atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
+
+        runs ->
+          expect(sampleTxt).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
+      it "selects the entry with that path in the tree view if it is not visible", ->
+        waitsForPromise ->
+          atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
+
+        runs ->
+          dirView = root1.find('.directory:contains(dir1)')
+          fileView = root1.find('.file:contains(sub-file1)')
+          expect(dirView).not.toHaveClass 'selected'
+          expect(fileView).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
       atom.notifications.clear()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2663,7 +2663,7 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
-  fdescribe "the focusOnReveal config option", ->
+  describe "the focusOnReveal config option", ->
     beforeEach ->
       treeView.detach()
       spyOn(treeView, 'focus')


### PR DESCRIPTION
1. AutoReveal - control the revealing of files automatically as they
    are switched in the panes.
2. FocusOnReveal - control whether the focus on the editor panes is
    transferred to the tree-view pane on calling 'reveal-active-file'

This adds a small behaviour which is more in line with what
SublimeText offers. This PR also addresses other open issues/PRs
like: #247 #459 #188