### PR TITLE
Terminate pending state after fulfillment of opened item promise

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -205,12 +205,12 @@ class TreeView extends View
       when 1
         @selectEntry(entry)
         if entry instanceof FileView
-          atom.workspace.open(entry.getPath(), pending: true)
+          @openedItem = atom.workspace.open(entry.getPath(), pending: true)
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
         if entry instanceof FileView
-          atom.workspace.getActivePaneItem().terminatePendingState?()
+          @openedItem.then((item) -> item.terminatePendingState?())
           @unfocus()
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -588,12 +588,14 @@ describe "TreeView", ->
 
         it "terminates pending state on second click", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
-          expect(activePaneItem.isPending()).toBe false
+          waitsFor ->
+            activePaneItem.isPending() is false
 
         it "does not create pending state on subsequent single click", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          expect(activePaneItem.isPending()).toBe false
+          waitsFor ->
+            activePaneItem.isPending() is false
 
       describe "when a file is single-clicked, then double-clicked", ->
         activePaneItem = null
@@ -611,15 +613,12 @@ describe "TreeView", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
           expect(activePaneItem.isPending()).toBe true
 
-        it "terminates pending state on the double-click and have focus", ->
+        it "terminates pending state on the double-click and focuses file", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 1})
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           expect(atom.views.getView(activePaneItem)).toHaveFocus()
-          expect(activePaneItem.isPending()).toBe false
-
-          sampleJs.trigger 'dblclick'
-          expect(atom.views.getView(activePaneItem)).toHaveFocus()
-          expect(activePaneItem.isPending()).toBe false
+          waitsFor ->
+            activePaneItem.isPending() is false
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->


### PR DESCRIPTION
Fixes https://github.com/atom/tree-view/issues/724. 

Thanks @Arcanemagus and @50Wliu for pointing out the problem!

Here's what was happening when you double-clicked a file:
1st click - file is opened asynchronously and once it's opened it is set to be the active pane item
2nd click - active pane item is grabbed, but since the pane was empty and the new file hasn't been set to active yet, we get `undefined` and throw an error when we try to invoke `terminatePendingState`

Thanks to @maxbrunsfeld suggestion I was able to recreate this locally by using setTimeout to stall the opening process. The fix involves storing the promise returned from `atom.workspace.open` and terminating the pending state only once that promise is fulfilled. 

/cc @maxbrunsfeld 