### PR TITLE
Focus tree-view if name of active file is clicked

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -205,13 +205,17 @@ class TreeView extends View
       when 1
         @selectEntry(entry)
         if entry instanceof FileView
-          @openedItem = atom.workspace.open(entry.getPath(), pending: true)
+          if entry.getPath() is atom.workspace.getActivePaneItem()?.getPath?()
+            @focus()
+          else
+            @openedItem = atom.workspace.open(entry.getPath(), pending: true)
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
         if entry instanceof FileView
           @openedItem.then((item) -> item.terminatePendingState?())
-          @unfocus()
+          unless entry.getPath() is atom.workspace.getActivePaneItem()?.getPath?()
+            @unfocus()
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -614,11 +614,17 @@ describe "TreeView", ->
           expect(activePaneItem.isPending()).toBe true
 
         it "terminates pending state on the double-click and focuses file", ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           expect(atom.views.getView(activePaneItem)).toHaveFocus()
           waitsFor ->
             activePaneItem.isPending() is false
+
+        it "keeps focus on tree-view if the file is the active pane item", ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          expect(treeView).toHaveFocus()
+
+          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          expect(treeView).toHaveFocus()
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->


### PR DESCRIPTION
Fixes https://github.com/atom/tree-view/issues/740

With https://github.com/atom/atom/pull/10178, single and double-clicking a file focuses the opened pane item so that you can jump in and start making changes or navigating through the file. 

To click and select a file in the tree-view and keep the tree-view focused, you can now achieve this if the file you've clicked is already open as the active pane item. 

![tree-view-focus2](https://cloud.githubusercontent.com/assets/7910250/13132264/264edb92-d5a6-11e5-95eb-611bc564ccc6.gif)
