### PR TITLE
Don't close dialog unless Atom has focus

### DIFF
--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -14,7 +14,7 @@ class Dialog extends View
     atom.commands.add @element,
       'core:confirm': => @onConfirm(@miniEditor.getText())
       'core:cancel': => @cancel()
-    @miniEditor.on 'blur', => @close()
+    @miniEditor.on 'blur', => @close() if document.hasFocus()
     @miniEditor.getModel().onDidChange => @showError()
     @miniEditor.getModel().setText(initialPath)
 


### PR DESCRIPTION
See atom/atom#1918 for context.  Now switching windows or activating the dev tools will not cause the dialog (new file/folder, duplicate, rename, etc.) to disappear.