### PR TITLE
Issue #566 - Using configuration parameter to allowDragAndDrop of files and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ This solution was not merged due to a decision to limit the number of configurat
 I'm leaving the solution here for others.
 
 Changes to files:
+
 package.json            - Added **allowDragAndDrop** parameter.
+
 tree-view.coffee        - Added one-liner to refresh tree-view on a change to **allowDragAndDrop**.
+
 directory-view.coffee   - Added one-liner to set HTMLElement **draggable** attribute with **allowDragAndDrop** value.
+
 file-view.coffee        - Added one-liner to set HTMLElement **draggable** attribute with **allowDragAndDrop** value.
+
 tree-view-spec.coffee   - Added tests.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 Explore and open files in the current project.
 
-Press <kbd>ctrl-\\</kbd> or <kbd>cmd-\\</kbd> to open/close the Tree view and <kbd>alt-\\</kbd> or <kbd>ctrl-0</kbd> to focus it.
+This fork successfully blocks dragging and dropping of files using a configuration parameter. See issue #566.
+This solution was not merged due to a decision to limit the number of configuration parameters, as well as a desire to solve in a global manner.
 
-When the Tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>, <kbd>m</kbd>, or <kbd>delete</kbd> to add, move
-or delete files and folders.
+I'm leaving the solution here for others.
 
-![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)
-
-## API
-
-The Tree View displays icons next to files. These icons are customizable by installing a package that provides an `atom.file-icons` service.
-
-The `atom.file-icons` service must provide the following methods:
-
-* `iconClassForPath(path)` - Returns a CSS class name to add to the file view
-* `onWillDeactivate` - An event that lets the tree view return to its default icon strategy
+Changes to files:
+package.json            - Added **allowDragAndDrop** parameter.
+tree-view.coffee        - Added one-liner to refresh tree-view on a change to **allowDragAndDrop**.
+directory-view.coffee   - Added one-liner to set HTMLElement **draggable** attribute with **allowDragAndDrop** value.
+file-view.coffee        - Added one-liner to set HTMLElement **draggable** attribute with **allowDragAndDrop** value.
+tree-view-spec.coffee   - Added tests.

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -50,7 +50,7 @@ class DirectoryView extends HTMLElement
     if @directory.isRoot
       @classList.add('project-root')
     else
-      @draggable = true
+      @draggable = atom.config.get('tree-view.allowDragAndDrop')
       @subscriptions.add @directory.onDidStatusChange => @updateStatus()
       @updateStatus()
 

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -7,7 +7,7 @@ class FileView extends HTMLElement
     @subscriptions = new CompositeDisposable()
     @subscriptions.add @file.onDidDestroy => @subscriptions.dispose()
 
-    @draggable = true
+    @draggable = atom.config.get('tree-view.allowDragAndDrop')
 
     @classList.add('file', 'entry', 'list-item')
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -96,11 +96,22 @@ class TreeView extends View
     @on 'mousedown', '.entry', (e) =>
       @onMouseDown(e)
     @on 'mousedown', '.tree-view-resize-handle', (e) => @resizeStarted(e)
-    @on 'dragstart', '.entry', (e) => @onDragStart(e)
-    @on 'dragenter', '.entry.directory > .header', (e) => @onDragEnter(e)
-    @on 'dragleave', '.entry.directory > .header', (e) => @onDragLeave(e)
-    @on 'dragover', '.entry', (e) => @onDragOver(e)
-    @on 'drop', '.entry', (e) => @onDrop(e)
+    @on 'dragstart', '.entry', (e) =>
+      if atom.config.get('tree-view.allowDragAndDrop')
+        @onDragStart(e)
+
+    @on 'dragenter', '.entry.directory > .header', (e) =>
+      if atom.config.get('tree-view.allowDragAndDrop')
+        @onDragEnter(e)
+    @on 'dragleave', '.entry.directory > .header', (e) =>
+      if atom.config.get('tree-view.allowDragAndDrop')
+        @onDragLeave(e)
+    @on 'dragover', '.entry', (e) =>
+      if atom.config.get('tree-view.allowDragAndDrop')
+        @onDragOver(e)
+    @on 'drop', '.entry', (e) =>
+      if atom.config.get('tree-view.allowDragAndDrop')
+        @onDrop(e)
 
     atom.commands.add @element,
      'core:move-up': @moveUp.bind(this)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -97,20 +97,14 @@ class TreeView extends View
       @onMouseDown(e)
     @on 'mousedown', '.tree-view-resize-handle', (e) => @resizeStarted(e)
     @on 'dragstart', '.entry', (e) =>
-      if atom.config.get('tree-view.allowDragAndDrop')
         @onDragStart(e)
-
     @on 'dragenter', '.entry.directory > .header', (e) =>
-      if atom.config.get('tree-view.allowDragAndDrop')
         @onDragEnter(e)
     @on 'dragleave', '.entry.directory > .header', (e) =>
-      if atom.config.get('tree-view.allowDragAndDrop')
         @onDragLeave(e)
     @on 'dragover', '.entry', (e) =>
-      if atom.config.get('tree-view.allowDragAndDrop')
         @onDragOver(e)
     @on 'drop', '.entry', (e) =>
-      if atom.config.get('tree-view.allowDragAndDrop')
         @onDrop(e)
 
     atom.commands.add @element,
@@ -153,6 +147,8 @@ class TreeView extends View
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideIgnoredNames', =>
+      @updateRoots()
+    @disposables.add atom.config.onDidChange 'tree-view.allowDragAndDrop', =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'core.ignoredNames', =>
       @updateRoots() if atom.config.get('tree-view.hideIgnoredNames')

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "type": "boolean",
       "default": true,
       "description": "When listing directory items, list subdirectories before listing files."
+    },
+    "allowDragAndDrop":{
+      "type": "boolean",
+      "default": true,
+      "description": "Allow drag and drop of folders and files."
     }
   }
 }


### PR DESCRIPTION
This is my very first Javascript as well as OpenSource Pull request.  I think I've done OK, but if not please be kind.  

**package.json:** Added allowDragAndDrop attribute with a default value of **true** which ensures backward compatibility.

**directory-view.coffee** and **file-view.coffee**:Simple one-liner to get config item and set draggable attribute in DOM structure.

**tree-view.coffee**: One-liner to ensure that changes to the config attribute are propagated to the tree-view immediately.  Without this line, the user would have to exit the app and restart.

**tree-view-spec.coffee**: Had the hardest time figuring this out.  I seemed to have both closure issues as well as inter-process issues with changing of the config item; but really not sure.  In the end, I've got both allowDragAndDrop = true as well as false tests.
