### PR TITLE
feat(option): added an option to control if sidebar gets focus on reveal

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -297,7 +297,7 @@ class TreeView extends View
     return if _.isEmpty(atom.project.getPaths())
 
     @attach()
-    @focus()
+    @focus() if atom.config.get('tree-view.focusOnReveal')
 
     return unless activeFilePath = @getActivePath()
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "type": "boolean",
       "default": true,
       "description": "When listing directory items, list subdirectories before listing files."
+    },
+    "focusOnReveal": {
+      "type": "boolean",
+      "default": true,
+      "description": "When a file is revealed in the sidebar, switch the focus to the sidebar."
     }
   }
 }

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2712,6 +2712,51 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
+  describe "the focusOnReveal config option", ->
+    beforeEach ->
+      treeView.detach()
+      spyOn(treeView, 'focus')
+
+    it "switches focus to sidebar on changing files when focusOnReveal option is set", ->
+      atom.config.set "tree-view.focusOnReveal", true
+
+      waitsForPromise ->
+        atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).toHaveBeenCalled()
+
+      waitsForPromise ->
+        treeView.focus.reset()
+        atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).toHaveBeenCalled()
+
+    it "does not switch focus to sidebar on changing files when focusOnReveal option is unset", ->
+      atom.config.set "tree-view.focusOnReveal", false
+
+      waitsForPromise ->
+        atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).not.toHaveBeenCalled()
+
+      waitsForPromise ->
+        treeView.focus.reset()
+        atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+
+      runs ->
+        atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.focus).not.toHaveBeenCalled()
+
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
       atom.notifications.clear()


### PR DESCRIPTION
control whether the focus on the editor panes is
transferred to the tree-view pane on calling 'reveal-active-file'
default set to true (the current behaviour)

PR split as requested by @benogle in #715 