### PR TITLE
feat(option): added an option to auto-reveal files on changing them

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -137,6 +137,7 @@ class TreeView extends View
 
     @disposables.add atom.workspace.onDidChangeActivePaneItem =>
       @selectActiveFile()
+      @revealActiveFile() if atom.config.get('tree-view.autoReveal')
     @disposables.add atom.project.onDidChangePaths =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "type": "boolean",
       "default": true,
       "description": "When listing directory items, list subdirectories before listing files."
+    },
+    "autoReveal": {
+      "type": "boolean",
+      "default": false,
+      "description": "Reveal files as they are opened or switched-to in the editor panes."
     }
   }
 }

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2712,6 +2712,33 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
+  describe "the autoReveal config option", ->
+    beforeEach ->
+      atom.config.set "tree-view.autoReveal", true
+
+    describe "when the item has a path", ->
+      it "selects the entry with that path in the tree view if it is visible", ->
+        waitsForFileToOpen ->
+          sampleJs.click()
+
+        waitsForPromise ->
+          atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
+
+        runs ->
+          expect(sampleTxt).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
+      it "selects the entry with that path in the tree view if it is not visible", ->
+        waitsForPromise ->
+          atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
+
+        runs ->
+          dirView = root1.find('.directory:contains(dir1)')
+          fileView = root1.find('.file:contains(sub-file1)')
+          expect(dirView).not.toHaveClass 'selected'
+          expect(fileView).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
       atom.notifications.clear()


### PR DESCRIPTION
this option controls the revealing of files automatically as they
are switched in the editor panes.

PR split as requested by @benogle in #715