### PR TITLE
Add backward-compatible support for new pending item API

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -213,7 +213,12 @@ class TreeView extends View
           entry.toggleExpansion(isRecursive)
       when 2
         if entry instanceof FileView
-          @openedItem.then((item) -> item.terminatePendingState?())
+          @openedItem.then (item) ->
+            activePane = atom.workspace.getActivePane()
+            if activePane?.getPendingItem?
+              activePane.clearPendingItem() if activePane.getPendingItem() is item
+            else if item.terminatePendingState?
+              item.terminatePendingState()
           unless entry.getPath() is atom.workspace.getActivePaneItem()?.getPath?()
             @unfocus()
         else if entry instanceof DirectoryView
@@ -393,9 +398,13 @@ class TreeView extends View
         selectedEntry.toggleExpansion()
     else if selectedEntry instanceof FileView
       uri = selectedEntry.getPath()
-      item = atom.workspace.getActivePane()?.itemForURI(uri)
+      activePane = atom.workspace.getActivePane()
+      item = activePane?.itemForURI(uri)
       if item? and not options.pending
-        item.terminatePendingState?()
+        if activePane?.getPendingItem?
+          activePane.clearPendingItem() if activePane.getPendingItem() is item
+        else if item.terminatePendingState?
+          item.terminatePendingState()
       atom.workspace.open(uri, options)
 
   openSelectedEntrySplit: (orientation, side) ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -526,7 +526,7 @@ describe "TreeView", ->
       sampleJs.mousedown()
       expect(sampleJs).toHaveClass 'selected'
 
-  if atom.workspace.buildTextEditor().isPending?
+  if atom.workspace.getActivePane().getPendingItem?
     describe "when files are clicked", ->
       beforeEach ->
         jasmine.attachToDOM(workspaceElement)
@@ -548,7 +548,7 @@ describe "TreeView", ->
 
         it "opens it in the pane in pending state", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(activePaneItem.isPending()).toBe true
+          expect(atom.workspace.getActivePane().getPendingItem()).toEqual activePaneItem
 
         it "changes the focus to the file", ->
           expect(atom.views.getView(activePaneItem)).toHaveFocus()
@@ -584,18 +584,18 @@ describe "TreeView", ->
 
         it "opens it in pending state on first click", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(activePaneItem.isPending()).toBe true
+          expect(atom.workspace.getActivePane().getPendingItem()).toEqual activePaneItem
 
         it "terminates pending state on second click", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           waitsFor ->
-            activePaneItem.isPending() is false
+            atom.workspace.getActivePane().getPendingItem() isnt activePaneItem
 
         it "does not create pending state on subsequent single click", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           sampleJs.trigger clickEvent(originalEvent: {detail: 1})
           waitsFor ->
-            activePaneItem.isPending() is false
+            atom.workspace.getActivePane().getPendingItem() isnt activePaneItem
 
       describe "when a file is single-clicked, then double-clicked", ->
         activePaneItem = null
@@ -611,13 +611,13 @@ describe "TreeView", ->
 
         it "opens it in pending state on single-click", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(activePaneItem.isPending()).toBe true
+          expect(atom.workspace.getActivePane().getPendingItem()).toEqual activePaneItem
 
         it "terminates pending state on the double-click and focuses file", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
           expect(atom.views.getView(activePaneItem)).toHaveFocus()
           waitsFor ->
-            activePaneItem.isPending() is false
+            atom.workspace.getActivePane().getPendingItem() isnt activePaneItem
 
         it "keeps focus on tree-view if the file is the active pane item", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 1})


### PR DESCRIPTION
This adds backward-compatible checks for the new pending item APIs, and falls back to using `Item::terminatePendingState` if they're not supported in the current Atom environment.

Fixes atom/atom#10995 until #741 can be merged.

/cc @kuychaco 