### PR TITLE
Add option to auto-reveal tree view entries when they become the active pane item

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -137,6 +137,7 @@ class TreeView extends View
 
     @disposables.add atom.workspace.onDidChangeActivePaneItem =>
       @selectActiveFile()
+      @revealActiveFile() if atom.config.get('tree-view.autoReveal')
     @disposables.add atom.project.onDidChangePaths =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "type": "boolean",
       "default": true,
       "description": "When listing directory items, list subdirectories before listing files."
+    },
+    "autoReveal": {
+      "type": "boolean",
+      "default": false,
+      "description": "Reveal files as they are opened or switched-to in the editor panes."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "autoReveal": {
       "type": "boolean",
       "default": false,
-      "description": "Reveal files as they are opened or switched-to in the editor panes."
+      "description": "Reveal tree view entries when they become the active pane item."
     }
   }
 }

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -712,6 +712,21 @@ describe "TreeView", ->
           dirView = root1.find('.directory:contains(dir1)')
           expect(dirView).toHaveClass 'selected'
 
+      describe "when the tree-view.autoReveal config setting is true", ->
+        beforeEach ->
+          atom.config.set "tree-view.autoReveal", true
+
+        it "selects the active item's entry in the tree view, expanding parent directories if needed", ->
+          waitsForPromise ->
+            atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
+
+          runs ->
+            dirView = root1.find('.directory:contains(dir1)')
+            fileView = root1.find('.file:contains(sub-file1)')
+            expect(dirView).not.toHaveClass 'selected'
+            expect(fileView).toHaveClass 'selected'
+            expect(treeView.find('.selected').length).toBe 1
+
     describe "when the item has no path", ->
       it "deselects the previously selected entry", ->
         waitsForFileToOpen ->
@@ -2711,33 +2726,6 @@ describe "TreeView", ->
         element.innerText
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
-
-  describe "the autoReveal config option", ->
-    beforeEach ->
-      atom.config.set "tree-view.autoReveal", true
-
-    describe "when the item has a path", ->
-      it "selects the entry with that path in the tree view if it is visible", ->
-        waitsForFileToOpen ->
-          sampleJs.click()
-
-        waitsForPromise ->
-          atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
-
-        runs ->
-          expect(sampleTxt).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
-
-      it "selects the entry with that path in the tree view if it is not visible", ->
-        waitsForPromise ->
-          atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
-
-        runs ->
-          dirView = root1.find('.directory:contains(dir1)')
-          fileView = root1.find('.file:contains(sub-file1)')
-          expect(dirView).not.toHaveClass 'selected'
-          expect(fileView).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
 
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2712,6 +2712,33 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
+  describe "the autoReveal config option", ->
+    beforeEach ->
+      atom.config.set "tree-view.autoReveal", true
+
+    describe "when the item has a path", ->
+      it "selects the entry with that path in the tree view if it is visible", ->
+        waitsForFileToOpen ->
+          sampleJs.click()
+
+        waitsForPromise ->
+          atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
+
+        runs ->
+          expect(sampleTxt).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
+      it "selects the entry with that path in the tree view if it is not visible", ->
+        waitsForPromise ->
+          atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
+
+        runs ->
+          dirView = root1.find('.directory:contains(dir1)')
+          fileView = root1.find('.file:contains(sub-file1)')
+          expect(dirView).not.toHaveClass 'selected'
+          expect(fileView).toHaveClass 'selected'
+          expect(treeView.find('.selected').length).toBe 1
+
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
       atom.notifications.clear()


### PR DESCRIPTION
Closes #751

This PR applies some minor cleanup to #751. Thanks to @kumarharsh for the contribution!

@kumarharsh: In case you're interested:

* I moved your test and went ahead and combined two tests into one, which tested the basic behavior as well as parent directory expansion.
* In the future, we *prefer* commit messages and PR titles to be phrased in the imperative voice. "Add option" rather than "Added option". That said, I'd rather have the contribution than worry too much about this so I'll go ahead and merge the commit as-is.

Thanks again!!