### PR TITLE
Fix #732: Tree-view API is not being called on startup

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,6 +34,7 @@ module.exports =
   consumeFileIcons: (service) ->
     FileIcons.setService(service)
     @fileIconsDisposable = service.onWillDeactivate -> FileIcons.resetService()
+    @treeView?.updateRoots()
 
   serialize: ->
     if @treeView?


### PR DESCRIPTION
This is fixes #732: Tree-view API is not being called on startup courtesy of ssorallen++.