### PR TITLE
Add check for undefined openedItem when double clicking file in tree view

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -213,7 +213,7 @@ class TreeView extends View
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
-        if entry instanceof FileView & @openedItem?
+        if entry instanceof FileView and @openedItem?
           @openedItem.then (item) ->
             activePane = atom.workspace.getActivePane()
             if activePane?.getPendingItem?

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -213,7 +213,7 @@ class TreeView extends View
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
-        if entry instanceof FileView
+        if entry instanceof FileView & @openedItem?
           @openedItem.then (item) ->
             activePane = atom.workspace.getActivePane()
             if activePane?.getPendingItem?


### PR DESCRIPTION
Fixes #747.

Just a simple change to check if openedItem is undefined before performing actions for double-clicking.
Could be undefined when atom is just launched.