### PR TITLE
Catch listSync errors. Prevent crash on unreadable directory.

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -266,7 +266,10 @@ class Directory
   squashDirectoryNames: (fullPath) ->
     squashedDirs = [@name]
     loop
-      contents = fs.listSync fullPath
+      try
+        contents = fs.listSync fullPath
+      catch error
+        break
       break if contents.length isnt 1
       break if not fs.isDirectorySync(contents[0])
       relativeDir = path.relative(fullPath, contents[0])


### PR DESCRIPTION
 Fix #687, fix #671, fix #651.
