### PR TITLE
Fix exception when double clicking opened file after activation

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -213,7 +213,7 @@ class TreeView extends View
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
-        if entry instanceof FileView & @openedItem?
+        if entry instanceof FileView and @openedItem?
           @openedItem.then (item) ->
             activePane = atom.workspace.getActivePane()
             if activePane?.getPendingItem?

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -213,7 +213,7 @@ class TreeView extends View
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
-        if entry instanceof FileView
+        if entry instanceof FileView & @openedItem?
           @openedItem.then (item) ->
             activePane = atom.workspace.getActivePane()
             if activePane?.getPendingItem?

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -207,13 +207,14 @@ class TreeView extends View
         @selectEntry(entry)
         if entry instanceof FileView
           if entry.getPath() is atom.workspace.getActivePaneItem()?.getPath?()
+            @openedItem = Promise.resolve(atom.workspace.getActivePaneItem())
             @focus()
           else
             @openedItem = atom.workspace.open(entry.getPath(), pending: true)
         else if entry instanceof DirectoryView
           entry.toggleExpansion(isRecursive)
       when 2
-        if entry instanceof FileView and @openedItem?
+        if entry instanceof FileView
           @openedItem.then (item) ->
             activePane = atom.workspace.getActivePane()
             if activePane?.getPendingItem?

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -560,6 +560,7 @@ describe "TreeView", ->
 
       it "does not throw when the file is double clicked", ->
         expect ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
         .not.toThrow()
 
@@ -574,9 +575,14 @@ describe "TreeView", ->
               editor = o
 
         it "marks the pending file as permanent", ->
-          expect(atom.workspace.getActivePane().getPendingItem()).toBe editor
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
-          expect(atom.workspace.getActivePane().getPendingItem()).toBeNull()
+          runs ->
+            expect(atom.workspace.getActivePane().getActiveItem()).toBe editor
+            expect(atom.workspace.getActivePane().getPendingItem()).toBe editor
+            sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+            sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+
+          waitsFor ->
+            atom.workspace.getActivePane().getPendingItem() is null
 
   if atom.workspace.getActivePane().getPendingItem?
     describe "when files are clicked", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -548,6 +548,36 @@ describe "TreeView", ->
       sampleJs.mousedown()
       expect(sampleJs).toHaveClass 'selected'
 
+  describe "when the package first activates and there is a file open (regression)", ->
+    # Note: it is important that this test is not nested inside any other tests
+    # that generate click events in their `beforeEach` hooks, as this test
+    # tests incorrect behavior that only manifested itself on the first
+    # UI interaction after the package was activated.
+    describe "when the file is permanent", ->
+      beforeEach ->
+        waitsForFileToOpen ->
+          atom.workspace.open('tree-view.js')
+
+      it "does not throw when the file is double clicked", ->
+        expect ->
+          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+        .not.toThrow()
+
+    # TODO: remove conditional on 1.6 release [MKT]
+    if atom.workspace.getActivePane().getPendingItem?
+      describe "when the file is pending", ->
+        editor = null
+
+        beforeEach ->
+          waitsForPromise ->
+            atom.workspace.open('tree-view.js', pending: true).then (o) ->
+              editor = o
+
+        it "marks the pending file as permanent", ->
+          expect(atom.workspace.getActivePane().getPendingItem()).toBe editor
+          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          expect(atom.workspace.getActivePane().getPendingItem()).toBeNull()
+
   if atom.workspace.getActivePane().getPendingItem?
     describe "when files are clicked", ->
       beforeEach ->


### PR DESCRIPTION
The incorrect behavior only exhibits itself on the very first interaction with tree-view after activation, and only if the currently active item is the same as the item being opened.

Thanks to @m133225 for the fix!

/cc @kuychaco 

Fixes #474 