### PR TITLE
Move away from deprecated Electron require syntax

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
-{shell} = require 'electron'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable} = require 'atom'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-shell = require 'shell'
+{shell} = require 'electron'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable} = require 'atom'


### PR DESCRIPTION
Required for atom/atom#10983.

Will merge once CI passes.