### PR TITLE
Fix squashed directories appearing duplicated when reloaded

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -29,17 +29,19 @@ class DirectoryView extends HTMLElement
       else
         iconClass = 'icon-file-submodule' if @directory.submodule
     @directoryName.classList.add(iconClass)
-    @directoryName.dataset.name = @directory.name
-    @directoryName.title = @directory.name
     @directoryName.dataset.path = @directory.path
 
     if @directory.squashedNames?
+      @directoryName.dataset.name = @directory.squashedNames.join('')
+      @directoryName.title = @directory.squashedNames.join('')
       squashedDirectoryNameNode = document.createElement('span')
       squashedDirectoryNameNode.classList.add('squashed-dir')
       squashedDirectoryNameNode.textContent = @directory.squashedNames[0]
       @directoryName.appendChild(squashedDirectoryNameNode)
       @directoryName.appendChild(document.createTextNode(@directory.squashedNames[1]))
     else
+      @directoryName.dataset.name = @directory.name
+      @directoryName.title = @directory.name
       @directoryName.textContent = @directory.name
 
     @appendChild(@header)

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -33,17 +33,16 @@ class DirectoryView extends HTMLElement
     @directoryName.title = @directory.name
     @directoryName.dataset.path = @directory.path
 
-    if @directory.squashedName?
-      @squashedDirectoryName = document.createElement('span')
-      @squashedDirectoryName.classList.add('squashed-dir')
-      @squashedDirectoryName.textContent = @directory.squashedName
-
-    directoryNameTextNode = document.createTextNode(@directory.name)
+    if @directory.squashedNames?
+      squashedDirectoryNameNode = document.createElement('span')
+      squashedDirectoryNameNode.classList.add('squashed-dir')
+      squashedDirectoryNameNode.textContent = @directory.squashedNames[0]
+      @directoryName.appendChild(squashedDirectoryNameNode)
+      @directoryName.appendChild(document.createTextNode(@directory.squashedNames[1]))
+    else
+      @directoryName.textContent = @directory.name
 
     @appendChild(@header)
-    if @squashedDirectoryName?
-      @directoryName.appendChild(@squashedDirectoryName)
-    @directoryName.appendChild(directoryNameTextNode)
     @header.appendChild(@directoryName)
     @appendChild(@entries)
 

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -274,7 +274,6 @@ class Directory
       fullPath = path.join(fullPath, relativeDir)
 
     if squashedDirs.length > 1
-      @squashedName = squashedDirs[0..squashedDirs.length - 2].join(path.sep) + path.sep
-    @name = squashedDirs[squashedDirs.length - 1]
+      @squashedNames = [squashedDirs[0..squashedDirs.length - 2].join(path.sep) + path.sep, _.last(squashedDirs)]
 
     return fullPath

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2354,6 +2354,11 @@ describe "TreeView", ->
       iotaDirPath = path.join(lambdaDirPath, "iota")
       kappaDirPath = path.join(lambdaDirPath, "kappa")
 
+      muDirPath = path.join(rootDirPath, "mu")
+      nuDirPath = path.join(muDirPath, "nu")
+      xiDirPath1 = path.join(muDirPath, "xi")
+      xiDirPath2 = path.join(nuDirPath, "xi")
+
       fs.makeTreeSync(zetaDirPath)
       fs.writeFileSync(zetaFilePath, "doesn't matter")
 
@@ -2369,6 +2374,11 @@ describe "TreeView", ->
       fs.makeTreeSync(lambdaDirPath)
       fs.makeTreeSync(iotaDirPath)
       fs.makeTreeSync(kappaDirPath)
+
+      fs.makeTreeSync(muDirPath)
+      fs.makeTreeSync(nuDirPath)
+      fs.makeTreeSync(xiDirPath1)
+      fs.makeTreeSync(xiDirPath2)
 
       atom.project.setPaths([rootDirPath])
 
@@ -2410,6 +2420,16 @@ describe "TreeView", ->
           element.innerText
 
         expect(lambdaEntries).toEqual(["iota", "kappa"])
+
+      describe "when a directory is reloaded", ->
+        it "squashes the directory names the last of which is same as an unsquashed directory", ->
+          muDir = $(treeView.roots[0].entries).find('.directory:contains(mu):first')
+          muDir[0].expand()
+          muDir[0].reload()
+          muEntries = [].slice.call(muDir[0].children[1].children).map (element) ->
+            element.innerText
+
+          expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
 
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []


### PR DESCRIPTION
Fixes #705 by not overwriting `@name` with nested directory name in `squashDirectoryNames`.