### PR TITLE
Use sync fs for testing

### DIFF
--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -5,7 +5,7 @@ fs = require 'fs-plus'
 
 module.exports =
 class File
-  constructor: ({@name, fullPath, @symlink, realpathCache}) ->
+  constructor: ({@name, fullPath, @symlink, realpathCache, useSyncFS}) ->
     @destroyed = false
     @emitter = new Emitter()
     @subscriptions = new CompositeDisposable()
@@ -16,11 +16,14 @@ class File
     @subscribeToRepo()
     @updateStatus()
 
-    fs.realpath @path, realpathCache, (error, realPath) =>
-      return if @destroyed
-      if realPath and realPath isnt @path
-        @realPath = realPath
-        @updateStatus()
+    if useSyncFS
+      @realPath = fs.realpathSync(@path)
+    else
+      fs.realpath @path, realpathCache, (error, realPath) =>
+        return if @destroyed
+        if realPath and realPath isnt @path
+          @realPath = realPath
+          @updateStatus()
 
   destroy: ->
     @destroyed = true

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -39,6 +39,7 @@ class TreeView extends View
     @scrollTopAfterAttach = -1
     @selectedPath = null
     @ignoredPatterns = []
+    @useSyncFS = false
 
     @dragEventCounts = new WeakMap
 
@@ -283,6 +284,7 @@ class TreeView extends View
                         oldExpansionStates[projectPath] ?
                         {isExpanded: true}
         @ignoredPatterns
+        @useSyncFS
       })
       root = new DirectoryView()
       root.initialize(directory)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2438,6 +2438,7 @@ describe "TreeView", ->
       fs.writeFileSync modifiedFile, 'ch ch changes'
       atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
+      treeView.useSyncFS = true
       treeView.updateRoots()
       $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
 


### PR DESCRIPTION
This is needed to support https://github.com/atom/atom/pull/11280.

So it seems like these tests were always racing: we depended on loading the `realpath` before emitting change events. It’s just that we usually won that race. Now we use synchronous FS during tests to *ensure* we win the race.

I don’t love this. It means testing isn’t quite doing the same thing as the Real Version. But I also don’t want to make dramatic changes and make https://github.com/atom/tree-view/pull/624 more difficult to merge.

/cc @thedaniel to make sure I’m not being crazy here.