### PR TITLE
Create new layer to reduce work on high DPI displays

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -51,6 +51,18 @@
 .tree-view {
   flex-grow: 1;
   flex-shrink: 0;
+  /*
+   * Force a new stacking context to prevent a large, duplicate paint layer from
+   * being created for tree-view's scrolling contents that can make the cost of
+   * layer tree updates scale at 3x the size of the layer rather than the
+   * optimal 1x.
+   *
+   * On high resolution displays, Chromium handles layers for scrolling content
+   * differently and inadvertently creates a duplicate paint layer the size of
+   * .tree-view-scroller because descendants of the scroller overlap the
+   * auto-created layer.
+   */
+  isolation: isolate;
   min-width: -webkit-min-content;
   min-height: 100%;
   padding-left: @component-icon-padding;


### PR DESCRIPTION
## TL;DR

This change improves typing performance when the tree-view is visible by decreasing the amount of work done in Chromium on each keypress.

Keypresses in `<atom-text-editor>` force layouts and layer tree updates. On high resolution displays (ex. Macbooks w/ Retina screens), Chromium inadvertently creates a duplicate layer in tree-view that causes layer tree updates to take 3x longer than needed.

## Investigation

Force a new stacking context to prevent a large, duplicate paint layer
from being created for tree-view's scrolling contents that can make the
cost of layer tree updates scale at 3x the size of the layer rather than
the optimal 1x.

On high resolution displays, Chromium handles layers for scrolling
content differently and inadvertently creates a duplicate paint layer
the size of .tree-view-scroller because descendants of the scroller
overlap the auto-created layer.

### Testing with a very large tree-view to accent the issue:

#### Example of duplicate layers created, no changes applied

Duplicate layers:
<img width="607" alt="screen shot 2016-04-06 at 10 38 58 am" src="https://cloud.githubusercontent.com/assets/29612/14327266/6a78611a-fbe6-11e5-96fa-144e3bb71e01.png">

Layer tree update ~60ms (occurs on every keypress in `<atom-text-editor>`):
<img width="728" alt="screen shot 2016-04-06 at 10 38 28 am" src="https://cloud.githubusercontent.com/assets/29612/14327316/9102fbce-fbe6-11e5-9dbf-55033167c966.png">

#### Example with isolation, new layer

Only one layer for scrolling contents:
<img width="606" alt="screen shot 2016-04-06 at 10 39 54 am" src="https://cloud.githubusercontent.com/assets/29612/14327291/7c5fbd60-fbe6-11e5-90ac-7ee2e68a1c24.png">

Layer tree update only ~20ms (occurs on every keypress in `<atom-text-editor>`):
<img width="829" alt="screen shot 2016-04-06 at 10 40 36 am" src="https://cloud.githubusercontent.com/assets/29612/14327370/d5c006a8-fbe6-11e5-8724-9bd706957da1.png">

### Testing with small file tree (atom/tree-view's own 'lib' directory recursively expanded)

#### w/ duplicate layers

Layer tree update ~1.5ms (occurs on every keypress in `<atom-text-editor>`):
<img width="782" alt="screen shot 2016-04-06 at 10 45 40 am" src="https://cloud.githubusercontent.com/assets/29612/14327399/00cfe174-fbe7-11e5-8414-64e71915f4cb.png">

#### w/ isolation, single layer

Layer tree update ~0.5ms (occurs on every keypress in `<atom-text-editor>`):
<img width="784" alt="screen shot 2016-04-06 at 10 45 05 am" src="https://cloud.githubusercontent.com/assets/29612/14327420/10793af8-fbe7-11e5-95d0-97cc508419ba.png">

cc @nathansobo @hellendag 