### PR TITLE
Don't open file on single-click unless core.allowPendingPaneItems=true

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -211,7 +211,8 @@ class TreeView extends View
     else if entry instanceof FileView
       detail = e.originalEvent?.detail ? 1
       if detail is 1
-        atom.workspace.open(entry.getPath(), pending: true, activatePane: false)
+        if atom.config.get('core.allowPendingPaneItems')
+          atom.workspace.open(entry.getPath(), pending: true, activatePane: false)
       else if detail is 2
         atom.workspace.open(entry.getPath())
 


### PR DESCRIPTION
Also cleaned up specs for when files are clicked. Removed unnecessary tests that cover behavior implemented in Atom core.

/cc @BinaryMuse 