### PR TITLE
Add package option to re-enable single-click behaviour

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -211,7 +211,7 @@ class TreeView extends View
     else if entry instanceof FileView
       detail = e.originalEvent?.detail ? 1
       if detail is 1
-        if atom.config.get('core.allowPendingPaneItems') or atom.config.get('tree-view.singleClickSelect')
+        if atom.config.get('core.allowPendingPaneItems') or atom.config.get('tree-view.openFilesWithSingleClick')
           atom.workspace.open(entry.getPath(), pending: true, activatePane: false)
       else if detail is 2
         atom.workspace.open(entry.getPath())

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -211,7 +211,7 @@ class TreeView extends View
     else if entry instanceof FileView
       detail = e.originalEvent?.detail ? 1
       if detail is 1
-        if atom.config.get('core.allowPendingPaneItems')
+        if atom.config.get('core.allowPendingPaneItems') or atom.config.get('tree-view.singleClickSelect')
           atom.workspace.open(entry.getPath(), pending: true, activatePane: false)
       else if detail is 2
         atom.workspace.open(entry.getPath())

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
       "default": true,
       "description": "Focus the tree view when revealing entries."
     },
-    "singleClickSelect": {
+    "openFilesWithSingleClick": {
       "type": "boolean",
       "default": false,
-      "title": "Single-click select",
+      "title": "Open files with single-click",
       "description": "Open files with a single-click instead of a double-click."
     }
   }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
       "type": "boolean",
       "default": true,
       "description": "Focus the tree view when revealing entries."
+    },
+    "singleClickSelect": {
+      "type": "boolean",
+      "default": false,
+      "title": "Single-click select",
+      "description": "Open files with a single-click instead of a double-click."
     }
   }
 }

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -26,6 +26,7 @@ describe "TreeView", ->
 
   beforeEach ->
     expect(atom.config.get('core.allowPendingPaneItems')).toBeTruthy()
+    expect(atom.config.get('tree-view.openFilesWithSingleClick')).toBeFalsy()
 
     fixturesPath = atom.project.getPaths()[0]
     path1 = path.join(fixturesPath, "root-dir1")
@@ -623,6 +624,18 @@ describe "TreeView", ->
 
         it "does not open the file", ->
           expect(atom.workspace.open).not.toHaveBeenCalled()
+      
+      describe "when tree-view.openFilesWithSingleClick is set to true", ->
+        beforeEach ->
+          atom.config.set('core.allowPendingPaneItems', false)
+          atom.config.set('tree-view.openFilesWithSingleClick', true)
+          spyOn(atom.workspace, 'open')
+          
+          treeView.focus()
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+        
+        it "opens the file immediately upon selection", ->
+          expect(atom.workspace.open).toHaveBeenCalled()
 
     describe "when a file is double-clicked", ->
       activePaneItem = null


### PR DESCRIPTION
Some users might prefer the old behaviour of single-clicking a file in the tree-view to open it. This PR adds a package setting (off by default) to restore the pre-1.7.0 method of selecting files.

Please let me know if a spec should be included as well. =)