### PR TITLE
Enclose path in quotes for explorer.exe

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -453,7 +453,7 @@ class TreeView extends View
         label: 'Finder'
         args: ['-R', pathToOpen]
       when 'win32'
-        args = ["/select,#{pathToOpen}"]
+        args = ["/select,\"#{pathToOpen}\""]
 
         if process.env.SystemRoot
           command = path.join(process.env.SystemRoot, 'explorer.exe')


### PR DESCRIPTION
Fixes an issue where a `&` in the folder/file name would be interpreted as a new command.

I am unaware of how to test this as `explorer.exe` always exits with code 9009 for me.

Fixes #757