### PR TITLE
Allow file-icons service to set multiple class names

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, "tree-view")
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path, @file.getMetadata())
+    iconClass = FileIcons.getService().iconClassForPath(@file.path)
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path, @)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, this)
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path, @file)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, @)
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,11 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    @fileName.classList.add(FileIcons.getService().iconClassForPath(@file.path))
+    iconClass = FileIcons.getService().iconClassForPath(@file.path)
+    if iconClass
+      unless Array.isArray iconClass
+        iconClass = iconClass.toString().split(/\s+/g)
+      @fileName.classList.add(iconClass...)
 
     @subscriptions.add @file.onDidStatusChange => @updateStatus()
     @updateStatus()

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path, this)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, @file.getMetadata())
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path, "tree-view")
+    iconClass = FileIcons.getService().iconClassForPath(@file.path)
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, @file)
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -36,7 +36,7 @@ class File
   onDidStatusChange: (callback) ->
     @emitter.on('did-status-change', callback)
 
-  # Subscribe to the project' repo for changes to the Git status of this file.
+  # Subscribe to the project's repo for changes to the Git status of this file.
   subscribeToRepo: ->
     repo = repoForPath(@path)
     return unless repo?
@@ -67,6 +67,3 @@ class File
 
   isPathEqual: (pathToCompare) ->
     @path is pathToCompare or @realPath is pathToCompare
-
-  # Return a snapshot of the instance's filesystem properties for API consumption
-  getMetadata: -> {@symlink, @realPath, @status, @stats}

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -67,3 +67,6 @@ class File
 
   isPathEqual: (pathToCompare) ->
     @path is pathToCompare or @realPath is pathToCompare
+
+  # Return a snapshot of the instance's filesystem properties for API consumption
+  getMetadata: -> {@symlink, @realPath, @status, @stats}

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,3 +1,7 @@
+fs = require 'fs-plus'
+temp = require('temp').track()
+path = require 'path'
+
 DefaultFileIcons = require '../lib/default-file-icons'
 FileIcons = require '../lib/file-icons'
 
@@ -21,3 +25,45 @@ describe 'FileIcons', ->
     FileIcons.resetService()
 
     expect(FileIcons.getService()).not.toBe(service)
+
+  
+  describe 'Class handling', ->
+    [workspaceElement, treeView, files] = []
+    
+    beforeEach ->
+      rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
+      
+      for i in [1..3]
+        filepath = path.join(rootDirPath, "file-#{i}.txt")
+        fs.writeFileSync(filepath, "Nah")
+      
+      atom.project.setPaths([rootDirPath])
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
+
+      FileIcons.setService
+        iconClassForPath: (path, file) ->
+          [name, id] = path.match(/file-(\d+)\.txt$/)
+          switch id
+            when "1" then 'first second'
+            when "2" then ['first', 'second']
+            when "3" then file.constructor.name
+
+      waitsForPromise ->
+        atom.packages.activatePackage('tree-view')
+      
+      runs ->
+        treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
+        files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
+      
+    afterEach ->
+      temp.cleanup()
+  
+    it 'allows multiple classes to be passed', ->
+      expect(files[0].fileName.className).toBe('name icon first second')
+
+    it 'allows an array of classes to be passed', ->
+      expect(files[1].fileName.className).toBe('name icon first second')
+
+    it 'passes a file reference as iconClassForPath\'s second argument', ->
+      expect(files[2].fileName.className).toBe('name icon File')

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -65,5 +65,5 @@ describe 'FileIcons', ->
     it 'allows an array of classes to be passed', ->
       expect(files[1].fileName.className).toBe('name icon first second')
 
-    it 'passes a file reference as iconClassForPath\'s second argument', ->
-      expect(files[2].fileName.className).toBe('name icon File')
+    it 'passes a FileView reference as iconClassForPath\'s second argument', ->
+      expect(files[2].fileName.className).toBe('name icon tree-view-file')

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,7 +1,3 @@
-fs = require 'fs-plus'
-temp = require('temp').track()
-path = require 'path'
-
 DefaultFileIcons = require '../lib/default-file-icons'
 FileIcons = require '../lib/file-icons'
 
@@ -25,45 +21,3 @@ describe 'FileIcons', ->
     FileIcons.resetService()
 
     expect(FileIcons.getService()).not.toBe(service)
-
-  
-  describe 'Class handling', ->
-    [workspaceElement, treeView, files] = []
-    
-    beforeEach ->
-      rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
-      
-      for i in [1..3]
-        filepath = path.join(rootDirPath, "file-#{i}.txt")
-        fs.writeFileSync(filepath, "Nah")
-      
-      atom.project.setPaths([rootDirPath])
-      workspaceElement = atom.views.getView(atom.workspace)
-      jasmine.attachToDOM(workspaceElement)
-
-      FileIcons.setService
-        iconClassForPath: (path, file) ->
-          [name, id] = path.match(/file-(\d+)\.txt$/)
-          switch id
-            when "1" then 'first second'
-            when "2" then ['first', 'second']
-            when "3" then file.constructor.name
-
-      waitsForPromise ->
-        atom.packages.activatePackage('tree-view')
-      
-      runs ->
-        treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
-        files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
-      
-    afterEach ->
-      temp.cleanup()
-  
-    it 'allows multiple classes to be passed', ->
-      expect(files[0].fileName.className).toBe('name icon first second')
-
-    it 'allows an array of classes to be passed', ->
-      expect(files[1].fileName.className).toBe('name icon first second')
-
-    it 'passes a FileView reference as iconClassForPath\'s second argument', ->
-      expect(files[2].fileName.className).toBe('name icon tree-view-file')

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3349,7 +3349,8 @@ describe 'Icon class handling', ->
     jasmine.attachToDOM(workspaceElement)
 
     FileIcons.setService
-      iconClassForPath: (path) ->
+      iconClassForPath: (path, context) ->
+        expect(context).toBe "tree-view"
         [name, id] = path.match(/file-(\d+)\.txt$/)
         switch id
           when "1" then 'first second'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3349,8 +3349,7 @@ describe 'Icon class handling', ->
     jasmine.attachToDOM(workspaceElement)
 
     FileIcons.setService
-      iconClassForPath: (path, context) ->
-        expect(context).toBe "tree-view"
+      iconClassForPath: (path) ->
         [name, id] = path.match(/file-(\d+)\.txt$/)
         switch id
           when "1" then 'first second'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -6,6 +6,9 @@ temp = require('temp').track()
 os = require 'os'
 eventHelpers = require "./event-helpers"
 
+DefaultFileIcons = require '../lib/default-file-icons'
+FileIcons = require '../lib/file-icons'
+
 waitsForFileToOpen = (causeFileToOpen) ->
   waitsFor (done) ->
     disposable = atom.workspace.onDidOpen ->
@@ -3325,3 +3328,42 @@ describe "TreeView", ->
 
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
           expect(atom.views.getView(atom.workspace.getPanes()[1])).toHaveFocus()
+
+
+describe 'Icon class handling', ->
+  [workspaceElement, treeView, files] = []
+  
+  beforeEach ->
+    rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
+    
+    for i in [1..3]
+      filepath = path.join(rootDirPath, "file-#{i}.txt")
+      fs.writeFileSync(filepath, "Nah")
+    
+    atom.project.setPaths([rootDirPath])
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
+
+    FileIcons.setService
+      iconClassForPath: (path) ->
+        [name, id] = path.match(/file-(\d+)\.txt$/)
+        switch id
+          when "1" then 'first second'
+          when "2" then ['first', 'second']
+          else "some-other-file"
+
+    waitsForPromise ->
+      atom.packages.activatePackage('tree-view')
+    
+    runs ->
+      treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
+      files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
+    
+  afterEach ->
+    temp.cleanup()
+
+  it 'allows multiple classes to be passed', ->
+    expect(files[0].fileName.className).toBe('name icon first second')
+
+  it 'allows an array of classes to be passed', ->
+    expect(files[1].fileName.className).toBe('name icon first second')

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3345,7 +3345,11 @@ describe 'Icon class handling', ->
     jasmine.attachToDOM(workspaceElement)
 
     FileIcons.setService
-      iconClassForPath: (path) ->
+      iconClassForPath: (path, info) ->
+        expect(info).toBeDefined()
+        expect(info.hasOwnProperty "symlink").toBe true
+        expect(info.hasOwnProperty "stats").toBe true
+
         [name, id] = path.match(/file-(\d+)\.txt$/)
         switch id
           when "1" then 'first second'

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3349,11 +3349,7 @@ describe 'Icon class handling', ->
     jasmine.attachToDOM(workspaceElement)
 
     FileIcons.setService
-      iconClassForPath: (path, info) ->
-        expect(info).toBeDefined()
-        expect(info.hasOwnProperty "symlink").toBe true
-        expect(info.hasOwnProperty "stats").toBe true
-
+      iconClassForPath: (path) ->
         [name, id] = path.match(/file-(\d+)\.txt$/)
         switch id
           when "1" then 'first second'


### PR DESCRIPTION
Packages that provide the `atom.file-icons` service are currently limited to setting only one class name per file. This is because any attempt to add a DOMTokenList item with a whitespace character will trigger an exception, as per the spec.

However, this is particularly limiting for packages that need flexibility. For example, the [File Icons](https://github.com/DanBrooker/file-icons) package will be adding two different classes: one for the icon, and another for its colour.

I've amended the service consumption routine to allow a list of classes to be specified as either an array or a whitespace-delimited string (analogous to jQuery's approach).

So this:
```js
service.iconClassForPath("gear-icon medium-orange");
```

will now lead to this:
```html
<span class="name icon gear-icon medium-orange">
```

... instead of, well, this:
<img src="https://cloud.githubusercontent.com/assets/2346707/14926664/8ca0248c-0e90-11e6-823e-c32042ec7e65.png" width="487" />