### PR TITLE
Emit events when directories are toggled

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -54,6 +54,12 @@ class Directory
   onDidRemoveEntries: (callback) ->
     @emitter.on('did-remove-entries', callback)
 
+  onDidCollapse: (callback) ->
+    @emitter.on('did-collapse', callback)
+
+  onDidExpand: (callback) ->
+    @emitter.on('did-expand', callback)
+
   loadRealPath: ->
     if @useSyncFS
       @realPath = fs.realpathSync(@path)
@@ -251,6 +257,7 @@ class Directory
     @expansionState.isExpanded = false
     @expansionState = @serializeExpansionState()
     @unwatch()
+    @emitter.emit('did-collapse')
 
   # Public: Expand this directory, load its children, and start watching it for
   # changes.
@@ -258,6 +265,7 @@ class Directory
     @expansionState.isExpanded = true
     @reload()
     @watch()
+    @emitter.emit('did-expand')
 
   serializeExpansionState: ->
     expansionState = {}


### PR DESCRIPTION
Packages currently have no reliable way of gauging when a folder's been opened (or closed). One may be tempted to simply attach `click` handlers to each directory entry, but this rules out the possibility of tabbed/keyboard navigation (as well as recursive expansion for subdirectories).

This PR adds two event emissions to the `Directory` class, each for when a directory is collapsed and expanded.

Please advise if you wish for a spec to be included.