### PR TITLE
Use getFullExtension instead of path.extname in dialogs

### DIFF
--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -1,5 +1,6 @@
 {$, TextEditorView, View} = require 'atom-space-pen-views'
 path = require 'path'
+{getFullExtension} = require "./helpers"
 
 module.exports =
 class Dialog extends View
@@ -19,7 +20,7 @@ class Dialog extends View
     @miniEditor.getModel().setText(initialPath)
 
     if select
-      extension = path.extname(initialPath)
+      extension = getFullExtension(initialPath)
       baseName = path.basename(initialPath)
       if baseName is extension
         selectionEnd = initialPath.length

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1987,7 +1987,7 @@ describe "TreeView", ->
           expect(moveDialog).toExist()
           expect(moveDialog.promptText.text()).toBe "Enter the new path for the file."
           expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(moveDialog.miniEditor.getModel().getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(moveDialog.miniEditor.getModel().getSelectedText()).toBe fileNameWithoutExtension
           expect(moveDialog.miniEditor).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->
@@ -2100,7 +2100,7 @@ describe "TreeView", ->
           expect(copyDialog).toExist()
           expect(copyDialog.promptText.text()).toBe "Enter the new path for the duplicate."
           expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(copyDialog.miniEditor.getModel().getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(copyDialog.miniEditor.getModel().getSelectedText()).toBe fileNameWithoutExtension
           expect(copyDialog.miniEditor).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->


### PR DESCRIPTION
Closes #838 

If we need a test for this, then I need some guidance regarding how to approach. And also the current test will only work because the file names used for testing already give the full extension using `path.extname`.
