### PR TITLE
:art: minor fix for before pseudo element

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -79,7 +79,7 @@
 
   .entry {
     // This fixes #110, see that issue for more details
-    &:before {
+    &::before {
       content: '';
       position: absolute;
     }


### PR DESCRIPTION
CSS code style. `::` is more preference, than `:`

```css
/* CSS3 syntax */
element::before { style properties }

/* CSS2 obsolete syntax (only needed to support IE8) */
element:before  { style properties }
```

https://developer.mozilla.org/en/docs/Web/CSS/::before