### PR TITLE
Fix bug where duplicate tabs open for a given file

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -39,6 +39,7 @@ class TreeView extends View
     @selectedPath = null
     @ignoredPatterns = []
     @useSyncFS = false
+    @currentlyOpening = new Map
 
     @dragEventCounts = new WeakMap
 
@@ -206,17 +207,25 @@ class TreeView extends View
     @selectEntry(entry)
     if entry instanceof DirectoryView
       entry.toggleExpansion(isRecursive)
-      return false
     else if entry instanceof FileView
-      detail = e.originalEvent?.detail ? 1
-      alwaysOpenExisting = atom.config.get('tree-view.alwaysOpenExisting')
-      if detail is 1
-        if atom.config.get('core.allowPendingPaneItems')
-          atom.workspace.open(entry.getPath(), pending: true, activatePane: false, searchAllPanes: alwaysOpenExisting)
-      else if detail is 2
-        atom.workspace.open(entry.getPath(), searchAllPanes: alwaysOpenExisting)
+      @fileViewEntryClicked(e)
 
     false
+
+  fileViewEntryClicked: (e) ->
+    filePath = e.currentTarget.getPath()
+    detail = e.originalEvent?.detail ? 1
+    alwaysOpenExisting = atom.config.get('tree-view.alwaysOpenExisting')
+    if detail is 1
+      if atom.config.get('core.allowPendingPaneItems')
+        openPromise = atom.workspace.open(filePath, pending: true, activatePane: false, searchAllPanes: alwaysOpenExisting)
+        @currentlyOpening.set(filePath, openPromise)
+        openPromise.then => @currentlyOpening.delete(filePath)
+    else if detail is 2
+      if promise = @currentlyOpening.get(filePath)
+        promise.then => atom.workspace.open(filePath, searchAllPanes: alwaysOpenExisting)
+      else
+        atom.workspace.open(filePath, searchAllPanes: alwaysOpenExisting)
 
   resizeStarted: =>
     $(document).on('mousemove', @resizeTreeView)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -638,6 +638,23 @@ describe "TreeView", ->
         it "does not open the file", ->
           expect(atom.workspace.open).not.toHaveBeenCalled()
 
+      describe "when it is immediately opened with `::openSelectedEntry` afterward", ->
+        it "does not open a duplicate file", ->
+          # Fixes https://github.com/atom/atom/issues/11391
+          openedCount = 0
+          originalOpen = atom.workspace.open.bind(atom.workspace)
+          spyOn(atom.workspace, 'open').andCallFake (uri, options) ->
+            originalOpen(uri, options).then -> openedCount++
+
+          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          treeView.openSelectedEntry()
+
+          waitsFor 'open to be called twice', ->
+            openedCount is 2
+
+          runs ->
+            expect(atom.workspace.getActivePane().getItems().length).toBe 1
+
     describe "when a file is double-clicked", ->
       activePaneItem = null
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/11391

In atom/atom#11391 a race condition in opening pending items caused
duplicate items to be opened in the pane. The issue was that the file
was not yet opened in the pane from the first click by the time the second
click triggered a check for the item in the pane. With this commit, the
second call to `atom.workspace.open` is called only after the promise for
the first call is fulfilled and the item has successfully opened in the pane

Signed-off-by: Michelle Tilley <binarymuse@github.com>