### PR TITLE
Reset drag counts when dropping

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -870,6 +870,7 @@ class TreeView extends View
     return unless entry instanceof DirectoryView
 
     entry.classList.remove('selected')
+    @dragEventCounts.set(entry, 0)
 
     newDirectoryPath = $(entry).find(".name").data("path")
     return false unless newDirectoryPath


### PR DESCRIPTION
currently, behavior in Atom 1.7.4 looks like this:

![bad-drag](https://cloud.githubusercontent.com/assets/6645121/15575558/1665345e-2319-11e6-874a-a40d770347a8.gif)

after an entry is dropped on a directory, that directory can no longer become `.selected` on `dragEnter` events.

this PR resets the `dragEventCounts` value for that directory so that subsequent `dragEnter` events give it the `.selected` class.

![good-drag](https://cloud.githubusercontent.com/assets/6645121/15575595/3c4308cc-2319-11e6-8c97-f22b64b30268.gif)

i'm having a hard time replicating the broken behavior in specs, which may have something to do with how drag events are being built
