### PR TITLE
Move title attribute to parent element

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -13,6 +13,7 @@ class DirectoryView extends HTMLElement
 
     @header = document.createElement('div')
     @header.classList.add('header', 'list-item')
+    @header.title = @directory.name
 
     @directoryName = document.createElement('span')
     @directoryName.classList.add('name', 'icon')
@@ -30,7 +31,6 @@ class DirectoryView extends HTMLElement
         iconClass = 'icon-file-submodule' if @directory.submodule
     @directoryName.classList.add(iconClass)
     @directoryName.dataset.name = @directory.name
-    @directoryName.title = @directory.name
     @directoryName.dataset.path = @directory.path
 
     if @directory.squashedName?

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -10,12 +10,12 @@ class FileView extends HTMLElement
     @draggable = true
 
     @classList.add('file', 'entry', 'list-item')
+    @title = @file.name
 
     @fileName = document.createElement('span')
     @fileName.classList.add('name', 'icon')
     @appendChild(@fileName)
     @fileName.textContent = @file.name
-    @fileName.title = @file.name
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 


### PR DESCRIPTION
Helps fixing #248 by exposing file/dir name to the "clickable area". This still makes sense semantically; if `title` isn't present on an element, the `title` of that element's parent  is relevant for it.

Now a tooltip emerges when hovering over anywhere in the "clickable area" of an entry rather than just the "name area". Might be a desirable side-effect.