### PR TITLE
Show current file in file manager in editor

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -23,6 +23,7 @@ module.exports =
       'tree-view:duplicate': => @createView().copySelectedEntry()
       'tree-view:remove': => @createView().removeSelectedEntries()
       'tree-view:rename': => @createView().moveSelectedEntry()
+      'tree-view:show-current-file-in-file-manager': => @createView().showCurrentFileInFileManager()
     })
 
   deactivate: ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -516,7 +516,7 @@ class TreeView extends View
 
   showCurrentFileInFileManager: ->
     return unless editor = atom.workspace.getActiveTextEditor()
-    return if editor.getPath() is undefined  # handle untitled tab
+    return unless editor.getPath()
     {command, args, label} = @fileManagerCommandForPath(editor.getPath(), true)
     @openInFileManager(command, args, label, true)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -514,6 +514,12 @@ class TreeView extends View
     {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
     @openInFileManager(command, args, label, isFile)
 
+  showCurrentFileInFileManager: ->
+    return unless editor = atom.workspace.getActiveTextEditor()
+    return if editor.getPath() is undefined  # handle untitled tab
+    {command, args, label} = @fileManagerCommandForPath(editor.getPath(), true)
+    @openInFileManager(command, args, label, true)
+
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()
       atom.open({pathsToOpen: [pathToOpen], newWindow: true})

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -505,10 +505,10 @@ class TreeView extends View
     showProcess.onWillThrowError ({error, handle}) ->
       handle()
       handleError(error?.message)
+    showProcess
 
   showSelectedEntryInFileManager: ->
-    entry = @selectedEntry()
-    return unless entry
+    return unless entry = @selectedEntry()
 
     isFile = entry instanceof FileView
     {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -483,13 +483,7 @@ class TreeView extends View
         label: 'File Manager'
         args: [pathToOpen]
 
-  showSelectedEntryInFileManager: ->
-    entry = @selectedEntry()
-    return unless entry
-
-    isFile = entry instanceof FileView
-    {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
-
+  openInFileManager: (command, args, label, isFile) ->
     handleError = (errorMessage) ->
       atom.notifications.addError "Opening #{if isFile then 'file' else 'folder'} in #{label} failed",
         detail: errorMessage
@@ -511,6 +505,14 @@ class TreeView extends View
     showProcess.onWillThrowError ({error, handle}) ->
       handle()
       handleError(error?.message)
+
+  showSelectedEntryInFileManager: ->
+    entry = @selectedEntry()
+    return unless entry
+
+    isFile = entry instanceof FileView
+    {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
+    @openInFileManager(command, args, label, isFile)
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -97,9 +97,28 @@
   'atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Rename', 'command': 'tree-view:rename'}
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
+  ]
+
+  '.platform-darwin atom-pane[data-active-item-path] .tab.active': [
+    {'label': 'Show In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-win32 atom-pane[data-active-item-path] .tab.active': [
+    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-linux atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  'atom-text-editor:not([mini])': [
+  '.platform-darwin atom-text-editor:not([mini])': [
+    {'label': 'Show In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-win32 atom-text-editor:not([mini])': [
+    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-linux atom-text-editor:not([mini])': [
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -97,4 +97,9 @@
   'atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Rename', 'command': 'tree-view:rename'}
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
+    {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  'atom-text-editor': [
+    {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -100,6 +100,6 @@
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  'atom-text-editor': [
+  'atom-text-editor:not([mini])': [
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3026,8 +3026,9 @@ describe "TreeView", ->
         atom.workspace.open(filePath)
 
       runs ->
-        fileManagerProcess = treeView.showCurrentFileInFileManager()
         {BufferedProcess} = require 'atom'
+        spyOn(BufferedProcess.prototype, 'spawn').andCallFake ->
+        fileManagerProcess = treeView.showCurrentFileInFileManager()
         expect(fileManagerProcess instanceof BufferedProcess).toBeTruthy()
         fileManagerProcess.kill()
 


### PR DESCRIPTION
it's about  _package-idea_ mentioned in [#589](https://github.com/atom/tree-view/issues/589);
this PR involves 3 major changes:

1. extract code from `showSelectedEntryInFileManager()` and wrap it as helper function `openInFileManager()`
2. add `showCurrentFileInFileManager()` for command `tree-view:show-current-file-in-file-manager` invoking `openInFileManager()`
3. add menu item `Show In File Manager` when right-click on _editor_ and _tab-title_