### PR TITLE
Hopefully fix intermittent test failures

### DIFF
--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -580,6 +580,10 @@ describe "TreeView", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
         .not.toThrow()
 
+        # Ensure we don't move on to the next test until the promise spawned click event resolves.
+        # (If it resolves in the middle of the next test we'll pollute that test)
+        waitsForPromise -> treeView.currentlyOpening.get(atom.workspace.getActivePaneItem().getPath())
+
     describe "when the file is pending", ->
       editor = null
 


### PR DESCRIPTION
In the modified test, the click events create a promise, which we were previously not waiting to be resolved before moving on to the next test. I hypothesize that in some cases, the promise would end up resolving in the middle of the *next* test, hence polluting it. It's hard to prove a negative, but I'm going to try merging this and seeing if our situation improves over the next few builds.

/cc @kuychaco @BinaryMuse