### PR TITLE
add new open-selected-entry-without-activate command

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -68,6 +68,7 @@
   'alt-left': 'tree-view:recursive-collapse-directory'
   'h': 'tree-view:collapse-directory'
   'enter': 'tree-view:open-selected-entry'
+  'o': 'tree-view:open-selected-entry-without-activate'
   'ctrl-C': 'tree-view:copy-full-path'
   'm': 'tree-view:move'
   'f2': 'tree-view:move'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -116,6 +116,7 @@ class TreeView extends View
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
      'tree-view:open-selected-entry': => @openSelectedEntry()
+     'tree-view:open-selected-entry-without-activate': => @openSelectedEntry(pending: true, activatePane: false)
      'tree-view:open-selected-entry-right': => @openSelectedEntryRight()
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
      'tree-view:open-selected-entry-up': => @openSelectedEntryUp()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1227,6 +1227,31 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry')
           expect(atom.workspace.getActivePaneItem()).toBeUndefined()
 
+      describe "tree-view:open-selected-entry-without-activate", ->
+        ensurePreviewOpen = (fileName) ->
+          runs ->
+            file = root1.find(".file:contains(#{fileName})")[0]
+            treeView.selectEntry(file)
+
+          waitsForFileToOpen ->
+            atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-without-activate')
+
+          runs ->
+            item = atom.workspace.getActivePaneItem()
+            expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)
+            expect(atom.views.getView(item)).not.toHaveFocus()
+            expect(atom.workspace.getActivePane().getPendingItem()).toEqual(item)
+            expect(treeView).toHaveFocus()
+
+        beforeEach ->
+          jasmine.attachToDOM(workspaceElement)
+          treeView.focus()
+          expect(treeView).toHaveFocus()
+
+        it "opens the file with pending state and focus remains on treeView", ->
+          ensurePreviewOpen('tree-view.js')
+          ensurePreviewOpen('tree-view.txt')
+
     describe "opening in new split panes", ->
       splitOptions =
         right: ['horizontal', 'after']


### PR DESCRIPTION
# Add new command:

 Name: `tree-view:open-selected-entry-without-activate`
 Scope: `.tree-view`
 defaultKeymap: `o`

# What's difference from normal `open-selected-entry`?

- `tree-view:open-selected-entry-without-activate` don't change focus to newly opened item, focus remains on treeView so that I can continue to open next item by `o` for quick previewing.

- Item is opened with `pending` mode.

# Motivation

I want to quickly preview multiple file, so don't want to loose focus of treeView after opening item.
I can do this by single clicking item with mouse, but I want to do this with **keyboard navigation**.
With this new feature and keybinding, user can do `jojojo` to quickly preview three files sequentially.

![open-selected-item-without-activate](https://cloud.githubusercontent.com/assets/155205/17394439/01fdb4fa-5a64-11e6-88af-6a846b0255a1.gif)

# Name of command

Which is better? not sure
`tree-view:open-selected-entry-without-activate` vs `tree-view:preview`