### PR TITLE
Declare calling context for icon-service providers

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -19,7 +19,7 @@ class FileView extends HTMLElement
     @fileName.dataset.name = @file.name
     @fileName.dataset.path = @file.path
 
-    iconClass = FileIcons.getService().iconClassForPath(@file.path)
+    iconClass = FileIcons.getService().iconClassForPath(@file.path, "tree-view")
     if iconClass
       unless Array.isArray iconClass
         iconClass = iconClass.toString().split(/\s+/g)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3349,7 +3349,8 @@ describe 'Icon class handling', ->
     jasmine.attachToDOM(workspaceElement)
 
     FileIcons.setService
-      iconClassForPath: (path) ->
+      iconClassForPath: (path, context) ->
+        expect(context).toBe "tree-view"
         [name, id] = path.match(/file-(\d+)\.txt$/)
         switch id
           when "1" then 'first second'


### PR DESCRIPTION
Following on from #825 after @as-cii [ordered me](https://github.com/atom/tree-view/pull/825#issuecomment-237788504) to remove an auxiliary addition in order to merge a bug-fix.

This PR (along with atom/fuzzy-finder#249 and atom/tabs#359) offers a solution to a shortcoming in the icon-service API. Currently, package authors have no way of determining where/how an icon is being displayed. This limitation makes granular adjustments to icon-classes impossible without resorting to hideous CSS hackery.

**Obvious example of why this might be an issue:**
A package might have a setting to control whether custom icons are shown in tabs or not. @as-cii suggested having a per-package setting called `disableCustomIcons` that would suppress service calls, but I don't believe that's solving the full issue.

**Less obvious example:**
A package might need to include (or remove) certain CSS classes depending on where an icon is being shown. Real-world example: the File Icons package has a *"Colour only on changes"* setting that adjusts tree-view entry colours based on whether the file's been modified:

<img src="https://cloud.githubusercontent.com/assets/2346707/17432738/171820ce-5b44-11e6-8780-e9c2bab6fa84.png" width="403" alt="Figure 1" />

This serves only to mark modifications in the project's scope, so the colour should be confined to the tree-view only. Obviously, this would require a package to understand the context of an API's call.