### PR TITLE
Use colors to indicate git status

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -57,8 +57,13 @@ class DirectoryView extends HTMLElement
     @expand() if @directory.expansionState.isExpanded
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified', 'status-added')
-    @classList.add("status-#{@directory.status}") if @directory.status?
+    @classList.remove(
+      'status-ignored', 'status-changed', 'status-conflicted',
+      'status-updated', 'status-unmodified')
+
+    if @directory.statuses?
+      @classList.add.apply(@classList, @directory.statuses.map (s) -> "status-#{s}")
+
 
   subscribeToDirectory: ->
     @subscriptions.add @directory.onDidAddEntries (addedEntries) =>

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -136,7 +136,7 @@ class Directory
       if statusCode & GIT_STATUS_IGNORED and newStatuses is []
         newStatuses.push "ignored"
 
-      if newStatuses is []
+      if newStatuses.length is 0
         newStatuses = ["unmodified"]
 
 

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -116,28 +116,27 @@ class Directory
       # - ignored files only matter if the only files in the dir are ignored
 
       if statusCode & GIT_STATUS_INDEX_NEW \
-      || statusCode & GIT_STATUS_INDEX_MODIFIED \
-      || statusCode & GIT_STATUS_INDEX_DELETED \
-      || statusCode & GIT_STATUS_INDEX_RENAMED \
-      || statusCode & GIT_STATUS_INDEX_TYPECHANGE
+      or statusCode & GIT_STATUS_INDEX_MODIFIED \
+      or statusCode & GIT_STATUS_INDEX_DELETED \
+      or statusCode & GIT_STATUS_INDEX_RENAMED \
+      or statusCode & GIT_STATUS_INDEX_TYPECHANGE
         newStatuses.push "updated"
 
       if statusCode & GIT_STATUS_WT_MODIFIED \
-      || statusCode & GIT_STATUS_WT_DELETED \
-      || statusCode & GIT_STATUS_WT_TYPECHANGE \
-      || statusCode & GIT_STATUS_WT_RENAMED \
-      || statusCode & GIT_STATUS_WT_UNREADABLE \
-      || statusCode & GIT_STATUS_WT_NEW
+      or statusCode & GIT_STATUS_WT_DELETED \
+      or statusCode & GIT_STATUS_WT_TYPECHANGE \
+      or statusCode & GIT_STATUS_WT_RENAMED \
+      or statusCode & GIT_STATUS_WT_UNREADABLE \
+      or statusCode & GIT_STATUS_WT_NEW
         newStatuses.push "changed"
 
       if statusCode & GIT_STATUS_CONFLICTED
         newStatuses.push "conflicted"
 
-      if statusCode & GIT_STATUS_IGNORED \
-      && newStatuses == []
+      if statusCode & GIT_STATUS_IGNORED and newStatuses is []
         newStatuses.push "ignored"
 
-      if newStatuses == []
+      if newStatuses is []
         newStatuses = ["unmodified"]
 
 

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -29,8 +29,11 @@ class FileView extends HTMLElement
     @updateStatus()
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified',  'status-added')
-    @classList.add("status-#{@file.status}") if @file.status?
+    @classList.remove(
+      'status-added', 'status-updated',
+      'status-unmerged', 'status-changed','status-untracked',
+      'status-conflicted', 'status-unmodified', 'status-ignored')
+    @classList.add.apply(@classList, @file.statuses.map (s) -> "status-#{s}")
 
   getPath: ->
     @fileName.dataset.path

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -31,7 +31,7 @@ class FileView extends HTMLElement
   updateStatus: ->
     @classList.remove(
       'status-added', 'status-updated',
-      'status-unmerged', 'status-changed','status-untracked',
+      'status-unmerged', 'status-changed', 'status-untracked',
       'status-conflicted', 'status-unmodified', 'status-ignored')
     @classList.add.apply(@classList, @file.statuses.map (s) -> "status-#{s}")
 

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -13,6 +13,8 @@ class File
     @path = fullPath
     @realPath = @path
 
+    @statuses = []
+
     @subscribeToRepo()
     @updateStatus()
 
@@ -48,22 +50,62 @@ class File
 
   # Update the status property of this directory using the repo.
   updateStatus: ->
+
+    GIT_STATUS_INDEX_NEW        = 1 << 0
+    GIT_STATUS_INDEX_MODIFIED   = 1 << 1
+    GIT_STATUS_INDEX_DELETED    = 1 << 2
+    GIT_STATUS_INDEX_RENAMED    = 1 << 3
+    GIT_STATUS_INDEX_TYPECHANGE = 1 << 4
+    GIT_STATUS_WT_NEW           = 1 << 7
+    GIT_STATUS_WT_MODIFIED      = 1 << 8
+    GIT_STATUS_WT_DELETED       = 1 << 9
+    GIT_STATUS_WT_TYPECHANGE    = 1 << 10
+    GIT_STATUS_WT_RENAMED       = 1 << 11
+    GIT_STATUS_WT_UNREADABLE    = 1 << 12
+    GIT_STATUS_IGNORED          = 1 << 14
+    GIT_STATUS_CONFLICTED       = 1 << 15
+
     repo = repoForPath(@path)
     return unless repo?
 
-    newStatus = null
     if repo.isPathIgnored(@path)
-      newStatus = 'ignored'
+      newStatuses = ['ignored']
     else
-      status = repo.getCachedPathStatus(@path)
-      if repo.isStatusModified(status)
-        newStatus = 'modified'
-      else if repo.isStatusNew(status)
-        newStatus = 'added'
+      statusCode = repo.getCachedPathStatus(@path)
+      index =
+        if statusCode & GIT_STATUS_INDEX_NEW
+          # git treats added the same as updated internally, but provides a
+          # different configuration slot name
+          "added"
+        else if statusCode & GIT_STATUS_INDEX_MODIFIED \
+             || statusCode & GIT_STATUS_INDEX_DELETED \
+             || statusCode & GIT_STATUS_INDEX_RENAMED \
+             || statusCode & GIT_STATUS_INDEX_TYPECHANGE
+          "updated"
 
-    if newStatus isnt @status
-      @status = newStatus
-      @emitter.emit('did-status-change', newStatus)
+      working =
+        if statusCode & GIT_STATUS_WT_MODIFIED \
+        || statusCode & GIT_STATUS_WT_DELETED \
+        || statusCode & GIT_STATUS_WT_TYPECHANGE \
+        || statusCode & GIT_STATUS_WT_RENAMED \
+        || statusCode & GIT_STATUS_WT_UNREADABLE
+          "changed"
+
+
+      overall =
+        if statusCode & GIT_STATUS_WT_NEW
+          "untracked"
+        else if statusCode & GIT_STATUS_IGNORED
+          "ignored"
+        else if statusCode & GIT_STATUS_CONFLICTED
+          "conflicted"
+
+      newStatuses = [index, working, overall].filter (x) -> x?
+      newStatuses = ["unmodified"] if newStatuses == []
+
+    if newStatuses isnt @statuses
+      @statuses = newStatuses
+      @emitter.emit('did-status-change', newStatuses)
 
   isPathEqual: (pathToCompare) ->
     @path is pathToCompare or @realPath is pathToCompare

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -101,7 +101,7 @@ class File
           "conflicted"
 
       newStatuses = [index, working, overall].filter (x) -> x?
-      newStatuses = ["unmodified"] if newStatuses is []
+      newStatuses = ["unmodified"] if newStatuses.length is 0
 
     if newStatuses isnt @statuses
       @statuses = newStatuses

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -71,24 +71,24 @@ class File
     if repo.isPathIgnored(@path)
       newStatuses = ['ignored']
     else
-      statusCode = repo.getCachedPathStatus(@path) || repo.getPathStatus(@path)
+      statusCode = repo.getCachedPathStatus(@path) or repo.getPathStatus(@path)
       index =
         if statusCode & GIT_STATUS_INDEX_NEW
           # git treats added the same as updated internally, but provides a
           # different configuration slot name
           "added"
         else if statusCode & GIT_STATUS_INDEX_MODIFIED \
-             || statusCode & GIT_STATUS_INDEX_DELETED \
-             || statusCode & GIT_STATUS_INDEX_RENAMED \
-             || statusCode & GIT_STATUS_INDEX_TYPECHANGE
+             or statusCode & GIT_STATUS_INDEX_DELETED \
+             or statusCode & GIT_STATUS_INDEX_RENAMED \
+             or statusCode & GIT_STATUS_INDEX_TYPECHANGE
           "updated"
 
       working =
         if statusCode & GIT_STATUS_WT_MODIFIED \
-        || statusCode & GIT_STATUS_WT_DELETED \
-        || statusCode & GIT_STATUS_WT_TYPECHANGE \
-        || statusCode & GIT_STATUS_WT_RENAMED \
-        || statusCode & GIT_STATUS_WT_UNREADABLE
+        or statusCode & GIT_STATUS_WT_DELETED \
+        or statusCode & GIT_STATUS_WT_TYPECHANGE \
+        or statusCode & GIT_STATUS_WT_RENAMED \
+        or statusCode & GIT_STATUS_WT_UNREADABLE
           "changed"
 
 
@@ -101,7 +101,7 @@ class File
           "conflicted"
 
       newStatuses = [index, working, overall].filter (x) -> x?
-      newStatuses = ["unmodified"] if newStatuses == []
+      newStatuses = ["unmodified"] if newStatuses is []
 
     if newStatuses isnt @statuses
       @statuses = newStatuses

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -71,7 +71,7 @@ class File
     if repo.isPathIgnored(@path)
       newStatuses = ['ignored']
     else
-      statusCode = repo.getCachedPathStatus(@path)
+      statusCode = repo.getCachedPathStatus(@path) || repo.getPathStatus(@path)
       index =
         if statusCode & GIT_STATUS_INDEX_NEW
           # git treats added the same as updated internally, but provides a

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2595,20 +2595,20 @@ describe "TreeView", ->
     describe "when a file is modified", ->
       it "adds a custom style", ->
         $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
-        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-changed'
 
-    describe "when a directory if modified", ->
+    describe "when a directory is modified", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-changed'
 
     describe "when a file is new", ->
       it "adds a custom style", ->
         $(treeView.roots[0].entries).find('.directory:contains(dir2)')[0].expand()
-        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
+        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-untracked'
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-changed'
 
     describe "when a file is ignored", ->
       it "adds a custom style", ->
@@ -2648,16 +2648,16 @@ describe "TreeView", ->
 
       describe "when a file is modified", ->
         it "updates its and its parent directories' styles", ->
-          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-changed'
+          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-changed'
 
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
+          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-changed'
+          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-changed'
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->
@@ -3336,14 +3336,14 @@ describe "TreeView", ->
 
 describe 'Icon class handling', ->
   [workspaceElement, treeView, files] = []
-  
+
   beforeEach ->
     rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
-    
+
     for i in [1..3]
       filepath = path.join(rootDirPath, "file-#{i}.txt")
       fs.writeFileSync(filepath, "Nah")
-    
+
     atom.project.setPaths([rootDirPath])
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -3358,11 +3358,11 @@ describe 'Icon class handling', ->
 
     waitsForPromise ->
       atom.packages.activatePackage('tree-view')
-    
+
     runs ->
       treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
       files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
-    
+
   afterEach ->
     temp.cleanup()
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2605,9 +2605,13 @@ describe "TreeView", ->
       it "adds a custom style", ->
         $(treeView.roots[0].entries).find('.directory:contains(dir2)')[0].expand()
         expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-untracked'
+      it "adds a custom style to the directory too", ->
+        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-changed'
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
+        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-changed'
+      it "adds a custom style to it's parent too", ->
         expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-changed'
 
     describe "when a file is ignored", ->

--- a/styles/git-colors.less
+++ b/styles/git-colors.less
@@ -4,48 +4,69 @@
 @green: @text-color-success;
 
 .gradient-text(@color1, @color2) {
-  background: linear-gradient(to right, @color1, @color2);
+  background-image: linear-gradient(to bottom, @color1, @color2);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
+// apply @rules to dirs and files
+.entries(@rules) {
+  &.directory .header .name, // dir name
+  &.directory .header .name::before, // dir icon
+  &.file { // file
+    @rules();
+  }
+}
+
 .tree-view {
    // new file, staged
-  .status-added .name {
-    color: @green;
+  .status-added {
+    .entries({
+      color: @green;
+    })
   }
    // modified and staged
-  .status-updated .name {
-    color: @green;
+  .status-updated {
+    .entries({
+      color: @green;
+    })
   }
 
   // The same file has both staged and unstaged parts
   .status-updated.status-changed,
   .status-added.status-changed {
-    .name {
+    .entries({
       .gradient-text(@green, @red);
-    }
-  }
-
-  .status-unmerged .name {
-    color: @red;
+    })
   }
 
   // modified, but not staged
-  .status-changed .name {
-    color: @red;
+  .status-changed {
+    .entries({
+        color: @red;
+    })
+  }
+
+  .status-unmerged {
+    .entries({
+      color: @red;
+    })
   }
 
   // new file, not yet staged
-  .status-untracked .name {
-    color: @red;
+  .status-untracked {
+    .entries({
+      color: @red;
+    })
   }
 
-  .status-conflicted .name {
-    color: @red;
+  .status-conflicted {
+    .entries({
+      color: @red;
+    })
   }
 
-  .status-unmodified .name {
+  .status-unmodified {
     // nothing
   }
 }

--- a/styles/git-colors.less
+++ b/styles/git-colors.less
@@ -4,16 +4,17 @@
 @green: @text-color-success;
 
 .gradient-text(@color1, @color2) {
-  background-image: linear-gradient(to bottom, @color1, @color2);
+  background: linear-gradient(to right, @color1, @color2);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
 // apply @rules to dirs and files
-.entries(@rules) {
+.all(@rules) {
   &.directory > .header > .name, // dir name
   &.directory > .header > .name::before, // dir icon
-  &.file { // file
+  &.file > .name, // file name
+  &.file > .name::before {  // file icon
     @rules();
   }
 }
@@ -21,13 +22,13 @@
 .tree-view {
    // new file, staged
   .status-added {
-    .entries({
+    .all({
       color: @green;
     })
   }
    // modified and staged
   .status-updated {
-    .entries({
+    .all({
       color: @green;
     })
   }
@@ -35,33 +36,33 @@
   // The same file has both staged and unstaged parts
   .status-updated.status-changed,
   .status-added.status-changed {
-    .entries({
+    .all({
       .gradient-text(@green, @red);
     })
   }
 
   // modified, but not staged
   .status-changed {
-    .entries({
+    .all({
         color: @red;
     })
   }
 
   .status-unmerged {
-    .entries({
+    .all({
       color: @red;
     })
   }
 
   // new file, not yet staged
   .status-untracked {
-    .entries({
+    .all({
       color: @red;
     })
   }
 
   .status-conflicted {
-    .entries({
+    .all({
       color: @red;
     })
   }

--- a/styles/git-colors.less
+++ b/styles/git-colors.less
@@ -11,8 +11,8 @@
 
 // apply @rules to dirs and files
 .entries(@rules) {
-  &.directory .header .name, // dir name
-  &.directory .header .name::before, // dir icon
+  &.directory > .header > .name, // dir name
+  &.directory > .header > .name::before, // dir icon
   &.file { // file
     @rules();
   }

--- a/styles/git-colors.less
+++ b/styles/git-colors.less
@@ -1,0 +1,51 @@
+
+@import "ui-variables";
+@red: @text-color-error;
+@green: @text-color-success;
+
+.gradient-text(@color1, @color2) {
+  background: linear-gradient(to right, @color1, @color2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.tree-view {
+   // new file, staged
+  .status-added .name {
+    color: @green;
+  }
+   // modified and staged
+  .status-updated .name {
+    color: @green;
+  }
+
+  // The same file has both staged and unstaged parts
+  .status-updated.status-changed,
+  .status-added.status-changed {
+    .name {
+      .gradient-text(@green, @red);
+    }
+  }
+
+  .status-unmerged .name {
+    color: @red;
+  }
+
+  // modified, but not staged
+  .status-changed .name {
+    color: @red;
+  }
+
+  // new file, not yet staged
+  .status-untracked .name {
+    color: @red;
+  }
+
+  .status-conflicted .name {
+    color: @red;
+  }
+
+  .status-unmodified .name {
+    // nothing
+  }
+}


### PR DESCRIPTION
Currently, the coloring of status in tree-view makes it very difficult to understand the git status of files. For example, changed files (to use the git meaning of the term) are shown the same as updated files, while added files are shown differently.

For example, for a repo in this state:
<img width="254" alt="screenshot 2016-08-07 12 39 27" src="https://cloud.githubusercontent.com/assets/181762/17464819/99b95652-5c9c-11e6-8a3e-efed1b068d95.png">

This is what tree-view tells me:
<img width="202" alt="screenshot 2016-08-07 12 41 14" src="https://cloud.githubusercontent.com/assets/181762/17464822/a381c5fc-5c9c-11e6-80b8-fb8bb8f19f93.png">


This is because tree-view doesn't differentiate between whether a file is in the git index or not. It's best shown in the current code:

```coffee
     if repo.isPathIgnored(@path)
      newStatus = 'ignored'
     else
      status = repo.getCachedPathStatus(@path)
      if repo.isStatusModified(status)
        newStatus = 'modified'
      else if repo.isStatusNew(status)
        newStatus = 'added'
```

Basically, the status can be status-ignored, status-modified, or status-added.

This isn't particularly useful if you use git, as I'm sure you all do. I find myself going to the command line frequently to figure out the actual status of my files. In particular, I find it very hard to make partial commits (dissecting my changes into multiple logical commits) as I constantly have to switch into the command line and back.

This is particularly annoying given that tree-view is one of the areas pointed out as "git integration": http://blog.atom.io/2014/03/13/git-integration.html. I thought perhaps that status-modified and status-added had different meanings, but it's clear (in the blog post and the code) that they are supposed to represent git.

I initially tried to make this a package, but none of the APIs were exposed and it involved a lot of fighting (races and CSS specificity mostly), and this felt like this was a bug in tree-view as opposed to a nice extra, hence making this change here.

OK, done with the justification, onto the changes.

For the same repo as above, here's what this looks like:
<img width="204" alt="screenshot 2016-08-07 12 51 30" src="https://cloud.githubusercontent.com/assets/181762/17464944/e41d463e-5c9e-11e6-9c2f-33034be8abea.png">


As you can see, while you can't tell anything in the current version of tree-view, with these changes you can really see the git status quite well.


Instead of taking a distillation of the the git status as it currently stands, these changes expose the actual git statuses, taking into account that some changes are in the index and some are not. It takes the git status code, analyses it to break the changes into 5 major statuses, which mirror git config's names for them (see color.status.<slot> in https://git-scm.com/docs/git-config for discussion):

- status-added
- status-updated
- status-changed
- status-unmerged
- status-untracked

And then some extras (which also come from the git status code):
- status-conflicted
- status-unmodified
- status-ignored

I also added styling (well, colors) for the statuses. I use the colors from `@ui-variables` - is that portable across themes? Styling currently seem to be handled by themes, but I added defaults so that we can ship this and let the themes catch up (we can remove the colors later if needs be). 

Note that files can be in two statuses at the same time. For example if you `git add` a file, then edit it afterwards, then the file will be both status-updated and status-changed. In the git CLI, this is displayed as a green M followed by a red M. To try and represent this here, I used a gradient. It looks quite pretty 😄. 

For directories, I cut it down to status-ignored, status-changed, status-conflicted, status-updated, status-unmodified. I'd appreciate feedback on this (well on anything, but esp on this :)).

I've fixed existing tests (except one, I'll be working on that soon). I also have more tests to write. Would love suggestions on what things people worry about here.

I'm not sure about status-conflicted. AFAICT, when a file is conflicted, it will have other statuses to indicate how the conflict happened. I choose to use status-conflicted instead of trying to represent those statuses, which I think makes the most sense. This bubbles up to directories: a directory is conflicted if any files in it are. However, I use the same color for conflicted (red) as for untracked, so maybe I should add italics or something. Suggestions welcome.

Ideally, some of this code should be moved to git-utils. git-utils doesn't expose much right now. That might be a nice followup, but it feels like a bad idea to try and make the change in git-utils first, without a downstream consumer, and it seems easier and more productive to get this into tree-view first. That's why I didn't refactor the git status code too much. Happy to revisit this if you folks don't like. (I will say that after many years of contributing code to multi-repo projects, I feel there's a real risk of being asked to make the change upstream first, and then being told that there's no consumers yet, so make it downstream. I would really like to avoid this 😄) 

There is some eventing code that will now receive an array instead of a status. It's undocumented so I presume that not much uses it (I tried to use it in my package and it seemed flaky, but hard to tell). It doesn't break any of the other git tools I use, but if there's a better way to address this, I'm all ears.

For some reason, status-unmodified is never reported. I'm looking into that now, but since I don't style it, it makes no functional difference for now.

~~Currently, the selected file (in one-dark-ui at least) doesn't show the status color. I think we should change that, but I'm not sure how. Punting for now.~~ NVM, this seems to work fine :)

OK, I think that's everything. Would love as much feedback as possible before I invest a lot of time in testing it :)


