### PR TITLE
Add "Sort By Case" option

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -171,7 +171,12 @@ class Directory
       names = fs.readdirSync(@path)
     catch error
       names = []
-    names.sort(new Intl.Collator(undefined, {numeric: true, sensitivity: "base"}).compare)
+
+    localizedCompare = new Intl.Collator(undefined, {numeric: true, sensitivity: "base"}).compare
+    if atom.config.get('tree-view.sortByCase')
+      @sortByCase(names, localizedCompare)
+    else
+      names.sort(localizedCompare)
 
     files = []
     directories = []
@@ -209,6 +214,30 @@ class Directory
     if normalizedValue?
       normalizedValue = normalizedValue.toLowerCase()
     normalizedValue
+
+  sortByCase: (names, localizedCompare) ->
+    # We want uppercase characters to be treated as "less than" lowercase characters, e.g.:
+    #   ["FOO", "Foo", "foo"]
+    # Everything but uppercase vs. lowercase is handled by the localized compare function.
+    uppercaseRegExp = /[A-Z]/
+    lowercaseRegExp = /[a-z]/
+    names.sort((a, b) ->
+      for i in [0...Math.min(a.length, b.length)]
+        aCharIsUppercase = uppercaseRegExp.test(a[i])
+        aCharIsLowercase = lowercaseRegExp.test(a[i])
+        bCharIsUppercase = uppercaseRegExp.test(b[i])
+        bCharIsLowercase = lowercaseRegExp.test(b[i])
+        aCharIsLetter = aCharIsUppercase or aCharIsLowercase
+        bCharIsLetter = bCharIsUppercase or bCharIsLowercase
+        unless aCharIsLetter and bCharIsLetter
+          break
+        if aCharIsUppercase and bCharIsLowercase
+          return -1
+        if aCharIsLowercase and bCharIsUppercase
+          return 1
+
+      return localizedCompare(a, b)
+    )
 
   sortEntries: (combinedEntries) ->
     if atom.config.get('tree-view.sortFoldersBeforeFiles')

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -150,6 +150,8 @@ class TreeView extends View
       @updateRoots() if atom.config.get('tree-view.hideIgnoredNames')
     @disposables.add atom.config.onDidChange 'tree-view.showOnRightSide', ({newValue}) =>
       @onSideToggled(newValue)
+    @disposables.add atom.config.onDidChange 'tree-view.sortByCase', =>
+      @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.sortFoldersBeforeFiles', =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       "default": false,
       "description": "Show the tree view on the right side of the editor instead of the left."
     },
+    "sortByCase": {
+      "type": "boolean",
+      "default": false,
+      "description": "When listing directory items, list uppercase items first."
+    },
     "sortFoldersBeforeFiles": {
       "type": "boolean",
       "default": true,

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2966,6 +2966,59 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
 
+  describe "the sortByCase config option", ->
+    [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
+
+    beforeEach ->
+      rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
+
+      filePaths = [
+        path.join(rootDirPath, "README.md")
+        path.join(rootDirPath, "LICENSE")
+        path.join(rootDirPath, "index.html")
+        path.join(rootDirPath, "vector.svg")
+        path.join(rootDirPath, "Makefile")
+        path.join(rootDirPath, ".gitignore")
+      ]
+
+      filePaths.forEach (filePath) =>
+        fs.writeFileSync(filePath, "doesn't matter")
+
+      atom.project.setPaths([rootDirPath])
+
+    it "defaults to unset", ->
+      expect(atom.config.get("tree-view.sortByCase")).toBeFalsy()
+
+    it "sorts with case sensitivity if the option is set", ->
+      atom.config.set "tree-view.sortByCase", true
+
+      topLevelEntries = [].slice.call(treeView.roots[0].entries.children).map (element) ->
+        element.innerText
+
+      expect(topLevelEntries).toEqual([
+        ".gitignore"
+        "LICENSE"
+        "README.md"
+        "Makefile"
+        "index.html"
+        "vector.svg"
+      ])
+
+    it "sorts without case sensitivity if the option is unset", ->
+      atom.config.set "tree-view.sortByCase", false
+
+      topLevelEntries = [].slice.call(treeView.roots[0].entries.children).map (element) ->
+        element.innerText
+
+      expect(topLevelEntries).toEqual([
+        ".gitignore"
+        "index.html"
+        "LICENSE"
+        "Makefile"
+        "README.md"
+        "vector.svg"
+      ])
+
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
       atom.notifications.clear()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2919,7 +2919,6 @@ describe "TreeView", ->
 
       atom.project.setPaths([rootDirPath])
 
-
     it "defaults to set", ->
       expect(atom.config.get("tree-view.sortFoldersBeforeFiles")).toBeTruthy()
 
@@ -3336,14 +3335,14 @@ describe "TreeView", ->
 
 describe 'Icon class handling', ->
   [workspaceElement, treeView, files] = []
-  
+
   beforeEach ->
     rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
-    
+
     for i in [1..3]
       filepath = path.join(rootDirPath, "file-#{i}.txt")
       fs.writeFileSync(filepath, "Nah")
-    
+
     atom.project.setPaths([rootDirPath])
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -3358,11 +3357,11 @@ describe 'Icon class handling', ->
 
     waitsForPromise ->
       atom.packages.activatePackage('tree-view')
-    
+
     runs ->
       treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
       files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
-    
+
   afterEach ->
     temp.cleanup()
 


### PR DESCRIPTION
Re: https://github.com/atom/tree-view/issues/235, this PR adds an option to put uppercase file/dir names above lowercase ones, consistent with the GitHub web UI:

![tree-view-sort](https://cloud.githubusercontent.com/assets/224895/17467352/3dc63690-5ceb-11e6-9b07-4a264ce5d1be.gif)

Right now it only affects the relative sort order between characters in the `A-Z` and `a-z` ranges. It's probably desirable to extend that to a wider set of uppercase/lowercase characters (e.g. so that `ÃLPHA` comes before `omega`), but that would require some [very lengthy regexes](http://apps.timwhitlock.info/js/regex#). For the initial PR, I wanted to keep things simple.
