### PR TITLE
Guard against undefined path

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,7 +51,7 @@ module.exports =
     @treeView
 
   shouldAttach: ->
-    projectPath = atom.project.getPaths()[0]
+    projectPath = atom.project.getPaths()[0] ? ''
     if atom.workspace.getActivePaneItem()
       false
     else if path.basename(projectPath) is '.git'


### PR DESCRIPTION
Passing in `undefined` to `path` module functions results is no longer supported as of Node v6. This PR is part of the effort to upgrade Atom to run on the latest release of Electron (atom/atom#12300).