### PR TITLE
Try increasing test resiliency

### DIFF
--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3359,14 +3359,14 @@ describe "TreeView", ->
 
 describe 'Icon class handling', ->
   [workspaceElement, treeView, files] = []
-  
+
   beforeEach ->
     rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))
-    
+
     for i in [1..3]
       filepath = path.join(rootDirPath, "file-#{i}.txt")
       fs.writeFileSync(filepath, "Nah")
-    
+
     atom.project.setPaths([rootDirPath])
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -3382,11 +3382,11 @@ describe 'Icon class handling', ->
 
     waitsForPromise ->
       atom.packages.activatePackage('tree-view')
-    
+
     runs ->
       treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
       files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
-    
+
   afterEach ->
     temp.cleanup()
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -583,9 +583,10 @@ describe "TreeView", ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
         .not.toThrow()
 
-        # Ensure we don't move on to the next test until the promise spawned click event resolves.
-        # (If it resolves in the middle of the next test we'll pollute that test)
-        waitsForPromise -> treeView.currentlyOpening.get(atom.workspace.getActivePaneItem().getPath())
+        waitsFor ->
+          # Ensure we don't move on to the next test until the promise spawned click event resolves.
+          # (If it resolves in the middle of the next test we'll pollute that test).
+          not treeView.currentlyOpening.has(atom.workspace.getActivePaneItem().getPath())
 
     describe "when the file is pending", ->
       editor = null


### PR DESCRIPTION
Sometimes `treeView.currentlyOpening` doesn't contain the expected `Promise`, thus causing failures like the one in https://circleci.com/gh/atom/atom/841. It's possible that such `Promise` finishes before the test has the chance to call `then` on it, thus causing it to be removed from that `Map` (see https://github.com/atom/tree-view/blob/06bdfae/lib/tree-view.coffee#L223).

With this pull-request, we'll now simply wait until that `Promise` is removed from the `currentlyOpening` `Map`, which should be more resilient.