### PR TITLE
Avoid breaking when calling lstat on virtual paths

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -276,6 +276,7 @@ class TreeView extends View
 
     @roots = for projectPath in atom.project.getPaths()
       stats = fs.lstatSyncNoException(projectPath)
+      continue unless stats
       stats = _.pick stats, _.keys(stats)...
       for key in ["atime", "birthtime", "ctime", "mtime"]
         stats[key] = stats[key].getTime()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -275,8 +275,7 @@ class TreeView extends View
     @loadIgnoredPatterns()
 
     @roots = for projectPath in atom.project.getPaths()
-      stats = fs.lstatSyncNoException(projectPath)
-      continue unless stats
+      continue unless stats = fs.lstatSyncNoException(projectPath)
       stats = _.pick stats, _.keys(stats)...
       for key in ["atime", "birthtime", "ctime", "mtime"]
         stats[key] = stats[key].getTime()

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -5,30 +5,31 @@ path = require 'path'
 temp = require('temp').track()
 
 describe "FileStats", ->
-  [file1Data, file2Data, timeStarted, treeView] = ["ABCDEFGHIJKLMNOPQRSTUVWXYZ", "0123456789"]
-  
-  beforeEach ->
-    timeStarted = Date.now()
-    rootDirPath = fs.absolute(temp.mkdirSync("tree-view"))
-    subdirPath = path.join(rootDirPath, "subdir")
-    filePath1 = path.join(rootDirPath, "file1.txt")
-    filePath2 = path.join(subdirPath, "file2.txt")
-
-    fs.makeTreeSync(subdirPath)
-    fs.writeFileSync(filePath1, file1Data)
-    fs.writeFileSync(filePath2, file2Data)
-    atom.project.setPaths([rootDirPath])
-    
-    waitsForPromise ->
-      atom.packages.activatePackage("tree-view")
-  
-    runs ->
-      treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
-      
-  afterEach ->
-    temp.cleanup()
 
   describe "provision of filesystem stats", ->
+    [file1Data, file2Data, timeStarted, treeView] = ["ABCDEFGHIJKLMNOPQRSTUVWXYZ", "0123456789"]
+
+    beforeEach ->
+      timeStarted = Date.now()
+      rootDirPath = fs.absolute(temp.mkdirSync("tree-view"))
+      subdirPath = path.join(rootDirPath, "subdir")
+      filePath1 = path.join(rootDirPath, "file1.txt")
+      filePath2 = path.join(subdirPath, "file2.txt")
+
+      fs.makeTreeSync(subdirPath)
+      fs.writeFileSync(filePath1, file1Data)
+      fs.writeFileSync(filePath2, file2Data)
+      atom.project.setPaths([rootDirPath])
+
+      waitsForPromise ->
+        atom.packages.activatePackage("tree-view")
+
+      runs ->
+        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+
+    afterEach ->
+      temp.cleanup()
+
     it "passes stats to File instances", ->
       stats = treeView.roots[0].directory.entries["file1.txt"].stats
       expect(stats).toBeDefined()
@@ -39,25 +40,36 @@ describe "FileStats", ->
       stats = treeView.roots[0].directory.entries["subdir"].stats
       expect(stats).toBeDefined()
       expect(stats.mtime).toBeDefined()
-    
+
     it "passes stats to a root directory when initialised", ->
       expect(treeView.roots[0].directory.stats).toBeDefined()
-    
+
     it "passes stats to File instances in subdirectories", ->
       treeView.find(".entries > li:contains(subdir)")[0].expand()
       subdir = treeView.roots[0].directory.entries["subdir"]
       stats = subdir.entries["file2.txt"].stats
       expect(stats).toBeDefined()
       expect(stats.size).toEqual(file2Data.length)
-    
+
     it "converts date-stats to timestamps", ->
       stats = treeView.roots[0].directory.entries["file1.txt"].stats
       stamp = stats.mtime
       expect(_.isDate stamp).toBe(false)
       expect(typeof stamp).toBe("number")
       expect(Number.isNaN stamp).toBe(false)
-    
+
     it "accurately converts timestamps", ->
       stats = treeView.roots[0].directory.entries["file1.txt"].stats
       # Two minutes should be enough
       expect(Math.abs stats.mtime - timeStarted).toBeLessThan(120000)
+
+  describe "virtual filepaths", ->
+    beforeEach ->
+      atom.project.setPaths([])
+      waitsForPromise -> Promise.all [
+        atom.packages.activatePackage("tree-view")
+        atom.packages.activatePackage("about")
+      ]
+
+    it "doesn't throw an exception when accessing virtual filepaths", ->
+      atom.project.setPaths(["atom://about"])


### PR DESCRIPTION
This should fix atom/tree-view#927.

To bottom-line it: if you open Atom's `about` view in a blank workspace window, it adds the `atom://about/` opener URI to the list of project paths. I didn't even know it was possible to add a project that wasn't a real filesystem path, so I didn't factor that in when working on #859.

Anyway, if a spec is needed for this, please tell me exactly where it should go (in which spec-file, suite, etc).