### PR TITLE
Add Ability to Expand Dragged Over Directory

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -866,6 +866,16 @@ class TreeView extends View
   onDragOver: (e) ->
     e.preventDefault()
     e.stopPropagation()
+    
+    # Toggle Expand/Collapse with Ctrl Key
+    target = e.currentTarget
+    return unless target instanceof DirectoryView
+
+    if e.ctrlKey
+      if not target.classList.contains "expanded"
+        target.expand()
+      else
+        target.collapse()
 
   # Handle entry drop event
   onDrop: (e) ->


### PR DESCRIPTION
![expandhoveredfolders](https://cloud.githubusercontent.com/assets/362627/18290264/22e0db8c-7483-11e6-803b-f59a8895ddb2.gif)

Ideally this would happen automatically but at the moment I've implemented it simply by listening for the 'Ctrl' key to toggle the directory status between expand and collapse.  This is by no means finished or an ideal solution.

I'm just putting this up here in the hopes of starting a discussion about this feature.
