### PR TITLE
Bolding file name if it’s not staged.

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -58,8 +58,9 @@ class DirectoryView extends HTMLElement
     @expand() if @directory.expansionState.isExpanded
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified', 'status-added')
+    @classList.remove('status-ignored', 'status-modified', 'status-added', 'status-unstaged')
     @classList.add("status-#{@directory.status}") if @directory.status?
+    @classList.add("status-unstaged") if @directory.staged == false
 
   subscribeToDirectory: ->
     @subscriptions.add @directory.onDidAddEntries (addedEntries) =>

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -88,6 +88,7 @@ class Directory
     return unless repo?
 
     newStatus = null
+    newStaged = null
     if repo.isPathIgnored(@path)
       newStatus = 'ignored'
     else
@@ -97,8 +98,15 @@ class Directory
       else if repo.isStatusNew(status)
         newStatus = 'added'
 
-    if newStatus isnt @status
+      try
+        newStaged = repo.isStatusStaged(status) unless not status
+      catch error
+        # While git doesn’t expose isStatusStaged method
+        newStaged = (status & 15) > 0 unless not status
+
+    if newStatus isnt @status or newStaged isnt @staged
       @status = newStatus
+      @staged = newStaged
       @emitter.emit('did-status-change', newStatus)
 
   # Is the given path ignored?

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -29,8 +29,9 @@ class FileView extends HTMLElement
     @updateStatus()
 
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified',  'status-added')
+    @classList.remove('status-ignored', 'status-modified',  'status-added', 'status-unstaged')
     @classList.add("status-#{@file.status}") if @file.status?
+    @classList.add("status-unstaged") if @file.staged == false
 
   getPath: ->
     @fileName.dataset.path

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -52,6 +52,7 @@ class File
     return unless repo?
 
     newStatus = null
+    newStaged = null
     if repo.isPathIgnored(@path)
       newStatus = 'ignored'
     else
@@ -61,8 +62,15 @@ class File
       else if repo.isStatusNew(status)
         newStatus = 'added'
 
-    if newStatus isnt @status
+      try
+        newStaged = repo.isStatusStaged(status) unless not status
+      catch error
+        # While git doesn’t expose isStatusStaged method
+        newStaged = (status & 15) > 0 unless not status
+
+    if newStatus isnt @status or newStaged isnt @staged
       @status = newStatus
+      @staged = newStaged
       @emitter.emit('did-status-change', newStatus)
 
   isPathEqual: (pathToCompare) ->

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -93,3 +93,9 @@
     }
   }
 }
+
+.status-unstaged {
+  & > div, & > span {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
As mentioned in these issues across Atom repositories:

- https://github.com/atom/tree-view/issues/430
- https://github.com/atom/atom/issues/8529

I found it difficult to choose a new color schema to identify unstaged files so I’ve just **bolded** the filename to identify files not staged yet. 

I maintain a plugin called [atom-hg](https://github.com/victor-torres/atom-hg) and my `isStatusStaged` method is already exposed. There’s a method with the same name in [git-utils](https://github.com/atom/git-utils/blob/v3.0.0/src/git.coffee)  but it doesn’t seem to be exposed yet so I manually added the same verification as a fallback (`(status & 15) > 0`). 

It would help a lot because we’ll finally have a clue whether a file is staged or not.