### PR TITLE
Fix scrolling performance issues in tree-view

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -46,6 +46,7 @@
   flex: 1;
   width: 100%;
   overflow: auto;
+  will-change: transform;
 }
 
 .tree-view {


### PR DESCRIPTION
Part of fix for atom/atom#12949.

Forces Chromium to use the compositor to render scroll containers. This greatly decreases CPU usage when scrolling.