### PR TITLE
Collapse all directories recursively

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -62,7 +62,6 @@
   'l': 'tree-view:expand-item'
   'left': 'tree-view:collapse-directory'
   'ctrl-[': 'tree-view:collapse-directory'
-  'ctrl-r': 'tree-view:collapse-all'
   'alt-ctrl-]': 'tree-view:recursive-expand-directory'
   'alt-right': 'tree-view:recursive-expand-directory'
   'alt-ctrl-[': 'tree-view:recursive-collapse-directory'

--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -62,6 +62,7 @@
   'l': 'tree-view:expand-item'
   'left': 'tree-view:collapse-directory'
   'ctrl-[': 'tree-view:collapse-directory'
+  'ctrl-r': 'tree-view:collapse-all'
   'alt-ctrl-]': 'tree-view:recursive-expand-directory'
   'alt-right': 'tree-view:recursive-expand-directory'
   'alt-ctrl-[': 'tree-view:recursive-collapse-directory'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -180,6 +180,7 @@ class TreeView
      'tree-view:recursive-expand-directory': => @expandDirectory(true)
      'tree-view:collapse-directory': => @collapseDirectory()
      'tree-view:recursive-collapse-directory': => @collapseDirectory(true)
+     'tree-view:collapse-all': => @collapseDirectory(true, true)
      'tree-view:open-selected-entry': => @openSelectedEntry()
      'tree-view:open-selected-entry-right': => @openSelectedEntryRight()
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
@@ -197,7 +198,6 @@ class TreeView
      'tree-view:toggle-vcs-ignored-files': -> toggleConfig 'tree-view.hideVcsIgnoredFiles'
      'tree-view:toggle-ignored-names': -> toggleConfig 'tree-view.hideIgnoredNames'
      'tree-view:remove-project-folder': (e) => @removeProjectFolder(e)
-     'tree-view:collapse-all': => @collapseAll()
 
     [0..8].forEach (index) =>
       atom.commands.add @element, "tree-view:open-selected-entry-in-pane-#{index + 1}", =>
@@ -218,9 +218,6 @@ class TreeView
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>
       @updateRoots()
-
-  collapseAll: ->
-    root.collapse(true) for root in @roots
 
   toggle: ->
     atom.workspace.toggle(this)
@@ -440,11 +437,13 @@ class TreeView
     else
       directory.expand(isRecursive)
 
-  collapseDirectory: (isRecursive=false) ->
+  collapseDirectory: (isRecursive=false, allDirectories=false) ->
     selectedEntry = @selectedEntry()
     return unless selectedEntry?
 
-    if directory = selectedEntry.closest('.expanded.directory')
+    if allDirectories
+      root.collapse(true) for root in @roots
+    else if directory = $(selectedEntry).closest('.expanded.directory')[0]
       directory.collapse(isRecursive)
       @selectEntry(directory)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -197,6 +197,7 @@ class TreeView
      'tree-view:toggle-vcs-ignored-files': -> toggleConfig 'tree-view.hideVcsIgnoredFiles'
      'tree-view:toggle-ignored-names': -> toggleConfig 'tree-view.hideIgnoredNames'
      'tree-view:remove-project-folder': (e) => @removeProjectFolder(e)
+     'tree-view:collapse-all': => @collapseAll()
 
     [0..8].forEach (index) =>
       atom.commands.add @element, "tree-view:open-selected-entry-in-pane-#{index + 1}", =>
@@ -217,6 +218,9 @@ class TreeView
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>
       @updateRoots()
+
+  collapseAll: ->
+    root.collapse(true) for root in @roots
 
   toggle: ->
     atom.workspace.toggle(this)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -443,7 +443,7 @@ class TreeView
 
     if allDirectories
       root.collapse(true) for root in @roots
-    else if directory = $(selectedEntry).closest('.expanded.directory')[0]
+    else if directory = selectedEntry.closest('.expanded.directory')
       directory.collapse(isRecursive)
       @selectEntry(directory)
 

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -64,6 +64,7 @@
 
     {'label': 'Add Project Folder', 'command': 'application:add-project-folder'}
     {'label': 'Remove Project Folder', 'command': 'tree-view:remove-project-folder'}
+    {'label': 'Collapse All Project Folders', 'command': 'tree-view:collapse-all'}
     {'type': 'separator'}
 
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1155,14 +1155,25 @@ describe "TreeView", ->
           expect(treeView.roots[0]).toHaveClass 'expanded'
 
     describe "tree-view:collapse-all", ->
-      it "collapses all the project directories", ->
-        expect(treeView.roots[0]).toHaveClass 'expanded'
-        expect(treeView.roots[1]).toHaveClass 'expanded'
+      expandAll = ->
+        for root in treeView.roots
+          root.expand(true)
+          children = $(root).find('.directory')
+          children.each (index, child) ->
+            expect(child).toHaveClass 'expanded'
+          expect(root).toHaveClass 'expanded'
 
+      checkAllCollapsed = ->
+        for root in treeView.roots
+          children = $(root).find('.directory')
+          children.each (index, child) ->
+            expect(child).not.toHaveClass 'expanded'
+          expect(root).not.toHaveClass 'expanded'
+
+      it "collapses all the project directories recursively", ->
+        expandAll()
         atom.commands.dispatch(treeView.element, 'tree-view:collapse-all')
-
-        expect(treeView.roots[0]).not.toHaveClass 'expanded'
-        expect(treeView.roots[1]).not.toHaveClass 'expanded'
+        checkAllCollapsed()
 
     describe "tree-view:open-selected-entry", ->
       describe "when a file is selected", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1158,15 +1158,15 @@ describe "TreeView", ->
       expandAll = ->
         for root in treeView.roots
           root.expand(true)
-          children = $(root).find('.directory')
-          children.each (index, child) ->
+          children = root1.querySelectorAll('.directory')
+          for child in children
             expect(child).toHaveClass 'expanded'
           expect(root).toHaveClass 'expanded'
 
       checkAllCollapsed = ->
         for root in treeView.roots
-          children = $(root).find('.directory')
-          children.each (index, child) ->
+          children = root1.querySelectorAll('.directory')
+          for child in children
             expect(child).not.toHaveClass 'expanded'
           expect(root).not.toHaveClass 'expanded'
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1154,6 +1154,16 @@ describe "TreeView", ->
             expect(child).not.toHaveClass 'expanded'
           expect(treeView.roots[0]).toHaveClass 'expanded'
 
+    describe "tree-view:collapse-all", ->
+      it "collapses all the project directories", ->
+        expect(treeView.roots[0]).toHaveClass 'expanded'
+        expect(treeView.roots[1]).toHaveClass 'expanded'
+
+        atom.commands.dispatch(treeView.element, 'tree-view:collapse-all')
+
+        expect(treeView.roots[0]).not.toHaveClass 'expanded'
+        expect(treeView.roots[1]).not.toHaveClass 'expanded'
+
     describe "tree-view:open-selected-entry", ->
       describe "when a file is selected", ->
         it "opens the file in the editor and focuses it", ->


### PR DESCRIPTION
Implementation of **shortcut to collapse all directories recursively** #960 .

~`ctrl-r` shortcut for recursively collaping all the directories.~

![tree-view-collapse-all](https://cloud.githubusercontent.com/assets/614105/20033731/eb8c6186-a3cd-11e6-9b43-80576e39cf37.gif)
