### PR TITLE
🐛 Avoid attaching tree view on reveal-active-file

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -315,7 +315,6 @@ class TreeView extends View
   revealActiveFile: ->
     return if _.isEmpty(atom.project.getPaths())
 
-    @attach()
     @focus() if atom.config.get('tree-view.focusOnReveal')
 
     return unless activeFilePath = @getActivePath()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -408,6 +408,16 @@ describe "TreeView", ->
             expect(treeView.hasParent()).toBeTruthy()
             expect(treeView.focus).not.toHaveBeenCalled()
 
+      describe "if tree view is hidden", ->
+        it "tree view remains hidden", ->
+          waitsForPromise ->
+            atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+
+          runs ->
+            expect(atom.workspace.getLeftPanels().length).toBe(0)
+            atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
+            expect(atom.workspace.getLeftPanels().length).toBe(0)
+
     describe "if the current file has no path", ->
       it "shows and focuses the tree view, but does not attempt to select a specific file", ->
         waitsForPromise ->
@@ -441,6 +451,9 @@ describe "TreeView", ->
         jasmine.attachToDOM(workspaceElement)
 
       it 'scrolls the selected file into the visible view', ->
+        treeView.attach()
+        expect(atom.workspace.getLeftPanels().length).toBe(1)
+
         # Open file at bottom
         waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-20.txt'))
         runs ->


### PR DESCRIPTION
Fix for #796 

![reveal-active-file](https://cloud.githubusercontent.com/assets/614105/20245091/6f52ed64-a9be-11e6-8698-7522fec0beb6.gif)
