### PR TITLE
🐛 Deleting squashed directory

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -565,7 +565,7 @@ class TreeView extends View
       message: "Are you sure you want to delete the selected #{if selectedPaths.length > 1 then 'items' else 'item'}?"
       detailedMessage: "You are deleting:\n#{selectedPaths.join('\n')}"
       buttons:
-        "Move to Trash": ->
+        "Move to Trash": =>
           failedDeletions = []
           for selectedPath in selectedPaths
             if not shell.moveItemToTrash(selectedPath)
@@ -576,6 +576,7 @@ class TreeView extends View
             atom.notifications.addError "The following #{if failedDeletions.length > 1 then 'files' else 'file'} couldn't be moved to trash#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
+          @updateRoots()
         "Cancel": null
 
   # Public: Copy the path of the selected entry element.

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2507,6 +2507,9 @@ describe "TreeView", ->
       xiDirPath1 = path.join(muDirPath, "xi")
       xiDirPath2 = path.join(nuDirPath, "xi")
 
+      omicronDirPath = path.join(rootDirPath, "omicron")
+      piDirPath = path.join(omicronDirPath, "pi")
+
       fs.makeTreeSync(zetaDirPath)
       fs.writeFileSync(zetaFilePath, "doesn't matter")
 
@@ -2527,6 +2530,9 @@ describe "TreeView", ->
       fs.makeTreeSync(nuDirPath)
       fs.makeTreeSync(xiDirPath1)
       fs.makeTreeSync(xiDirPath2)
+
+      fs.makeTreeSync(omicronDirPath)
+      fs.makeTreeSync(piDirPath)
 
       atom.project.setPaths([rootDirPath])
 
@@ -2568,6 +2574,19 @@ describe "TreeView", ->
           element.innerText
 
         expect(lambdaEntries).toEqual(["iota", "kappa"])
+
+      describe "when a squashed directory is deleted", ->
+        it "un-squashes the directories", ->
+          jasmine.attachToDOM(workspaceElement)
+          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          treeView.focus()
+          treeView.selectEntry(piDir)
+          spyOn(atom, 'confirm').andCallFake (dialog) ->
+            dialog.buttons["Move to Trash"]()
+          atom.commands.dispatch(treeView.element, 'tree-view:remove')
+
+          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
+          expect(omicronDir.title).toEqual("omicron")
 
       describe "when a directory is reloaded", ->
         it "squashes the directory names the last of which is same as an unsquashed directory", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Calling `@updateRoots()` after the deletion of a squashed directory refresh the view and solves the bug in #1005.

### Alternate Designs

-

### Benefits

It solves a bug. The expected behavior after deleting a directory is to make it disappear from the tree view. That's possible with this pull request. The current behavior is that the directory is deleted in the file system but the tree view keeps showing the un-existing directory.

### Possible Drawbacks

-

### Applicable Issues

#1005 #799 
