### PR TITLE
Close files within the tree view

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -25,8 +25,24 @@ class FileView extends HTMLElement
         iconClass = iconClass.toString().split(/\s+/g)
       @fileName.classList.add(iconClass...)
 
+    @fileCloser = document.createElement('span')
+    @fileCloser.classList.add('icon-x')
+
+    @subscriptions.add @file.onDidOpen => @open()
+    @subscriptions.add @file.onDidClose => @close()
     @subscriptions.add @file.onDidStatusChange => @updateStatus()
     @updateStatus()
+
+  open: ->
+    @appendChild(@fileCloser)
+    @fileCloser.onclick = => @closeFile(@fileName.dataset.path)
+
+  close: ->
+    @removeChild(@fileCloser)
+  
+  closeFile: (path) ->
+    atom.workspace.textEditorRegistry.editors.forEach (editor) ->
+      editor.destroy() if editor.getPath() is path
 
   updateStatus: ->
     @classList.remove('status-ignored', 'status-modified',  'status-added')

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -30,11 +30,23 @@ class File
     @subscriptions.dispose()
     @emitter.emit('did-destroy')
 
+  open: ->
+    @emitter.emit('did-open')
+
+  close: ->
+    @emitter.emit('did-close')
+
   onDidDestroy: (callback) ->
     @emitter.on('did-destroy', callback)
 
   onDidStatusChange: (callback) ->
     @emitter.on('did-status-change', callback)
+
+  onDidOpen: (callback) ->
+    @emitter.on('did-open', callback)
+
+  onDidClose: (callback) ->
+    @emitter.on('did-close', callback)
 
   # Subscribe to the project's repo for changes to the Git status of this file.
   subscribeToRepo: ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -65,6 +65,9 @@ class TreeView extends View
     @width(state.width) if state.width > 0
     @attach() if state.attached
 
+    @disposables.add atom.workspace.observeTextEditors (editor) =>
+      @onFileOpened(editor)
+
   attached: ->
     @focus() if @focusAfterAttach
     @scroller.scrollLeft(@scrollLeftAfterAttach) if @scrollLeftAfterAttach > 0
@@ -158,6 +161,14 @@ class TreeView extends View
     @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>
       @updateRoots()
 
+  onFileOpened: (editor) ->
+    filePath = editor.getPath()
+    entry = @entryForPath(filePath)
+    if entry? and entry.file?
+      file = entry.file
+      @disposables.add editor.onDidDestroy => file.close()
+      file.open()
+      
   toggle: ->
     if @isVisible()
       @detach()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -664,13 +664,34 @@ describe "TreeView", ->
           runs ->
             expect(atom.workspace.getActivePane().getItems().length).toBe 1
 
+      describe "when the icon-x is clicked", ->
+        it "closes the file and the icon-x disappears", ->
+          waitsForFileToOpen ->
+            sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+            sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+
+          runs ->
+            initialTextEditorsOpened = atom.workspace.textEditorRegistry.editors.size
+            treeView.focus()
+            activePaneItem = atom.workspace.getActivePaneItem()
+            file = treeView.entryForPath(activePaneItem.getPath())
+            iconX = file.lastChild
+            # Conditions before click icon-x
+            expect(iconX.className).toBe('icon-x')
+            expect(atom.workspace.textEditorRegistry.editors.size).toBe(initialTextEditorsOpened)
+
+            iconX.click()
+            # Conditions after click icon-x
+            expect(atom.workspace.textEditorRegistry.editors.size).toBe(initialTextEditorsOpened - 1)
+            expect(file.lastChild).not.toBe('icon-x')
+
     describe "when a file is double-clicked", ->
       activePaneItem = null
 
       beforeEach ->
         treeView.focus()
 
-      it "opens the file and focuses it", ->
+      it "opens the file, shows icon-x and focuses it", ->
         waitsForFileToOpen ->
           sampleJs.trigger clickEvent(originalEvent: {detail: 1})
           sampleJs.trigger clickEvent(originalEvent: {detail: 2})
@@ -682,6 +703,9 @@ describe "TreeView", ->
           activePaneItem = atom.workspace.getActivePaneItem()
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
           expect(atom.views.getView(activePaneItem)).toHaveFocus()
+          file = treeView.entryForPath(activePaneItem.getPath())
+          iconX = file.lastChild
+          expect(iconX.className).toBe('icon-x')
 
       it "does not open a duplicate file", ->
         # Fixes https://github.com/atom/atom/issues/11391

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -79,6 +79,25 @@
 
   .list-tree {
     position: static;
+
+    .file {
+      position: relative;
+
+      .name {
+        padding-right: 30px;
+      }
+
+      .icon-x {
+        position: absolute;
+        top: 1px;
+        right: 10px;
+        cursor: default;
+
+        &:hover {
+          color: @background-color-info;
+        }
+      }
+    }
   }
 
   .entry {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Adds a new feature. When a file is opened an icon (icon-x) is shown on the right of the file name in the tree view. If this icon is clicked the file gets closed.

![](http://g.recordit.co/2Aa7TYfRpV.gif)

### Alternate Designs

-

### Benefits

New feature.

### Possible Drawbacks

-

### Applicable Issues

#1003 
