### PR TITLE
Cover trash failures for macOS and Windows with a message

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -588,7 +588,7 @@ class TreeView extends View
     switch process.platform
       when 'linux' then 'Is `gvfs-trash` installed?'
       when 'darwin' then 'Is Trash enabled on the volume where the files are stored?'
-      when 'win32' then 'Is RecycleBin support enabled on the drive where the files are stored?'
+      when 'win32' then 'Is there a Recycle Bin on the drive where the files are stored?'
 
   # Public: Copy the path of the selected entry element.
   #         Save the path in localStorage, so that copying from 2 different

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -573,11 +573,22 @@ class TreeView extends View
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)
           if failedDeletions.length > 0
-            atom.notifications.addError "The following #{if failedDeletions.length > 1 then 'files' else 'file'} couldn't be moved to trash#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
+            atom.notifications.addError @formatTrashFailureMessage(failedDeletions),
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
           @updateRoots()
         "Cancel": null
+
+  formatTrashFailureMessage: (failedDeletions) ->
+    fileText = if failedDeletions.length > 1 then 'files' else 'file'
+
+    "The following #{fileText} couldn't be moved to the trash. #{@formatTrashEnabledMessage()}"
+
+  formatTrashEnabledMessage: ->
+    switch process.platform
+      when 'linux' then 'Is `gvfs-trash` installed?'
+      when 'darwin' then 'Is Trash enabled on the volume where the files are stored?'
+      when 'win32' then 'Is RecycleBin support enabled on the drive where the files are stored?'
 
   # Public: Copy the path of the selected entry element.
   #         Save the path in localStorage, so that copying from 2 different

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2351,7 +2351,7 @@ describe "TreeView", ->
           expect(notificationsNumber).toBe 1
           if notificationsNumber is 1
             notification = atom.notifications.getNotifications()[0]
-            expect(notification.getMessage()).toContain 'The following file couldn\'t be moved to trash'
+            expect(notification.getMessage()).toContain 'The following file couldn\'t be moved to the trash'
             expect(notification.getDetail()).toContain 'test-file.txt'
 
       it "does nothing when no file is selected", ->


### PR DESCRIPTION
### Description of the Change

Deleting files from the Tree View can fail if the volume, drive or share doesn't support the platform's implementation of a "trash". Because this occurs much more frequently on Linux, we previously covered this with an enhanced error message in https://github.com/atom/tree-view/pull/695. This problem can still occur on Windows or macOS though and people on those platforms deserve a better error message to give them some idea of why Atom is unable to delete their files for them.

### Alternate Designs

Considered returning more information from Electron's [`shell.moveItemToTrash` function](http://electron.atom.io/docs/all/#shellmoveitemtotrashfullpath) so that it could be detected if it was truly a trash problem or some other failure to delete the file. Adding support for better error conditions in a cross-platform way is beyond the scope of my time and abilities though, so this is what I opted for.

### Benefits

* People will get a less cryptic error message

### Possible Drawbacks

* The error message still may not point them in the right direction

### Applicable Issues

* #856 
* https://discuss.atom.io/t/can-not-delete-files-from-tree-view/37639

