### PR TITLE
🐛 🐎 Creating a file/directory un-squashes the tree-view

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -664,9 +664,11 @@ class TreeView extends View
     dialog.on 'directory-created', (event, createdPath) =>
       @entryForPath(createdPath)?.reload()
       @selectEntryForPath(createdPath)
+      @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
       false
-    dialog.on 'file-created', (event, createdPath) ->
+    dialog.on 'file-created', (event, createdPath) =>
       atom.workspace.open(createdPath)
+      @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
       false
     dialog.attach()
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -576,7 +576,7 @@ class TreeView extends View
             atom.notifications.addError "The following #{if failedDeletions.length > 1 then 'files' else 'file'} couldn't be moved to trash#{if process.platform is 'linux' then " (is `gvfs-trash` installed?)" else ""}",
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
-          @updateRoots()
+          @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
         "Cancel": null
 
   # Public: Copy the path of the selected entry element.

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2588,6 +2588,43 @@ describe "TreeView", ->
           omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
           expect(omicronDir.title).toEqual("omicron")
 
+      describe "when a file is created within a directory with another squashed directory", ->
+        it "un-squashes the directories", ->
+          jasmine.attachToDOM(workspaceElement)
+          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          expect(piDir).not.toBeNull()
+          omicronPath = piDir.getPath().replace "/pi", ""
+          sigmaFilePath = path.join(omicronPath, "sigma.txt")
+          fs.writeFileSync(sigmaFilePath, "doesn't matter")
+          treeView.updateRoots()
+
+          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
+          expect(omicronDir.title).toEqual("omicron")
+          omicronDir.click()
+          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
+          expect(piDir.title).toEqual("pi")
+          sigmaFile = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .file:contains(sigma) span")[0]
+          expect(sigmaFile.title).toEqual("sigma.txt")
+
+      describe "when a directory is created within a directory with another squashed directory", ->
+        it "un-squashes the directories", ->
+          jasmine.attachToDOM(workspaceElement)
+          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          expect(piDir).not.toBeNull()
+          omicronPath = piDir.getPath().replace "/pi", ""
+          rhoDirPath = path.join(omicronPath, "rho")
+          fs.makeTreeSync(rhoDirPath)
+          treeView.updateRoots()
+
+          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
+          expect(omicronDir.title).toEqual("omicron")
+          omicronDir.click()
+          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
+          expect(piDir.title).toEqual("pi")
+          rhoDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(rho) span")[0]
+          expect(rhoDir.title).toEqual("rho")
+
+
       describe "when a directory is reloaded", ->
         it "squashes the directory names the last of which is same as an unsquashed directory", ->
           muDir = $(treeView.roots[0].entries).find('.directory:contains(mu):first')

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2593,6 +2593,7 @@ describe "TreeView", ->
           jasmine.attachToDOM(workspaceElement)
           piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
           expect(piDir).not.toBeNull()
+          # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
           sigmaFilePath = path.join(omicronPath, "sigma.txt")
           fs.writeFileSync(sigmaFilePath, "doesn't matter")
@@ -2611,6 +2612,7 @@ describe "TreeView", ->
           jasmine.attachToDOM(workspaceElement)
           piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
           expect(piDir).not.toBeNull()
+          # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
           rhoDirPath = path.join(omicronPath, "rho")
           fs.makeTreeSync(rhoDirPath)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2593,7 +2593,7 @@ describe "TreeView", ->
           jasmine.attachToDOM(workspaceElement)
           piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
           expect(piDir).not.toBeNull()
-          omicronPath = piDir.getPath().replace "/pi", ""
+          omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
           sigmaFilePath = path.join(omicronPath, "sigma.txt")
           fs.writeFileSync(sigmaFilePath, "doesn't matter")
           treeView.updateRoots()
@@ -2611,7 +2611,7 @@ describe "TreeView", ->
           jasmine.attachToDOM(workspaceElement)
           piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
           expect(piDir).not.toBeNull()
-          omicronPath = piDir.getPath().replace "/pi", ""
+          omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
           rhoDirPath = path.join(omicronPath, "rho")
           fs.makeTreeSync(rhoDirPath)
           treeView.updateRoots()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2624,7 +2624,6 @@ describe "TreeView", ->
           rhoDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(rho) span")[0]
           expect(rhoDir.title).toEqual("rho")
 
-
       describe "when a directory is reloaded", ->
         it "squashes the directory names the last of which is same as an unsquashed directory", ->
           muDir = $(treeView.roots[0].entries).find('.directory:contains(mu):first')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This pull request solves a bug mentioned in #702. When creating a file/directory within a squashed directory it gets un-squashed (since the directory will contain more than one item in it).

Also improves performance of PR #1008 calling `updateRoots()` only if necessary (if the squash config key is set to `true`). I've decided to introduce this change in the same pull request since it's highly related with the bug-fix.

### Alternate Designs

-

### Benefits

Solves a bug

### Possible Drawbacks

-

### Applicable Issues

#702 
