### PR TITLE
🐛 Prevent root directories to be squashed

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -14,7 +14,7 @@ class Directory
     @emitter = new Emitter()
     @subscriptions = new CompositeDisposable()
 
-    if atom.config.get('tree-view.squashDirectoryNames')
+    if atom.config.get('tree-view.squashDirectoryNames') and not @isRoot
       fullPath = @squashDirectoryNames(fullPath)
 
     @path = fullPath

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2543,7 +2543,7 @@ describe "TreeView", ->
       beforeEach ->
         atom.config.set('tree-view.squashDirectoryNames', true)
 
-      it "it does not squash root directories", ->
+      it "does not squash root directories", ->
         rootDir = fs.absolute(temp.mkdirSync('tree-view'))
         zetaDir = path.join(rootDir, "zeta")
         fs.makeTreeSync(zetaDir)

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2543,6 +2543,18 @@ describe "TreeView", ->
       beforeEach ->
         atom.config.set('tree-view.squashDirectoryNames', true)
 
+      it "it does not squash root directories", ->
+        rootDir = fs.absolute(temp.mkdirSync('tree-view'))
+        zetaDir = path.join(rootDir, "zeta")
+        fs.makeTreeSync(zetaDir)
+        atom.project.setPaths([rootDir])
+        jasmine.attachToDOM(workspaceElement)
+
+        rootDirPath = treeView.roots[0].getPath()
+        expect(rootDirPath).toBe(rootDir)
+        zetaDirPath = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')[0].getPath()
+        expect(zetaDirPath).toBe(zetaDir)
+
       it "does not squash a file in to a DirectoryViews", ->
         zetaDir = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')
         zetaDir[0].expand()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR solves two bugs:
- One that causes root directories to be squashed. Issue #697 
- Another one that prevent squashed root directories to be removed from project #942 (Since root directories are not squashed anymore this issue gets solved for free!)

### Alternate Designs

-

### Benefits

Solves a bug

### Possible Drawbacks

-

### Applicable Issues

Fixes #697, #942 
