### PR TITLE
:art: Improve the no trash notification formatting

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -574,6 +574,7 @@ class TreeView extends View
               repo.getPathStatus(selectedPath)
           if failedDeletions.length > 0
             atom.notifications.addError @formatTrashFailureMessage(failedDeletions),
+              description: @formatTrashEnabledMessage()
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
           @updateRoots()
@@ -582,7 +583,7 @@ class TreeView extends View
   formatTrashFailureMessage: (failedDeletions) ->
     fileText = if failedDeletions.length > 1 then 'files' else 'file'
 
-    "The following #{fileText} couldn't be moved to the trash. #{@formatTrashEnabledMessage()}"
+    "The following #{fileText} couldn't be moved to the trash."
 
   formatTrashEnabledMessage: ->
     switch process.platform


### PR DESCRIPTION
### Description of the Change

**Old:**

<img width="467" alt="screen shot 2017-01-03 at 12 16 44 pm" src="https://cloud.githubusercontent.com/assets/1038121/21621628/b9dfe61c-d1ae-11e6-96b3-1f141483520f.png">

**New:**

<img width="470" alt="screen shot 2017-01-03 at 12 17 52 pm" src="https://cloud.githubusercontent.com/assets/1038121/21621635/c146ad46-d1ae-11e6-9ea9-ed2175ddb162.png">


### Alternate Designs

N/A

### Benefits

* Makes the notification cleaner
* Draws more attention to the question of is Trash enabled

### Possible Drawbacks

N/A

### Applicable Issues

N/A
