### PR TITLE
🐛 Prevent files to be expanded

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -392,6 +392,7 @@ class TreeView extends View
 
   expandDirectory: (isRecursive=false) ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry instanceof DirectoryView
     if isRecursive is false and selectedEntry.isExpanded
       @moveDown() if selectedEntry.directory.getEntries().length > 0
     else

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1098,12 +1098,12 @@ describe "TreeView", ->
 
       describe "when trying to expand a file", ->
         it "won't raise an error", ->
-          sampleTxt.click()
-          treeView.roots[0].collapse()
+          file = root1.find('.file:contains(tree-view.js)')[0]
+          treeView.selectEntry(file)
 
-          expect(treeView.roots[0]).not.toHaveClass 'expanded'
+          expect(file).not.toHaveClass 'expanded'
           atom.commands.dispatch(treeView.element, 'tree-view:recursive-expand-directory')
-          expect(treeView.roots[0]).not.toHaveClass 'expanded'
+          expect(file).not.toHaveClass 'expanded'
 
     describe "tree-view:collapse-directory", ->
       subdir = null

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1097,12 +1097,15 @@ describe "TreeView", ->
             expect(child).toHaveClass 'expanded'
 
       describe "when trying to expand a file", ->
-        it "won't raise an error", ->
+        it "doesn't expand the file and doesn't error", ->
           file = root1.find('.file:contains(tree-view.js)')[0]
           treeView.selectEntry(file)
-
           expect(file).not.toHaveClass 'expanded'
-          atom.commands.dispatch(treeView.element, 'tree-view:recursive-expand-directory')
+
+          expect(-> treeView.expandDirectory(true)).not.toThrow()
+          expect(file).not.toHaveClass 'expanded'
+
+          expect(-> treeView.expandDirectory(false)).not.toThrow()
           expect(file).not.toHaveClass 'expanded'
 
     describe "tree-view:collapse-directory", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1096,6 +1096,15 @@ describe "TreeView", ->
           children.each (index, child) ->
             expect(child).toHaveClass 'expanded'
 
+      describe "when trying to expand a file", ->
+        it "won't raise an error", ->
+          sampleTxt.click()
+          treeView.roots[0].collapse()
+
+          expect(treeView.roots[0]).not.toHaveClass 'expanded'
+          atom.commands.dispatch(treeView.element, 'tree-view:recursive-expand-directory')
+          expect(treeView.roots[0]).not.toHaveClass 'expanded'
+
     describe "tree-view:collapse-directory", ->
       subdir = null
 


### PR DESCRIPTION
### Description of the Change

Solves #921. Prevents files to be expanded (and therefore causing an error).
This PR is a copy of #970 but with a test scenario.

### Benefits

Solves #921

### Applicable Issues

#921 
