### PR TITLE
Manually close editors for files deleted from tree view

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -568,7 +568,11 @@ class TreeView extends View
         "Move to Trash": =>
           failedDeletions = []
           for selectedPath in selectedPaths
-            if not shell.moveItemToTrash(selectedPath)
+            if shell.moveItemToTrash(selectedPath)
+              for editor in atom.workspace.getTextEditors()
+                if editor?.getPath() is selectedPath
+                  editor.destroy()
+            else
               failedDeletions.push "#{selectedPath}"
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)


### PR DESCRIPTION
Destroys any open editors for a file that's deleted from tree-view. Intended to preserve the behavior of editors closing when a file is deleted once https://github.com/atom/text-buffer/pull/178 is merged to resolve https://github.com/atom/tabs/issues/306.