### PR TITLE
Remove jQuery from `spec/tree-view-spec.coffee`

### DIFF
--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -29,7 +29,7 @@ class Dialog extends View
       @miniEditor.getModel().setSelectedBufferRange(range)
 
   attach: ->
-    @panel = atom.workspace.addModalPanel(item: this.element)
+    @panel = atom.workspace.addModalPanel(item: this)
     @miniEditor.focus()
     @miniEditor.getModel().scrollToCursorPosition()
 

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2555,11 +2555,7 @@ describe "TreeView", ->
         expect(zetaEntries).toEqual(["zeta.txt"])
 
       it "squashes two dir names when the first only contains a single dir", ->
-        if path.sep is '\\'
-          # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\beta")
-        else
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
+        betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
         betaDir.expand()
         betaEntries = [].slice.call(betaDir.children[1].children).map (element) ->
           element.innerText
@@ -2567,11 +2563,7 @@ describe "TreeView", ->
         expect(betaEntries).toEqual(["beta.txt"])
 
       it "squashes three dir names when the first and second only contain single dirs", ->
-        if path.sep is '\\'
-          # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\delta\\epsilon")
-        else
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
+        epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
         epsilonDir.expand()
         epsilonEntries = [].slice.call(epsilonDir.children[1].children).map (element) ->
           element.innerText

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2543,13 +2543,13 @@ describe "TreeView", ->
 
         rootDirPath = treeView.roots[0].getPath()
         expect(rootDirPath).toBe(rootDir)
-        zetaDirPath = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')[0].getPath()
+        zetaDirPath = findDirectoryContainingText(treeView.roots[0], 'zeta').getPath()
         expect(zetaDirPath).toBe(zetaDir)
 
       it "does not squash a file in to a DirectoryViews", ->
-        zetaDir = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')
-        zetaDir[0].expand()
-        zetaEntries = [].slice.call(zetaDir[0].children[1].children).map (element) ->
+        zetaDir = findDirectoryContainingText(treeView.roots[0], 'zeta')
+        zetaDir.expand()
+        zetaEntries = [].slice.call(zetaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(zetaEntries).toEqual(["zeta.txt"])
@@ -2557,11 +2557,11 @@ describe "TreeView", ->
       it "squashes two dir names when the first only contains a single dir", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = $(treeView.roots[0].entries).find(".directory:contains(alpha\\\\beta):first")
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\\\beta")
         else
-          betaDir = $(treeView.roots[0].entries).find(".directory:contains(alpha#{path.sep}beta):first")
-        betaDir[0].expand()
-        betaEntries = [].slice.call(betaDir[0].children[1].children).map (element) ->
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
+        betaDir.expand()
+        betaEntries = [].slice.call(betaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(betaEntries).toEqual(["beta.txt"])
@@ -2569,19 +2569,19 @@ describe "TreeView", ->
       it "squashes three dir names when the first and second only contain single dirs", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = $(treeView.roots[0].entries).find(".directory:contains(gamma\\\\delta\\\\epsilon):first")
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\\\delta\\\\epsilon")
         else
-          epsilonDir = $(treeView.roots[0].entries).find(".directory:contains(gamma#{path.sep}delta#{path.sep}epsilon):first")
-        epsilonDir[0].expand()
-        epsilonEntries = [].slice.call(epsilonDir[0].children[1].children).map (element) ->
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
+        epsilonDir.expand()
+        epsilonEntries = [].slice.call(epsilonDir.children[1].children).map (element) ->
           element.innerText
 
         expect(epsilonEntries).toEqual(["theta.txt"])
 
       it "does not squash a dir name when there are two child dirs ", ->
-        lambdaDir = $(treeView.roots[0].entries).find('.directory:contains(lambda):first')
-        lambdaDir[0].expand()
-        lambdaEntries = [].slice.call(lambdaDir[0].children[1].children).map (element) ->
+        lambdaDir = findDirectoryContainingText(treeView.roots[0], "lambda")
+        lambdaDir.expand()
+        lambdaEntries = [].slice.call(lambdaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(lambdaEntries).toEqual(["iota", "kappa"])
@@ -2589,20 +2589,20 @@ describe "TreeView", ->
       describe "when a squashed directory is deleted", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           treeView.focus()
           treeView.selectEntry(piDir)
           spyOn(atom, 'confirm').andCallFake (dialog) ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
 
       describe "when a file is created within a directory with another squashed directory", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           expect(piDir).not.toBeNull()
           # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
@@ -2610,18 +2610,18 @@ describe "TreeView", ->
           fs.writeFileSync(sigmaFilePath, "doesn't matter")
           treeView.updateRoots()
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
           omicronDir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
-          expect(piDir.title).toEqual("pi")
-          sigmaFile = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .file:contains(sigma) span")[0]
-          expect(sigmaFile.title).toEqual("sigma.txt")
+          piDir = findDirectoryContainingText(omicronDir, "pi")
+          expect(piDir.header.textContent).toEqual("pi")
+          sigmaFile = findFileContainingText(omicronDir, "sigma.txt")
+          expect(sigmaFile.fileName.textContent).toEqual("sigma.txt")
 
       describe "when a directory is created within a directory with another squashed directory", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           expect(piDir).not.toBeNull()
           # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
@@ -2629,25 +2629,33 @@ describe "TreeView", ->
           fs.makeTreeSync(rhoDirPath)
           treeView.updateRoots()
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
           omicronDir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
-          expect(piDir.title).toEqual("pi")
-          rhoDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(rho) span")[0]
-          expect(rhoDir.title).toEqual("rho")
+          piDir = findDirectoryContainingText(omicronDir, "pi")
+          expect(piDir.header.textContent).toEqual("pi")
+          rhoDir = findDirectoryContainingText(omicronDir, "rho")
+          expect(rhoDir.header.textContent).toEqual("rho")
 
       describe "when a directory is reloaded", ->
         it "squashes the directory names the last of which is same as an unsquashed directory", ->
-          muDir = $(treeView.roots[0].entries).find('.directory:contains(mu):first')
-          muDir[0].expand()
-          muEntries = Array.from(muDir[0].children[1].children).map (element) -> element.innerText
+          muDir = findDirectoryContainingText(treeView.roots[0], "mu")
+          muDir.expand()
+          muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
 
-          muDir[0].expand()
-          muDir[0].reload()
-          muEntries = Array.from(muDir[0].children[1].children).map (element) -> element.innerText
+          muDir.expand()
+          muDir.reload()
+          muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
+
+    findDirectoryContainingText = (element, text) ->
+      directories = Array.from(element.querySelectorAll('.entries .directory'))
+      directories.find((directory) -> directory.header.textContent is text)
+
+    findFileContainingText = (element, text) ->
+      files = Array.from(element.querySelectorAll('.entries .file'))
+      files.find((file) -> file.fileName.textContent is text)
 
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -225,7 +225,7 @@ describe "TreeView", ->
     it "restores the focus state of the tree view", ->
       jasmine.attachToDOM(workspaceElement)
       treeView.focus()
-      expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+      expect(treeView.list).toMatchSelector(":focus")
       atom.packages.deactivatePackage("tree-view")
 
       waitsForPromise ->
@@ -233,7 +233,7 @@ describe "TreeView", ->
 
       runs ->
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     it "restores the scroll top when toggled", ->
       workspaceElement.style.height = '5px'
@@ -294,7 +294,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     describe "when tree-view:toggle-side is triggered on the root view", ->
       describe "when the tree view is on the left", ->
@@ -330,7 +330,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     describe "when the tree view is shown", ->
       it "focuses the tree view", ->
@@ -342,7 +342,7 @@ describe "TreeView", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
           expect(treeView).toBeVisible()
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
       describe "when the tree view is focused", ->
         it "unfocuses the tree view", ->
@@ -354,7 +354,7 @@ describe "TreeView", ->
             expect(treeView).toBeVisible()
             atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
             expect(treeView).toBeVisible()
-            expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
+            expect(treeView.list).not.toMatchSelector(":focus")
 
   describe "when tree-view:reveal-active-file is triggered on the root view", ->
     beforeEach ->
@@ -464,10 +464,10 @@ describe "TreeView", ->
       runs ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
         atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
         expect(treeView).toBeVisible()
-        expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
+        expect(treeView.list).not.toMatchSelector(":focus")
         expect(atom.workspace.getActivePane().isActive()).toBe(true)
 
   describe "copy path commands", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toHaveFocus()
+            expect(treeView.querySelector(".tree-view")).toHaveFocus()
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toHaveFocus()
+            expect(treeView.querySelector(".tree-view")).toHaveFocus()
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2836,9 +2836,9 @@ describe "TreeView", ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
         fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
-        expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+        expect(treeView.list).toHaveClass('multi-select')
         fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
-        expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+        expect(treeView.list).toHaveClass('full-menu')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
@@ -2904,16 +2904,16 @@ describe "TreeView", ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
           describe 'previous item is selected including the ctrl clicked', ->
             it 'displays the multi-select menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+              expect(treeView.list).not.toHaveClass('full-menu')
+              expect(treeView.list).toHaveClass('multi-select')
 
             it 'does not deselect any of the items', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -2926,8 +2926,8 @@ describe "TreeView", ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
           describe 'when no item is selected', ->
             it 'selects the ctrl clicked item', ->
@@ -2936,8 +2936,8 @@ describe "TreeView", ->
 
             it 'displays the full context menu', ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
         describe "right-clicking", ->
           describe 'when multiple items are selected', ->
@@ -2947,15 +2947,15 @@ describe "TreeView", ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+              expect(treeView.list).not.toHaveClass('full-menu')
+              expect(treeView.list).toHaveClass('multi-select')
 
           describe 'when a single item is selected', ->
             it 'displays the full context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
             it 'selects right clicked item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -2975,8 +2975,8 @@ describe "TreeView", ->
             it 'shows the full context menu', ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
@@ -3337,7 +3337,7 @@ describe "TreeView", ->
         runs ->
           expect(sampleJs).toHaveClass 'selected'
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
         waitsForFileToOpen ->
           sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -3346,7 +3346,7 @@ describe "TreeView", ->
           expect(sampleTxt).toHaveClass 'selected'
           expect(treeView.element.querySelectorAll('.selected').length).toBe 1
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
     describe "opening existing opened files in existing split panes", ->
       beforeEach ->
@@ -3422,7 +3422,7 @@ describe "TreeView", ->
             expect(treeView).toHaveFocus()
 
           it "doesn't open the file in the active pane", ->
-            expect(atom.views.getView(treeView)).toHaveFocus()
+            expect(atom.views.getView(treeView).element).toHaveFocus()
             expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
 
       describe "when a file is double-clicked", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -57,40 +57,42 @@ describe "TreeView", ->
 
     runs ->
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+      treeView = atom.workspace.getLeftPanels()[0].getItem()
+      files = treeView[0].querySelectorAll('.file')
+      root1 = treeView.roots[0]
+      root2 = treeView.roots[1]
+      sampleJs = files[0]
+      sampleTxt = files[1]
 
-      root1 = $(treeView.roots[0])
-      root2 = $(treeView.roots[1])
-      sampleJs = treeView.find('.file:contains(tree-view.js)')
-      sampleTxt = treeView.find('.file:contains(tree-view.txt)')
-
-      expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
+      expect(root1.directory.watchSubscription).toBeTruthy()
 
   afterEach ->
     temp.cleanup()
 
   describe ".initialize(project)", ->
     it "renders the root directories of the project and their contents alphabetically with subdirectories first, in a collapsed state", ->
-      expect(root1.find('> .header .disclosure-arrow')).not.toHaveClass('expanded')
-      expect(root1.find('> .header .name')).toHaveText('root-dir1')
+      expect(root1.querySelector('.header .disclosure-arrow')).not.toHaveClass('expanded')
+      expect(root1.querySelector('.header .name')).toHaveText('root-dir1')
 
-      rootEntries = root1.find('.entries')
-      subdir0 = rootEntries.find('> li:eq(0)')
+      rootEntries = root1.querySelectorAll('.entries li')
+      subdir0 = rootEntries[0]
       expect(subdir0).not.toHaveClass('expanded')
-      expect(subdir0.find('.name')).toHaveText('dir1')
+      expect(subdir0.querySelector('.name')).toHaveText('dir1')
 
-      subdir2 = rootEntries.find('> li:eq(1)')
+      subdir2 = rootEntries[1]
       expect(subdir2).not.toHaveClass('expanded')
-      expect(subdir2.find('.name')).toHaveText('dir2')
+      expect(subdir2.querySelector('.name')).toHaveText('dir2')
 
-      expect(subdir0.find('[data-name="dir1"]')).toExist()
-      expect(subdir2.find('[data-name="dir2"]')).toExist()
+      expect(subdir0.querySelector('[data-name="dir1"]')).toExist()
+      expect(subdir2.querySelector('[data-name="dir2"]')).toExist()
 
-      expect(rootEntries.find('> .file:contains(tree-view.js)')).toExist()
-      expect(rootEntries.find('> .file:contains(tree-view.txt)')).toExist()
+      file1 = root1.querySelector('.file [data-name="tree-view.js"]')
+      expect(file1).toExist()
+      expect(file1).toHaveText('tree-view.js')
 
-      expect(rootEntries.find('> .file [data-name="tree-view.js"]')).toExist()
-      expect(rootEntries.find('> .file [data-name="tree-view.txt"]')).toExist()
+      file2 = root1.querySelector('.file [data-name="tree-view.txt"]')
+      expect(file2).toExist()
+      expect(file2).toHaveText('tree-view.txt')
 
     it "selects the root folder", ->
       expect(treeView.selectedEntry()).toEqual(treeView.roots[0])
@@ -208,10 +210,10 @@ describe "TreeView", ->
         expect(atom.workspace.getLeftPanels().length).toBe(0)
 
     it "restores expanded directories and selected file when deserialized", ->
-      root1.find('.directory:contains(dir1)').click()
+      root1.querySelectorAll('.directory')[0].dispatchEvent(new MouseEvent('click', {detail: 1, bubbles: true}))
 
       waitsForFileToOpen ->
-        sampleJs.click()
+        sampleJs.dispatchEvent(new MouseEvent('click', {detail: 1, bubbles: true}))
 
       runs ->
         atom.packages.deactivatePackage("tree-view")
@@ -220,7 +222,7 @@ describe "TreeView", ->
         atom.packages.activatePackage("tree-view")
 
       runs ->
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         expect($(treeView.selectedEntry())).toMatchSelector(".file:contains(tree-view.js)")
         root1 = $(treeView.roots[0])
@@ -236,7 +238,7 @@ describe "TreeView", ->
         atom.packages.activatePackage("tree-view")
 
       runs ->
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView.list).toMatchSelector ':focus'
 
     it "restores the scroll top when toggled", ->
@@ -322,7 +324,7 @@ describe "TreeView", ->
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
           expect(atom.workspace.getLeftPanels().length).toBe 0
-          treeView = $(atom.workspace.getRightPanels()[0].getItem()).view()
+          treeView = atom.workspace.getRightPanels()[0].getItem()
           expect(treeView).toMatchSelector('[data-show-on-right-side="true"]')
 
   describe "when tree-view:toggle-focus is triggered on the root view", ->
@@ -512,7 +514,7 @@ describe "TreeView", ->
 
   describe "when a directory's disclosure arrow is clicked", ->
     it "expands / collapses the associated directory", ->
-      subdir = root1.find('.entries > li:contains(dir1)')
+      subdir = root1.querySelector('.entries > li')
 
       expect(subdir).not.toHaveClass('expanded')
 
@@ -524,10 +526,10 @@ describe "TreeView", ->
       expect(subdir).not.toHaveClass('expanded')
 
     it "restores the expansion state of descendant directories", ->
-      child = root1.find('.entries > li:contains(dir1)')
+      child = root1.querySelector('.entries > li')
       child.click()
 
-      grandchild = child.find('.entries > li:contains(sub-dir1)')
+      grandchild = child.querySelector('.entries > li')
       grandchild.click()
 
       root1.click()
@@ -535,37 +537,37 @@ describe "TreeView", ->
       root1.click()
 
       # previously expanded descendants remain expanded
-      expect(root1.find('> .entries > li:contains(dir1) > .entries > li:contains(sub-dir1) > .entries').length).toBe 1
+      expect(root1.querySelectorAll('.entries > li > .entries > li > .entries').length).toBe 1
 
       # collapsed descendants remain collapsed
-      expect(root1.find('> .entries > li:contains(dir2) > .entries')).not.toHaveClass('expanded')
+      expect(root1.querySelectorAll('.entries > li')[1].querySelector('.entries')).not.toHaveClass('expanded')
 
     it "when collapsing a directory, removes change subscriptions from the collapsed directory and its descendants", ->
-      child = root1.find('li:contains(dir1)')
+      child = root1.querySelector('li')
       child.click()
 
-      grandchild = child.find('li:contains(sub-dir1)')
+      grandchild = child.querySelector('li')
       grandchild.click()
 
-      expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
-      expect(child[0].directory.watchSubscription).toBeTruthy()
-      expect(grandchild[0].directory.watchSubscription).toBeTruthy()
+      expect(root1.directory.watchSubscription).toBeTruthy()
+      expect(child.directory.watchSubscription).toBeTruthy()
+      expect(grandchild.directory.watchSubscription).toBeTruthy()
 
       root1.click()
 
-      expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
-      expect(child[0].directory.watchSubscription).toBeFalsy()
-      expect(grandchild[0].directory.watchSubscription).toBeFalsy()
+      expect(root1.directory.watchSubscription).toBeFalsy()
+      expect(child.directory.watchSubscription).toBeFalsy()
+      expect(grandchild.directory.watchSubscription).toBeFalsy()
 
   describe "when mouse down fires on a file or directory", ->
     it "selects the entry", ->
-      dir = root1.find('li:contains(dir1)')
+      dir = root1.querySelector('li')
       expect(dir).not.toHaveClass 'selected'
-      dir.mousedown()
+      dir.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, detail: 1}))
       expect(dir).toHaveClass 'selected'
 
       expect(sampleJs).not.toHaveClass 'selected'
-      sampleJs.mousedown()
+      sampleJs.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, detail: 1}))
       expect(sampleJs).toHaveClass 'selected'
 
   describe "when the package first activates and there is a file open (regression)", ->
@@ -580,8 +582,8 @@ describe "TreeView", ->
 
       it "does not throw when the file is double clicked", ->
         expect ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
         .not.toThrow()
 
         waitsFor ->
@@ -601,8 +603,8 @@ describe "TreeView", ->
         runs ->
           expect(atom.workspace.getActivePane().getActiveItem()).toBe editor
           expect(atom.workspace.getActivePane().getPendingItem()).toBe editor
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor ->
           atom.workspace.getActivePane().getPendingItem() is null
@@ -638,7 +640,7 @@ describe "TreeView", ->
           spyOn(atom.workspace, 'open')
 
           treeView.focus()
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         it "selects the file and retains focus on tree-view", ->
           expect(sampleJs).toHaveClass 'selected'
@@ -655,7 +657,7 @@ describe "TreeView", ->
           spyOn(atom.workspace, 'open').andCallFake (uri, options) ->
             originalOpen(uri, options).then -> openedCount++
 
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
           treeView.openSelectedEntry()
 
           waitsFor 'open to be called twice', ->
@@ -672,8 +674,8 @@ describe "TreeView", ->
 
       it "opens the file and focuses it", ->
         waitsForFileToOpen ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor "next tick to avoid race condition", (done) ->
           setImmediate(done)
@@ -690,8 +692,8 @@ describe "TreeView", ->
         spyOn(atom.workspace, 'open').andCallFake (uri, options) ->
           originalOpen(uri, options).then -> openedCount++
 
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-        sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor 'open to be called twice', ->
           openedCount is 2
@@ -701,8 +703,8 @@ describe "TreeView", ->
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->
-      subdir = root1.find('.directory:first')
-      subdir.trigger clickEvent(originalEvent: {detail: 1})
+      subdir = root1.querySelector('.directory')
+      subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
       expect(subdir).toHaveClass 'selected'
 
   describe "when a directory is double-clicked", ->
@@ -711,15 +713,15 @@ describe "TreeView", ->
 
       subdir = null
       waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         treeView.focus()
-        subdir = root1.find('.directory:first')
-        subdir.trigger clickEvent(originalEvent: {detail: 1})
+        subdir = root1.querySelector('.directory')
+        subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
         expect(subdir).toHaveClass 'selected'
         expect(subdir).toHaveClass 'expanded'
-        subdir.trigger clickEvent(originalEvent: {detail: 2})
+        subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
         expect(subdir).toHaveClass 'selected'
         expect(subdir).not.toHaveClass 'expanded'
         expect(treeView).toHaveFocus()
@@ -731,36 +733,38 @@ describe "TreeView", ->
         treeView.roots[0].collapse()
 
         expect(treeView.roots[0]).not.toHaveClass 'expanded'
-        root1.trigger clickEvent({altKey: true})
+        root1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1, altKey: true}))
         expect(treeView.roots[0]).toHaveClass 'expanded'
 
-        children = root1.find('.directory')
+        children = root1.querySelectorAll('.directory')
         expect(children.length).toBeGreaterThan 0
-        children.each (index, child) -> expect(child).toHaveClass 'expanded'
+        for child in children
+          expect(child).toHaveClass 'expanded'
 
     describe "when the directory is expanded", ->
       parent    = null
       children  = null
 
       beforeEach ->
-        parent = root1.find('> .entries > .directory').eq(2)
-        parent[0].expand()
-        children = parent.find('.expanded.directory')
-        children.each (index, child) ->
+        parent = root1.querySelectorAll('.entries > .directory')[2]
+        parent.expand()
+        children = parent.querySelectorAll('.expanded.directory')
+        for child in children
           child.expand()
 
       it "recursively collapses the directory", ->
-        parent.click()
-        parent[0].expand()
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+        parent.expand()
         expect(parent).toHaveClass 'expanded'
-        children.each (index, child) ->
-          $(child).click().expand()
-          expect($(child)).toHaveClass 'expanded'
+        for child in children
+          child.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          child.expand()
+          expect(child).toHaveClass 'expanded'
 
-        parent.trigger clickEvent({altKey: true})
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1, altKey: true}))
 
         expect(parent).not.toHaveClass 'expanded'
-        children.each (index, child) ->
+        for child in children
           expect(child).not.toHaveClass 'expanded'
         expect(treeView.roots[0]).toHaveClass 'expanded'
 
@@ -768,21 +772,21 @@ describe "TreeView", ->
     describe "when the item has a path", ->
       it "selects the entry with that path in the tree view if it is visible", ->
         waitsForFileToOpen ->
-          sampleJs.click()
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         waitsForPromise ->
           atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
 
         runs ->
           expect(sampleTxt).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
+          expect(treeView.querySelectorAll('.selected').length).toBe 1
 
       it "selects the path's parent dir if its entry is not visible", ->
         waitsForPromise ->
           atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
 
         runs ->
-          dirView = root1.find('.directory:contains(dir1)')
+          dirView = root1.querySelector('.directory')
           expect(dirView).toHaveClass 'selected'
 
       describe "when the tree-view.autoReveal config setting is true", ->
@@ -794,20 +798,20 @@ describe "TreeView", ->
             atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
 
           runs ->
-            dirView = root1.find('.directory:contains(dir1)')
-            fileView = root1.find('.file:contains(sub-file1)')
+            dirView = root1.querySelector('.directory')
+            fileView = root1.querySelector('.file')
             expect(dirView).not.toHaveClass 'selected'
             expect(fileView).toHaveClass 'selected'
-            expect(treeView.find('.selected').length).toBe 1
+            expect(treeView[0].querySelectorAll('.selected').length).toBe 1
 
     describe "when the item has no path", ->
       it "deselects the previously selected entry", ->
         waitsForFileToOpen ->
-          sampleJs.click()
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           atom.workspace.getActivePane().activateItem(document.createElement("div"))
-          expect(treeView.find('.selected')).not.toExist()
+          expect(treeView[0].querySelector('.selected')).not.toExist()
 
   describe "when a different editor becomes active", ->
     beforeEach ->
@@ -817,14 +821,14 @@ describe "TreeView", ->
       leftEditorPane = null
 
       waitsForFileToOpen ->
-        sampleJs.click()
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         leftEditorPane = atom.workspace.getActivePane()
         leftEditorPane.splitRight()
 
       waitsForFileToOpen ->
-        sampleTxt.click()
+        sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         expect(sampleTxt).toHaveClass('selected')
@@ -833,64 +837,67 @@ describe "TreeView", ->
 
   describe "keyboard navigation", ->
     afterEach ->
-      expect(treeView.find('.selected').length).toBeLessThan 2
+      expect(treeView[0].querySelectorAll('.selected').length).toBeLessThan 2
 
     describe "core:move-down", ->
       describe "when a collapsed directory is selected", ->
         it "skips to the next directory", ->
-          root1.find('.directory:eq(0)').click()
+          root1.querySelector('.directory').dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           atom.commands.dispatch(treeView.element, 'core:move-down')
-          expect(root1.find('.directory:eq(1)')).toHaveClass 'selected'
+          expect(root1.querySelectorAll('.directory')[1]).toHaveClass 'selected'
 
       describe "when an expanded directory is selected", ->
         it "selects the first entry of the directory", ->
-          subdir = root1.find('.directory:eq(1)')
-          subdir.click()
+          subdir = root1.querySelectorAll('.directory')[1]
+          subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           atom.commands.dispatch(treeView.element, 'core:move-down')
 
-          expect($(subdir[0].entries).find('.entry:first')).toHaveClass 'selected'
+          expect(subdir.querySelector('.entry')).toHaveClass 'selected'
 
       describe "when the last entry of an expanded directory is selected", ->
         it "selects the entry after its parent directory", ->
-          subdir1 = root1.find('.directory:eq(1)')
-          subdir1[0].expand()
+          subdir1 = root1.querySelectorAll('.directory')[1]
+          subdir1.expand()
           waitsForFileToOpen ->
-            $(subdir1[0].entries).find('.entry:last').click()
+            entries = subdir1.querySelectorAll('.entry')
+            entries[entries.length - 1].dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           runs ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(root1.find('.directory:eq(2)')).toHaveClass 'selected'
+            expect(root1.querySelectorAll('.directory')[2]).toHaveClass 'selected'
 
       describe "when the last directory of another last directory is selected", ->
         [nested, nested2] = []
 
         beforeEach ->
-          nested = root1.find('.directory:eq(2)')
-          expect(nested.find('.header').text()).toContain 'nested'
-          nested[0].expand()
-          nested2 = $(nested[0].entries).find('.entry:last')
-          nested2.click()
-          nested2[0].collapse()
+          nested = root1.querySelectorAll('.directory')[2]
+          expect(nested.querySelector('.header').textContent).toContain 'nested'
+          nested.expand()
+          entries = nested.querySelectorAll('.entry')
+          nested2 = entries[entries.length - 1]
+          nested2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          nested2.collapse()
 
         describe "when the directory is collapsed", ->
           it "selects the entry after its grandparent directory", ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(nested.next()).toHaveClass 'selected'
+            expect(nested.nextSibling).toHaveClass 'selected'
 
         describe "when the directory is expanded", ->
           it "selects the entry after its grandparent directory", ->
-            nested2[0].expand()
-            nested2.find('.file').remove() # kill the .gitkeep file, which has to be there but screws the test
+            nested2.expand()
+            nested2.querySelector('.file').remove() # kill the .gitkeep file, which has to be there but screws the test
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(nested.next()).toHaveClass 'selected'
+            expect(nested.nextSibling).toHaveClass 'selected'
 
       describe "when the last entry of the last directory is selected", ->
         it "does not change the selection", ->
-          lastEntry = root2.find('> .entries .entry:last')
+          entries = root2.querySelectorAll('.entries .entry')
+          lastEntry = entries[entries.length - 1]
           waitsForFileToOpen ->
-            lastEntry.click()
+            lastEntry.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           runs ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
@@ -2395,7 +2402,7 @@ describe "TreeView", ->
   describe "project changes", ->
     beforeEach ->
       atom.project.setPaths([path1])
-      treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+      treeView = atom.workspace.getLeftPanels()[0].getItem()
       root1 = $(treeView.roots[0])
 
     describe "when a root folder is added", ->
@@ -2403,7 +2410,7 @@ describe "TreeView", ->
         root1.find('.directory:contains(dir1)').click()
         atom.project.setPaths([path1, path2])
 
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         root1 = $(treeView.roots[0])
         expect(root1.find(".directory:contains(dir1)")).toHaveClass("expanded")
@@ -2412,7 +2419,7 @@ describe "TreeView", ->
         root1.click()
         atom.project.setPaths([path1, path2])
 
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         root1 = $(treeView.roots[0])
         expect(root1).toHaveClass("collapsed")

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1852,7 +1852,7 @@ describe "TreeView", ->
                 dirView3.entries.querySelectorAll(".file").length > 1
 
               runs ->
-                expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)
+                expect(treeView.element.querySelector('.file.selected').textContent).toBe path.basename(newPath)
 
           describe "when a file already exists at that location", ->
             it "shows an error message and does not close the dialog", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.querySelector(".tree-view")).toHaveFocus()
+            expect(treeView.list).toMatchSelector(":focus")
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.querySelector(".tree-view")).toHaveFocus()
+            expect(treeView.list).toMatchSelector(":focus")
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2717,7 +2717,7 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(dirView.directory.updateStatus).toHaveBeenCalled()
 
-    describe "when the project is a symbolic link to the repository root", ->
+    describe "on #darwin, when the project is a symbolic link to the repository root", ->
       beforeEach ->
         symlinkPath = temp.path('tree-view-project')
         fs.symlinkSync(projectPath, symlinkPath, 'junction')
@@ -2739,12 +2739,8 @@ describe "TreeView", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          waitsFor ->
-            not treeView.element.querySelector('.file.status-modified')
-
-          runs ->
-            expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
-            expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2557,7 +2557,7 @@ describe "TreeView", ->
       it "squashes two dir names when the first only contains a single dir", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\\\beta")
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\beta")
         else
           betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
         betaDir.expand()
@@ -2569,7 +2569,7 @@ describe "TreeView", ->
       it "squashes three dir names when the first and second only contain single dirs", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\\\delta\\\\epsilon")
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\delta\\epsilon")
         else
           epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
         epsilonDir.expand()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2739,8 +2739,12 @@ describe "TreeView", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
-          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
+          waitsFor ->
+            not treeView.element.querySelector('.file.status-modified')
+
+          runs ->
+            expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+            expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->
@@ -3414,7 +3418,7 @@ describe "TreeView", ->
             expect(treeView).toHaveFocus()
 
           it "doesn't open the file in the active pane", ->
-            expect(atom.views.getView(treeView).element).toHaveFocus()
+            expect(atom.views.getView(treeView)).toHaveFocus()
             expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
 
       describe "when a file is double-clicked", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -225,7 +225,7 @@ describe "TreeView", ->
     it "restores the focus state of the tree view", ->
       jasmine.attachToDOM(workspaceElement)
       treeView.focus()
-      expect(treeView.list).toMatchSelector ':focus'
+      expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
       atom.packages.deactivatePackage("tree-view")
 
       waitsForPromise ->
@@ -233,7 +233,7 @@ describe "TreeView", ->
 
       runs ->
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView.list).toMatchSelector ':focus'
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     it "restores the scroll top when toggled", ->
       workspaceElement.style.height = '5px'
@@ -294,7 +294,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "when tree-view:toggle-side is triggered on the root view", ->
       describe "when the tree view is on the left", ->
@@ -330,7 +330,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "when the tree view is shown", ->
       it "focuses the tree view", ->
@@ -342,7 +342,7 @@ describe "TreeView", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
           expect(treeView).toBeVisible()
-          expect(treeView.list).toMatchSelector(':focus')
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
       describe "when the tree view is focused", ->
         it "unfocuses the tree view", ->
@@ -354,7 +354,7 @@ describe "TreeView", ->
             expect(treeView).toBeVisible()
             atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
             expect(treeView).toBeVisible()
-            expect(treeView.list).not.toMatchSelector(':focus')
+            expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
 
   describe "when tree-view:reveal-active-file is triggered on the root view", ->
     beforeEach ->
@@ -464,10 +464,10 @@ describe "TreeView", ->
       runs ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
         atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
         expect(treeView).toBeVisible()
-        expect(treeView.list).not.toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
         expect(atom.workspace.getActivePane().isActive()).toBe(true)
 
   describe "copy path commands", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toMatchSelector(':focus')
+            expect(treeView.find(".tree-view")).toHaveFocus()
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toMatchSelector(':focus')
+            expect(treeView.find(".tree-view")).toHaveFocus()
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2649,14 +2649,6 @@ describe "TreeView", ->
           muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
 
-    findDirectoryContainingText = (element, text) ->
-      directories = Array.from(element.querySelectorAll('.entries .directory'))
-      directories.find((directory) -> directory.header.textContent is text)
-
-    findFileContainingText = (element, text) ->
-      files = Array.from(element.querySelectorAll('.entries .file'))
-      files.find((file) -> file.fileName.textContent is text)
-
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []
 
@@ -2686,60 +2678,59 @@ describe "TreeView", ->
 
       treeView.useSyncFS = true
       treeView.updateRoots()
-      $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
+      treeView.roots[0].entries.querySelectorAll('.directory')[1].expand()
 
     describe "when the project is the repository root", ->
       it "adds a custom style", ->
-        expect(treeView.find('.icon-repo').length).toBe 1
+        expect(treeView.element.querySelectorAll('.icon-repo').length).toBe 1
 
     describe "when a file is modified", ->
       it "adds a custom style", ->
-        $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
-        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+        expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
 
     describe "when a directory if modified", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+        expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
 
     describe "when a file is new", ->
       it "adds a custom style", ->
-        $(treeView.roots[0].entries).find('.directory:contains(dir2)')[0].expand()
-        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
+        treeView.roots[0].entries.querySelectorAll('.directory')[2].expand()
+        expect(treeView.element.querySelector('.file.status-added')).toHaveText('new2')
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+        expect(treeView.element.querySelector('.directory.status-added').header).toHaveText('dir2')
 
     describe "when a file is ignored", ->
       it "adds a custom style", ->
-        expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
+        expect(treeView.element.querySelector('.file.status-ignored')).toHaveText('ignored.txt')
 
     describe "when a file is selected in a directory", ->
       beforeEach ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        element.expand() for element in treeView.find('.directory')
-        fileView = treeView.find('.file:contains(new2)')
+        element.expand() for element in treeView.element.querySelectorAll('.directory')
+        fileView = treeView.element.querySelector('.file.status-added')
         expect(fileView).not.toBeNull()
         fileView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       describe "when the file is deleted", ->
         it "updates the style of the directory", ->
           expect(treeView.selectedEntry().getPath()).toContain(path.join('dir2', 'new2'))
-          dirView = $(treeView.roots[0].entries).find('.directory:contains(dir2)')
+          dirView = findDirectoryContainingText(treeView.roots[0], 'dir2')
           expect(dirView).not.toBeNull()
-          spyOn(dirView[0].directory, 'updateStatus')
+          spyOn(dirView.directory, 'updateStatus')
           spyOn(atom, 'confirm').andCallFake (dialog) ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
-          expect(dirView[0].directory.updateStatus).toHaveBeenCalled()
+          expect(dirView.directory.updateStatus).toHaveBeenCalled()
 
     describe "when the project is a symbolic link to the repository root", ->
       beforeEach ->
         symlinkPath = temp.path('tree-view-project')
         fs.symlinkSync(projectPath, symlinkPath, 'junction')
         atom.project.setPaths([symlinkPath])
-        $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
+        treeView.roots[0].entries.querySelectorAll('.directory')[1].expand()
 
         waitsFor (done) ->
           disposable = atom.project.getRepositories()[0].onDidChangeStatuses ->
@@ -2748,29 +2739,31 @@ describe "TreeView", ->
 
       describe "when a file is modified", ->
         it "updates its and its parent directories' styles", ->
-          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+          expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
+          expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
 
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
+          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->
-      treeView.width(10).find('.list-tree').width 100
+      treeView.element.style.width = '10px'
+      treeView.element.querySelector('.list-tree').style.width = '100px'
+      jasmine.attachToDOM(workspaceElement)
 
     it "sets the width of the tree to be the width of the list", ->
-      expect(treeView.width()).toBe 10
-      treeView.find('.tree-view-resize-handle').trigger 'dblclick'
-      expect(treeView.width()).toBeGreaterThan 10
+      expect(parseInt(treeView.element.style.width)).toBe 10
+      treeView.element.querySelector('.tree-view-resize-handle').dispatchEvent(new MouseEvent('dblclick', {bubbles: true}))
+      expect(parseInt(treeView.element.style.width)).toBeGreaterThan 10
 
-      treeView.width(1000)
-      treeView.find('.tree-view-resize-handle').trigger 'dblclick'
-      expect(treeView.width()).toBeLessThan 1000
+      treeView.element.style.width = '1000px'
+      treeView.element.querySelector('.tree-view-resize-handle').dispatchEvent(new MouseEvent('dblclick', {bubbles: true}))
+      expect(parseInt(treeView.element.style.width)).toBeLessThan 1000
 
   describe "when other panels are added", ->
     beforeEach ->
@@ -2780,20 +2773,20 @@ describe "TreeView", ->
       expect(treeView).toBeVisible()
       expect(atom.workspace.getLeftPanels().length).toBe(1)
 
-      treeView.width(100)
+      treeView.element.style.width = '100px'
 
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       panel = document.createElement('div')
       panel.style.width = '100px'
       atom.workspace.addLeftPanel({item: panel, priority: 10})
 
       expect(atom.workspace.getLeftPanels().length).toBe(2)
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       treeView.resizeTreeView({pageX: 250, which: 1})
 
-      expect(treeView.width()).toBe(150)
+      expect(parseInt(treeView.element.style.width)).toBe(150)
 
     it "should resize normally on the right side", ->
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
@@ -2802,20 +2795,20 @@ describe "TreeView", ->
       expect(treeView).toBeVisible()
       expect(atom.workspace.getRightPanels().length).toBe(1)
 
-      treeView.width(100)
+      treeView.element.style.width = '100px'
 
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       panel = document.createElement('div')
       panel.style.width = '100px'
       atom.workspace.addRightPanel({item: panel, priority: 10})
 
       expect(atom.workspace.getRightPanels().length).toBe(2)
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
-      treeView.resizeTreeView({pageX: $(document.body).width() - 250, which: 1})
+      treeView.resizeTreeView({pageX: document.body.offsetWidth - 250, which: 1})
 
-      expect(treeView.width()).toBe(150)
+      expect(parseInt(treeView.element.style.width)).toBe(150)
 
   describe "selecting items", ->
     [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []
@@ -2835,30 +2828,28 @@ describe "TreeView", ->
 
       atom.project.setPaths([rootDirPath])
 
-      dirView = $(treeView.roots[0].entries).find('.directory:contains(test-dir)')
-      dirView[0].expand()
-      fileView1 = treeView.find('.file:contains(test-file1.txt)')
-      fileView2 = treeView.find('.file:contains(test-file2.txt)')
-      fileView3 = treeView.find('.file:contains(test-file3.txt)')
+      dirView = treeView.entryForPath(dirPath)
+      dirView.expand()
+      [fileView1, fileView2, fileView3] = dirView.querySelectorAll('.file')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-        fileView2.trigger($.Event('mousedown', {shiftKey: true}))
-        expect(treeView.find('.tree-view')).toHaveClass('multi-select')
-        fileView3.trigger($.Event('mousedown'))
-        expect(treeView.find('.tree-view')).toHaveClass('full-menu')
+        fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
+        expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+        fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+        expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-        fileView2.trigger($.Event('mousedown', {shiftKey: true}))
+        fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
         expect(treeView.find('.tree-view')).toHaveClass('multi-select')
 
       describe 'using the shift key', ->
         it 'selects the items between the already selected item and the shift clicked item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          fileView3.trigger($.Event('mousedown', {shiftKey: true}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
           expect(fileView1).toHaveClass('selected')
           expect(fileView2).toHaveClass('selected')
           expect(fileView3).toHaveClass('selected')
@@ -2866,7 +2857,7 @@ describe "TreeView", ->
       describe 'using the metakey(cmd) key', ->
         it 'selects the cmd clicked item in addition to the original selected item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          fileView3.trigger($.Event('mousedown', {metaKey: true}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
           expect(fileView1).toHaveClass('selected')
           expect(fileView3).toHaveClass('selected')
           expect(fileView2).not.toHaveClass('selected')
@@ -2885,7 +2876,7 @@ describe "TreeView", ->
         describe 'using the ctrl key', ->
           it 'selects the ctrl clicked item in addition to the original selected item', ->
             fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+            fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
             expect(fileView1).toHaveClass('selected')
             expect(fileView3).toHaveClass('selected')
             expect(fileView2).not.toHaveClass('selected')
@@ -2905,87 +2896,87 @@ describe "TreeView", ->
           describe "previous item is selected but the ctrl clicked item is not", ->
             it 'selects the clicked item, but deselects the previous item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView1).not.toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
               expect(fileView2).not.toHaveClass('selected')
 
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
           describe 'previous item is selected including the ctrl clicked', ->
             it 'displays the multi-select menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).not.toHaveClass('full-menu')
-              expect(treeView.list).toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
 
             it 'does not deselect any of the items', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
 
           describe 'when clicked item is the only item selected', ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
           describe 'when no item is selected', ->
             it 'selects the ctrl clicked item', ->
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView3).toHaveClass('selected')
 
             it 'displays the full context menu', ->
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
         describe "right-clicking", ->
           describe 'when multiple items are selected', ->
             it 'displays the multi-select context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.list).not.toHaveClass('full-menu')
-              expect(treeView.list).toHaveClass('multi-select')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
 
           describe 'when a single item is selected', ->
             it 'displays the full context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
             it 'selects right clicked item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
 
             it 'de-selects the previously selected item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).not.toHaveClass('selected')
 
           describe 'when no item is selected', ->
             it 'selects the right clicked item', ->
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
 
             it 'shows the full context menu', ->
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
@@ -3031,16 +3022,16 @@ describe "TreeView", ->
 
       expect(topLevelEntries).toEqual(["alpha", "gamma", "alpha.txt", "zeta.txt"])
 
-      alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-      alphaDir[0].expand()
-      alphaEntries = [].slice.call(alphaDir[0].children[1].children).map (element) ->
+      alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+      alphaDir.expand()
+      alphaEntries = [].slice.call(alphaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(alphaEntries).toEqual(["eta", "beta.txt"])
 
-      gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-      gammaDir[0].expand()
-      gammaEntries = [].slice.call(gammaDir[0].children[1].children).map (element) ->
+      gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+      gammaDir.expand()
+      gammaEntries = [].slice.call(gammaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(gammaEntries).toEqual(["theta", "delta.txt", "epsilon.txt"])
@@ -3053,16 +3044,16 @@ describe "TreeView", ->
 
       expect(topLevelEntries).toEqual(["alpha", "alpha.txt", "gamma", "zeta.txt"])
 
-      alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-      alphaDir[0].expand()
-      alphaEntries = [].slice.call(alphaDir[0].children[1].children).map (element) ->
+      alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+      alphaDir.expand()
+      alphaEntries = [].slice.call(alphaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(alphaEntries).toEqual(["beta.txt", "eta"])
 
-      gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-      gammaDir[0].expand()
-      gammaEntries = [].slice.call(gammaDir[0].children[1].children).map (element) ->
+      gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+      gammaDir.expand()
+      gammaEntries = [].slice.call(gammaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
@@ -3123,7 +3114,7 @@ describe "TreeView", ->
       waitsForPromise ->
         atom.workspace.open()
       runs ->
-        $(workspaceElement).focus()
+        workspaceElement.focus()
         expect(treeView.showCurrentFileInFileManager()).toBeUndefined()
 
     it "shows file in file manager when some file is opened", ->
@@ -3205,14 +3196,15 @@ describe "TreeView", ->
     describe "when dragging a FileView onto a DirectoryView's header", ->
       it "should add the selected class to the DirectoryView", ->
         # Dragging theta onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        deltaFile = gammaDir[0].entries.children[2]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        deltaFile = gammaDir.entries.children[2]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.find('.header')[0])
+            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'))
         treeView.onDragStart(dragStartEvent)
         treeView.onDragEnter(dragEnterEvent)
         expect(alphaDir).toHaveClass('selected')
@@ -3228,104 +3220,104 @@ describe "TreeView", ->
     describe "when dropping a FileView onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->
         # Dragging delta.txt onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        deltaFile = gammaDir[0].entries.children[2]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        deltaFile = gammaDir.entries.children[2]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.find('.header')[0], alphaDir[0])
+            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'), alphaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       it "should move the directory to the hovered directory", ->
         # Dragging thetaDir onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        thetaDir = gammaDir[0].entries.children[0]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        thetaDir = gammaDir.entries.children[0]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.find('.header')[0], alphaDir[0])
+            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a file from the OS onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->
         # Dragging delta.txt from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a directory from the OS onto a DirectoryView's header", ->
       it "should move the directory to the hovered directory", ->
         # Dragging gammaDir from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([gammaDirPath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([gammaDirPath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a file and directory from the OS onto a DirectoryView's header", ->
       it "should move the file and directory to the hovered directory", ->
         # Dragging delta.txt and gammaDir from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 3
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 3
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 4
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
 
   describe "the alwaysOpenExisting config option", ->
     it "defaults to unset", ->
@@ -3340,21 +3332,21 @@ describe "TreeView", ->
         treeView.focus()
 
         waitsForFileToOpen ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           expect(sampleJs).toHaveClass 'selected'
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(treeView.list).toHaveFocus()
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
         waitsForFileToOpen ->
-          sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+          sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           expect(sampleTxt).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
+          expect(treeView.element.querySelectorAll('.selected').length).toBe 1
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-          expect(treeView.list).toHaveFocus()
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "opening existing opened files in existing split panes", ->
       beforeEach ->
@@ -3420,7 +3412,7 @@ describe "TreeView", ->
             treeView.focus()
 
             waitsForFileToOpen ->
-              sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+              sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
             runs ->
               activePaneItem = atom.workspace.getActivePaneItem()
@@ -3445,8 +3437,8 @@ describe "TreeView", ->
           treeView.focus()
 
           waitsForFileToOpen ->
-            sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
-            sampleTxt.trigger clickEvent(originalEvent: {detail: 2})
+            sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
           waits 100
 
@@ -3499,14 +3491,14 @@ describe "TreeView", ->
       describe "when dragging on the top part of the root", ->
         it "should add the placeholder above the directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.top)
-          expect(alphaDir[0].previousSibling).toHaveClass('placeholder')
+          expect(alphaDir.previousSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3515,14 +3507,14 @@ describe "TreeView", ->
       describe "when dragging on the bottom part of the root", ->
         it "should add the placeholder below the directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
-          expect(alphaDir[0].nextSibling).toHaveClass('placeholder')
+          expect(alphaDir.nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3531,16 +3523,16 @@ describe "TreeView", ->
       describe "when below all entries", ->
         it "should add the placeholder below the last directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          lastDir = $(treeView).find('.project-root:last')
+          alphaDir = treeView.roots[0]
+          lastDir = treeView.roots[treeView.roots.length - 1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(alphaDir.find('.project-root-header')[0], treeView.find('.tree-view')[0])
+            eventHelpers.buildPositionalDragEvents(alphaDir.querySelector('.project-root-header'), treeView.element.querySelector('.tree-view'))
 
-          expect(alphaDir[0]).not.toEqual(lastDir[0])
+          expect(alphaDir).not.toEqual(lastDir)
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
-          expect(lastDir[0].nextSibling).toHaveClass('placeholder')
+          expect(lastDir.nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3551,10 +3543,10 @@ describe "TreeView", ->
       describe "when dropping on the top part of the header", ->
         it "should add the placeholder above the directory", ->
           # dropping gammaDir above alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.top)
@@ -3568,10 +3560,10 @@ describe "TreeView", ->
       describe "when dropping on the bottom part of the header", ->
         it "should add the placeholder below the directory", ->
           # dropping thetaDir below alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          thetaDir = $(treeView).find('.project-root:contains(theta):first')
+          alphaDir = treeView.roots[0]
+          thetaDir = treeView.roots[2]
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(thetaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(thetaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.bottom)
@@ -3585,8 +3577,8 @@ describe "TreeView", ->
 
     describe "when a root folder is dragged out of application", ->
       it "should carry the folder's information", ->
-        gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-        [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
+        gammaDir = treeView.roots[1]
+        [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'))
         treeView.rootDragAndDrop.onDragStart(dragStartEvent)
 
         expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual gammaDirPath
@@ -3595,8 +3587,8 @@ describe "TreeView", ->
 
     describe "when a root folder is dropped from another Atom window", ->
       it "adds the root folder to the window", ->
-        alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.find('.project-root-header')[0], '.tree-view')
+        alphaDir = treeView.roots[0]
+        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.querySelector('.project-root-header'), '.tree-view')
 
         dropEvent = dragDropEvents.bottom
         dropEvent.originalEvent.dataTransfer.setData('atom-tree-view-event', true)
@@ -3620,14 +3612,21 @@ describe "TreeView", ->
 
     describe "when a root folder is dropped to another Atom window", ->
       it "removes the root folder from the first window", ->
-        gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-        [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
+        gammaDir = treeView.roots[1]
+        [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'))
         treeView.rootDragAndDrop.onDragStart(dragStartEvent)
-        treeView.rootDragAndDrop.onDropOnOtherWindow({}, gammaDir.index())
+        treeView.rootDragAndDrop.onDropOnOtherWindow({}, Array.from(gammaDir.parentElement.children).indexOf(gammaDir))
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
         expect('.placeholder').not.toExist()
 
+  findDirectoryContainingText = (element, text) ->
+    directories = Array.from(element.querySelectorAll('.entries .directory'))
+    directories.find((directory) -> directory.header.textContent is text)
+
+  findFileContainingText = (element, text) ->
+    files = Array.from(element.querySelectorAll('.entries .file'))
+    files.find((file) -> file.fileName.textContent is text)
 
 describe 'Icon class handling', ->
   it 'allows multiple classes to be passed', ->


### PR DESCRIPTION
The benefits of this pull request are twofold:

1. **Tests will now pass on Windows.** We have finally discovered the cause of the hard crashes we were observing on Windows when running tests. We believe it can be attributed to jQuery leaking `pathwatcher` objects when wrapping tree view elements inside a `$()` function.
2. **It paves the way for the `atom-space-pen-views` removal from production code.** In facts, the work we did on this pull request should have happened anyways as part of the space-pen removal we are planning to do. By doing it first and in a separate pull request, however, we can ensure the old behavior is preserved both on Windows and on macOS.

/cc: @atom/maintainers