### PR TITLE
Remove atom-space-pen-views and custom elements

### DIFF
--- a/lib/add-dialog.coffee
+++ b/lib/add-dialog.coffee
@@ -23,6 +23,12 @@ class AddDialog extends Dialog
       select: false
       iconClass: if isCreatingFile then 'icon-file-add' else 'icon-file-directory-create'
 
+  onDidCreateFile: (callback) ->
+    @emitter.on('did-create-file', callback)
+
+  onDidCreateDirectory: (callback) ->
+    @emitter.on('did-create-directory', callback)
+
   onConfirm: (newPath) ->
     newPath = newPath.replace(/\s+$/, '') # Remove trailing whitespace
     endsWithDirectorySeparator = newPath[newPath.length - 1] is path.sep
@@ -44,11 +50,11 @@ class AddDialog extends Dialog
         else
           fs.writeFileSync(newPath, '')
           repoForPath(newPath)?.getPathStatus(newPath)
-          @trigger 'file-created', [newPath]
+          @emitter.emit('did-create-file', newPath)
           @close()
       else
         fs.makeTreeSync(newPath)
-        @trigger 'directory-created', [newPath]
+        @emitter.emit('did-create-directory', newPath)
         @cancel()
     catch error
       @showError("#{error.message}.")

--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -29,7 +29,7 @@ class Dialog extends View
       @miniEditor.getModel().setSelectedBufferRange(range)
 
   attach: ->
-    @panel = atom.workspace.addModalPanel(item: this.element)
+    @panel = atom.workspace.addModalPanel(item: this)
     @miniEditor.focus()
     @miniEditor.getModel().scrollToCursorPosition()
 

--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -60,7 +60,7 @@ class Dialog
 
   cancel: ->
     @close()
-    document.querySelector('.tree-view').focus()
+    document.querySelector('.tree-view')?.focus()
 
   showError: (message='') ->
     @errorMessage.textContent = message

--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -1,48 +1,69 @@
-{$, TextEditorView, View} = require 'atom-space-pen-views'
+{TextEditor, CompositeDisposable, Disposable, Emitter, Range, Point} = require 'atom'
 path = require 'path'
 
 module.exports =
-class Dialog extends View
-  @content: ({prompt} = {}) ->
-    @div class: 'tree-view-dialog', =>
-      @label prompt, class: 'icon', outlet: 'promptText'
-      @subview 'miniEditor', new TextEditorView(mini: true)
-      @div class: 'error-message', outlet: 'errorMessage'
+class Dialog
+  constructor: ({initialPath, select, iconClass, prompt} = {}) ->
+    @emitter = new Emitter()
+    @disposables = new CompositeDisposable()
 
-  initialize: ({initialPath, select, iconClass} = {}) ->
-    @promptText.addClass(iconClass) if iconClass
+    @element = document.createElement('div')
+    @element.classList.add('tree-view-dialog')
+
+    @promptText = document.createElement('label')
+    @promptText.classList.add('icon')
+    @promptText.classList.add(iconClass) if iconClass
+    @promptText.textContent = prompt
+    @element.appendChild(@promptText)
+
+    @miniEditor = new TextEditor({mini: true})
+    blurHandler = =>
+      @close() if document.hasFocus()
+    @miniEditor.element.addEventListener('blur', blurHandler)
+    @disposables.add(new Disposable(=> @miniEditor.element.removeEventListener('blur', blurHandler)))
+    @disposables.add(@miniEditor.onDidChange => @showError())
+    @element.appendChild(@miniEditor.element)
+
+    @errorMessage = document.createElement('div')
+    @errorMessage.classList.add('error-message')
+    @element.appendChild(@errorMessage)
+
     atom.commands.add @element,
       'core:confirm': => @onConfirm(@miniEditor.getText())
       'core:cancel': => @cancel()
-    @miniEditor.on 'blur', => @close() if document.hasFocus()
-    @miniEditor.getModel().onDidChange => @showError()
-    @miniEditor.getModel().setText(initialPath)
+
+    @miniEditor.setText(initialPath)
 
     if select
       extension = path.extname(initialPath)
       baseName = path.basename(initialPath)
+      selectionStart = initialPath.length - baseName.length
       if baseName is extension
         selectionEnd = initialPath.length
       else
         selectionEnd = initialPath.length - extension.length
-      range = [[0, initialPath.length - baseName.length], [0, selectionEnd]]
-      @miniEditor.getModel().setSelectedBufferRange(range)
+      @miniEditor.setSelectedBufferRange(Range(Point(0, selectionStart), Point(0, selectionEnd)))
 
   attach: ->
     @panel = atom.workspace.addModalPanel(item: this)
-    @miniEditor.focus()
-    @miniEditor.getModel().scrollToCursorPosition()
+    @miniEditor.element.focus()
+    @miniEditor.scrollToCursorPosition()
 
   close: ->
     panelToDestroy = @panel
     @panel = null
     panelToDestroy?.destroy()
+    @emitter.dispose()
+    @disposables.dispose()
+    @miniEditor.destroy()
     atom.workspace.getActivePane().activate()
 
   cancel: ->
     @close()
-    $('.tree-view').focus()
+    document.querySelector('.tree-view').focus()
 
   showError: (message='') ->
-    @errorMessage.text(message)
-    @flashError() if message
+    @errorMessage.textContent = message
+    if message
+      @element.classList.add('error')
+      window.setTimeout((=> @element.classList.remove('error')), 300)

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -33,6 +33,7 @@ class FileView
     @element.isPathEqual = @isPathEqual.bind(this)
     @element.file = @file
     @element.fileName = @fileName
+    @element.updateStatus = @updateStatus.bind(this)
 
   updateStatus: ->
     @element.classList.remove('status-ignored', 'status-modified',  'status-added')

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -2,18 +2,19 @@
 FileIcons = require './file-icons'
 
 module.exports =
-class FileView extends HTMLElement
-  initialize: (@file) ->
+class FileView
+  constructor: (@file) ->
     @subscriptions = new CompositeDisposable()
     @subscriptions.add @file.onDidDestroy => @subscriptions.dispose()
 
-    @draggable = true
-
-    @classList.add('file', 'entry', 'list-item')
+    @element = document.createElement('li')
+    @element.setAttribute('is', 'tree-view-file')
+    @element.draggable = true
+    @element.classList.add('file', 'entry', 'list-item')
 
     @fileName = document.createElement('span')
     @fileName.classList.add('name', 'icon')
-    @appendChild(@fileName)
+    @element.appendChild(@fileName)
     @fileName.textContent = @file.name
     @fileName.title = @file.name
     @fileName.dataset.name = @file.name
@@ -28,14 +29,17 @@ class FileView extends HTMLElement
     @subscriptions.add @file.onDidStatusChange => @updateStatus()
     @updateStatus()
 
+    @element.getPath = @getPath.bind(this)
+    @element.isPathEqual = @isPathEqual.bind(this)
+    @element.file = @file
+    @element.fileName = @fileName
+
   updateStatus: ->
-    @classList.remove('status-ignored', 'status-modified',  'status-added')
-    @classList.add("status-#{@file.status}") if @file.status?
+    @element.classList.remove('status-ignored', 'status-modified',  'status-added')
+    @element.classList.add("status-#{@file.status}") if @file.status?
 
   getPath: ->
     @fileName.dataset.path
 
   isPathEqual: (pathToCompare) ->
     @file.isPathEqual(pathToCompare)
-
-module.exports = document.registerElement('tree-view-file', prototype: FileView.prototype, extends: 'li')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,6 +2,7 @@
 path = require 'path'
 
 FileIcons = require './file-icons'
+TreeView = require './tree-view'
 
 module.exports =
   treeView: null
@@ -47,7 +48,6 @@ module.exports =
 
   createView: ->
     unless @treeView?
-      TreeView = require './tree-view'
       @treeView = new TreeView(@state)
     @treeView
 

--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -16,11 +16,11 @@ class RootDragAndDropHandler
   handleEvents: ->
     # onDragStart is called directly by TreeView's onDragStart
     # will be cleaned up by tree view, since they are tree-view's handlers
-    @treeView.element.addEventListener 'dragenter', @onDragEnter
-    @treeView.element.addEventListener 'dragend', @onDragEnd
-    @treeView.element.addEventListener 'dragleave', @onDragLeave
-    @treeView.element.addEventListener 'dragover', @onDragOver
-    @treeView.element.addEventListener 'drop', @onDrop
+    @treeView.element.addEventListener 'dragenter', @onDragEnter.bind(this)
+    @treeView.element.addEventListener 'dragend', @onDragEnd.bind(this)
+    @treeView.element.addEventListener 'dragleave', @onDragLeave.bind(this)
+    @treeView.element.addEventListener 'dragover', @onDragOver.bind(this)
+    @treeView.element.addEventListener 'drop', @onDrop.bind(this)
 
   onDragStart: (e) =>
     return unless @treeView.list.contains(e.target)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -423,6 +423,8 @@ class TreeView
 
   expandDirectory: (isRecursive=false) ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry?
+
     if isRecursive is false and selectedEntry.isExpanded
       @moveDown() if selectedEntry.directory.getEntries().length > 0
     else
@@ -438,6 +440,8 @@ class TreeView
 
   openSelectedEntry: (options={}, expandDirectory=false) ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry?
+
     if selectedEntry.classList.contains('directory')
       if expandDirectory
         @expandDirectory(false)
@@ -450,6 +454,8 @@ class TreeView
 
   openSelectedEntrySplit: (orientation, side) ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry?
+
     pane = atom.workspace.getActivePane()
     if pane and selectedEntry.classList.contains('file')
       if atom.workspace.getActivePaneItem()
@@ -472,6 +478,8 @@ class TreeView
 
   openSelectedEntryInPane: (index) ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry?
+
     pane = atom.workspace.getPanes()[index]
     if pane and selectedEntry.classList.contains('file')
       atom.workspace.openURIInPane selectedEntry.getPath(), pane

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -7,9 +7,9 @@ _ = require 'underscore-plus'
 {$, View} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 
-AddDialog = null  # Defer requiring until actually needed
-MoveDialog = null # Defer requiring until actually needed
-CopyDialog = null # Defer requiring until actually needed
+AddDialog = require './add-dialog'
+MoveDialog = require './move-dialog'
+CopyDialog = require './copy-dialog'
 Minimatch = null  # Defer requiring until actually needed
 
 Directory = require './directory'
@@ -454,7 +454,6 @@ class TreeView extends View
       oldPath = @getActivePath()
 
     if oldPath
-      MoveDialog ?= require './move-dialog'
       dialog = new MoveDialog(oldPath)
       dialog.attach()
 
@@ -542,7 +541,6 @@ class TreeView extends View
       oldPath = @getActivePath()
     return unless oldPath
 
-    CopyDialog ?= require './copy-dialog'
     dialog = new CopyDialog(oldPath)
     dialog.attach()
 
@@ -675,17 +673,14 @@ class TreeView extends View
     selectedEntry = @selectedEntry() ? @roots[0]
     selectedPath = selectedEntry?.getPath() ? ''
 
-    AddDialog ?= require './add-dialog'
     dialog = new AddDialog(selectedPath, isCreatingFile)
-    dialog.on 'directory-created', (event, createdPath) =>
+    dialog.onDidCreateDirectory (createdPath) =>
       @entryForPath(createdPath)?.reload()
       @selectEntryForPath(createdPath)
       @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
-      false
-    dialog.on 'file-created', (event, createdPath) =>
+    dialog.onDidCreateFile (createdPath) =>
       atom.workspace.open(createdPath)
       @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
-      false
     dialog.attach()
 
   removeProjectFolder: (e) ->

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "atom-space-pen-views": "^2.1.1",
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
     "minimatch": "~0.3.0",

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -1,5 +1,3 @@
-{$} = require 'atom-space-pen-views'
-
 module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
   dataTransfer =
     data: {}
@@ -7,20 +5,20 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
     getData: (key) -> @data[key]
     setDragImage: (@image) -> return
 
-  dragStartEvent = $.Event()
-  dragStartEvent.target = dragged
-  dragStartEvent.currentTarget = dragged
-  dragStartEvent.originalEvent = {dataTransfer}
+  dragStartEvent = new DragEvent('dragstart')
+  Object.defineProperty(dragStartEvent, 'target', value: dragged)
+  Object.defineProperty(dragStartEvent, 'currentTarget', value: dragged)
+  Object.defineProperty(dragStartEvent, 'dataTransfer', value: dataTransfer)
 
-  dropEvent = $.Event()
-  dropEvent.target = dropTarget
-  dropEvent.currentTarget = dropTarget
-  dropEvent.originalEvent = {dataTransfer}
+  dropEvent = new DragEvent('drop')
+  Object.defineProperty(dropEvent, 'target', value: dropTarget)
+  Object.defineProperty(dropEvent, 'currentTarget', value: dropTarget)
+  Object.defineProperty(dropEvent, 'dataTransfer', value: dataTransfer)
 
-  dragEnterEvent = $.Event()
-  dragEnterEvent.target = enterTarget
-  dragEnterEvent.currentTarget = enterTarget
-  dragEnterEvent.originalEvent = {dataTransfer}
+  dragEnterEvent = new DragEvent('dragenter')
+  Object.defineProperty(dragEnterEvent, 'target', value: enterTarget)
+  Object.defineProperty(dragEnterEvent, 'currentTarget', value: enterTarget)
+  Object.defineProperty(dragEnterEvent, 'dataTransfer', value: dataTransfer)
 
   [dragStartEvent, dragEnterEvent, dropEvent]
 
@@ -31,38 +29,39 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
     getData: (key) -> @data[key]
     files: []
 
-  dropEvent = $.Event()
-  dropEvent.target = dropTarget
-  dropEvent.currentTarget = dropTarget
-  dropEvent.originalEvent = {dataTransfer}
+  dropEvent = new DragEvent('drop')
+  Object.defineProperty(dropEvent, 'target', value: dropTarget)
+  Object.defineProperty(dropEvent, 'currentTarget', value: dropTarget)
+  Object.defineProperty(dropEvent, 'dataTransfer', value: dataTransfer)
 
   for filePath in filePaths
-    dropEvent.originalEvent.dataTransfer.files.push({path: filePath})
+    dropEvent.dataTransfer.files.push({path: filePath})
 
   dropEvent
 
 buildElementPositionalDragEvents = (el, dataTransfer, currentTargetSelector) ->
   if not el?
     return {}
-  $el = $(el)
 
-  $currentTarget = if currentTargetSelector then $el.closest(currentTargetSelector) else $el
-  currentTarget = $currentTarget[0]
+  currentTarget = if currentTargetSelector then el.closest(currentTargetSelector) else el
 
-  topEvent = $.Event()
-  topEvent.target = el
-  topEvent.currentTarget = currentTarget
-  topEvent.originalEvent = {dataTransfer, pageY: $el.offset().top}
+  topEvent = new DragEvent('dragstart')
+  Object.defineProperty(topEvent, 'target', value: el)
+  Object.defineProperty(topEvent, 'currentTarget', value: currentTarget)
+  Object.defineProperty(topEvent, 'dataTransfer', value: dataTransfer)
+  Object.defineProperty(topEvent, 'pageY', value: el.getBoundingClientRect().top)
 
-  middleEvent = $.Event()
-  middleEvent.target = el
-  middleEvent.currentTarget = currentTarget
-  middleEvent.originalEvent = {dataTransfer, pageY: $el.offset().top + $el.height() * 0.5}
+  middleEvent = new DragEvent('dragover')
+  Object.defineProperty(middleEvent, 'target', value: el)
+  Object.defineProperty(middleEvent, 'currentTarget', value: currentTarget)
+  Object.defineProperty(middleEvent, 'dataTransfer', value: dataTransfer)
+  Object.defineProperty(middleEvent, 'pageY', value: el.getBoundingClientRect().top + el.offsetHeight * 0.5)
 
-  bottomEvent = $.Event()
-  bottomEvent.target = el
-  bottomEvent.currentTarget = currentTarget
-  bottomEvent.originalEvent = {dataTransfer, pageY: $el.offset().bottom}
+  bottomEvent = new DragEvent('dragend')
+  Object.defineProperty(bottomEvent, 'target', value: el)
+  Object.defineProperty(bottomEvent, 'currentTarget', value: currentTarget)
+  Object.defineProperty(bottomEvent, 'dataTransfer', value: dataTransfer)
+  Object.defineProperty(bottomEvent, 'pageY', value: el.getBoundingClientRect().bottom)
 
   {top: topEvent, middle: middleEvent, bottom: bottomEvent}
 
@@ -74,14 +73,14 @@ module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelect
     getData: (key) -> @data[key]
     setDragImage: (@image) -> return
 
-  dragStartEvent = $.Event()
-  dragStartEvent.target = dragged
-  dragStartEvent.currentTarget = dragged
-  dragStartEvent.originalEvent = {dataTransfer}
+  dragStartEvent = new DragEvent('dragstart')
+  Object.defineProperty(dragStartEvent, 'target', value: dragged)
+  Object.defineProperty(dragStartEvent, 'currentTarget', value: dragged)
+  Object.defineProperty(dragStartEvent, 'dataTransfer', value: dataTransfer)
 
-  dragEndEvent = $.Event()
-  dragEndEvent.target = dragged
-  dragEndEvent.currentTarget = dragged
-  dragEndEvent.originalEvent = {dataTransfer}
+  dragEndEvent = new DragEvent('dragend')
+  Object.defineProperty(dragEndEvent, 'target', value: dragged)
+  Object.defineProperty(dragEndEvent, 'currentTarget', value: dragged)
+  Object.defineProperty(dragEndEvent, 'dataTransfer', value: dataTransfer)
 
   [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer, currentTargetSelector), dragEndEvent]

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -1,5 +1,4 @@
 _ = require 'underscore-plus'
-{$, $$} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 path = require 'path'
 temp = require('temp').track()
@@ -25,7 +24,7 @@ describe "FileStats", ->
         atom.packages.activatePackage("tree-view")
 
       runs ->
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
 
     afterEach ->
       temp.cleanup()
@@ -45,7 +44,7 @@ describe "FileStats", ->
       expect(treeView.roots[0].directory.stats).toBeDefined()
 
     it "passes stats to File instances in subdirectories", ->
-      treeView.find(".entries > li:contains(subdir)")[0].expand()
+      treeView.element.querySelector(".entries > li").expand()
       subdir = treeView.roots[0].directory.entries["subdir"]
       stats = subdir.entries["file2.txt"].stats
       expect(stats).toBeDefined()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2555,11 +2555,7 @@ describe "TreeView", ->
         expect(zetaEntries).toEqual(["zeta.txt"])
 
       it "squashes two dir names when the first only contains a single dir", ->
-        if path.sep is '\\'
-          # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\beta")
-        else
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
+        betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
         betaDir.expand()
         betaEntries = [].slice.call(betaDir.children[1].children).map (element) ->
           element.innerText
@@ -2567,11 +2563,7 @@ describe "TreeView", ->
         expect(betaEntries).toEqual(["beta.txt"])
 
       it "squashes three dir names when the first and second only contain single dirs", ->
-        if path.sep is '\\'
-          # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\delta\\epsilon")
-        else
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
+        epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
         epsilonDir.expand()
         epsilonEntries = [].slice.call(epsilonDir.children[1].children).map (element) ->
           element.innerText

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2543,13 +2543,13 @@ describe "TreeView", ->
 
         rootDirPath = treeView.roots[0].getPath()
         expect(rootDirPath).toBe(rootDir)
-        zetaDirPath = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')[0].getPath()
+        zetaDirPath = findDirectoryContainingText(treeView.roots[0], 'zeta').getPath()
         expect(zetaDirPath).toBe(zetaDir)
 
       it "does not squash a file in to a DirectoryViews", ->
-        zetaDir = $(treeView.roots[0].entries).find('.directory:contains(zeta):first')
-        zetaDir[0].expand()
-        zetaEntries = [].slice.call(zetaDir[0].children[1].children).map (element) ->
+        zetaDir = findDirectoryContainingText(treeView.roots[0], 'zeta')
+        zetaDir.expand()
+        zetaEntries = [].slice.call(zetaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(zetaEntries).toEqual(["zeta.txt"])
@@ -2557,11 +2557,11 @@ describe "TreeView", ->
       it "squashes two dir names when the first only contains a single dir", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = $(treeView.roots[0].entries).find(".directory:contains(alpha\\\\beta):first")
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\\\beta")
         else
-          betaDir = $(treeView.roots[0].entries).find(".directory:contains(alpha#{path.sep}beta):first")
-        betaDir[0].expand()
-        betaEntries = [].slice.call(betaDir[0].children[1].children).map (element) ->
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
+        betaDir.expand()
+        betaEntries = [].slice.call(betaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(betaEntries).toEqual(["beta.txt"])
@@ -2569,19 +2569,19 @@ describe "TreeView", ->
       it "squashes three dir names when the first and second only contain single dirs", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = $(treeView.roots[0].entries).find(".directory:contains(gamma\\\\delta\\\\epsilon):first")
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\\\delta\\\\epsilon")
         else
-          epsilonDir = $(treeView.roots[0].entries).find(".directory:contains(gamma#{path.sep}delta#{path.sep}epsilon):first")
-        epsilonDir[0].expand()
-        epsilonEntries = [].slice.call(epsilonDir[0].children[1].children).map (element) ->
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
+        epsilonDir.expand()
+        epsilonEntries = [].slice.call(epsilonDir.children[1].children).map (element) ->
           element.innerText
 
         expect(epsilonEntries).toEqual(["theta.txt"])
 
       it "does not squash a dir name when there are two child dirs ", ->
-        lambdaDir = $(treeView.roots[0].entries).find('.directory:contains(lambda):first')
-        lambdaDir[0].expand()
-        lambdaEntries = [].slice.call(lambdaDir[0].children[1].children).map (element) ->
+        lambdaDir = findDirectoryContainingText(treeView.roots[0], "lambda")
+        lambdaDir.expand()
+        lambdaEntries = [].slice.call(lambdaDir.children[1].children).map (element) ->
           element.innerText
 
         expect(lambdaEntries).toEqual(["iota", "kappa"])
@@ -2589,20 +2589,20 @@ describe "TreeView", ->
       describe "when a squashed directory is deleted", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           treeView.focus()
           treeView.selectEntry(piDir)
           spyOn(atom, 'confirm').andCallFake (dialog) ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
 
       describe "when a file is created within a directory with another squashed directory", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           expect(piDir).not.toBeNull()
           # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
@@ -2610,18 +2610,18 @@ describe "TreeView", ->
           fs.writeFileSync(sigmaFilePath, "doesn't matter")
           treeView.updateRoots()
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
           omicronDir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
-          expect(piDir.title).toEqual("pi")
-          sigmaFile = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .file:contains(sigma) span")[0]
-          expect(sigmaFile.title).toEqual("sigma.txt")
+          piDir = findDirectoryContainingText(omicronDir, "pi")
+          expect(piDir.header.textContent).toEqual("pi")
+          sigmaFile = findFileContainingText(omicronDir, "sigma.txt")
+          expect(sigmaFile.fileName.textContent).toEqual("sigma.txt")
 
       describe "when a directory is created within a directory with another squashed directory", ->
         it "un-squashes the directories", ->
           jasmine.attachToDOM(workspaceElement)
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron#{path.sep}pi):first")[0]
+          piDir = findDirectoryContainingText(treeView.roots[0], "omicron#{path.sep}pi")
           expect(piDir).not.toBeNull()
           # omicron is a squashed dir, so searching for omicron would give us omicron/pi instead
           omicronPath = piDir.getPath().replace "#{path.sep}pi", ""
@@ -2629,25 +2629,33 @@ describe "TreeView", ->
           fs.makeTreeSync(rhoDirPath)
           treeView.updateRoots()
 
-          omicronDir = $(treeView.roots[0].entries).find(".directory:contains(omicron):first span")[0]
-          expect(omicronDir.title).toEqual("omicron")
+          omicronDir = findDirectoryContainingText(treeView.roots[0], "omicron")
+          expect(omicronDir.header.textContent).toEqual("omicron")
           omicronDir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          piDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(pi) span")[0]
-          expect(piDir.title).toEqual("pi")
-          rhoDir = $(treeView.roots[0].entries).find(".directory:contains(omicron) .entries .directory:contains(rho) span")[0]
-          expect(rhoDir.title).toEqual("rho")
+          piDir = findDirectoryContainingText(omicronDir, "pi")
+          expect(piDir.header.textContent).toEqual("pi")
+          rhoDir = findDirectoryContainingText(omicronDir, "rho")
+          expect(rhoDir.header.textContent).toEqual("rho")
 
       describe "when a directory is reloaded", ->
         it "squashes the directory names the last of which is same as an unsquashed directory", ->
-          muDir = $(treeView.roots[0].entries).find('.directory:contains(mu):first')
-          muDir[0].expand()
-          muEntries = Array.from(muDir[0].children[1].children).map (element) -> element.innerText
+          muDir = findDirectoryContainingText(treeView.roots[0], "mu")
+          muDir.expand()
+          muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
 
-          muDir[0].expand()
-          muDir[0].reload()
-          muEntries = Array.from(muDir[0].children[1].children).map (element) -> element.innerText
+          muDir.expand()
+          muDir.reload()
+          muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
+
+    findDirectoryContainingText = (element, text) ->
+      directories = Array.from(element.querySelectorAll('.entries .directory'))
+      directories.find((directory) -> directory.header.textContent is text)
+
+    findFileContainingText = (element, text) ->
+      files = Array.from(element.querySelectorAll('.entries .file'))
+      files.find((file) -> file.fileName.textContent is text)
 
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -225,7 +225,7 @@ describe "TreeView", ->
     it "restores the focus state of the tree view", ->
       jasmine.attachToDOM(workspaceElement)
       treeView.focus()
-      expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+      expect(treeView.list).toMatchSelector(":focus")
       atom.packages.deactivatePackage("tree-view")
 
       waitsForPromise ->
@@ -233,7 +233,7 @@ describe "TreeView", ->
 
       runs ->
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     it "restores the scroll top when toggled", ->
       workspaceElement.style.height = '5px'
@@ -294,7 +294,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     describe "when tree-view:toggle-side is triggered on the root view", ->
       describe "when the tree view is on the left", ->
@@ -330,7 +330,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
 
     describe "when the tree view is shown", ->
       it "focuses the tree view", ->
@@ -342,7 +342,7 @@ describe "TreeView", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
           expect(treeView).toBeVisible()
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
       describe "when the tree view is focused", ->
         it "unfocuses the tree view", ->
@@ -354,7 +354,7 @@ describe "TreeView", ->
             expect(treeView).toBeVisible()
             atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
             expect(treeView).toBeVisible()
-            expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
+            expect(treeView.list).not.toMatchSelector(":focus")
 
   describe "when tree-view:reveal-active-file is triggered on the root view", ->
     beforeEach ->
@@ -464,10 +464,10 @@ describe "TreeView", ->
       runs ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+        expect(treeView.list).toMatchSelector(":focus")
         atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
         expect(treeView).toBeVisible()
-        expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
+        expect(treeView.list).not.toMatchSelector(":focus")
         expect(atom.workspace.getActivePane().isActive()).toBe(true)
 
   describe "copy path commands", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toHaveFocus()
+            expect(treeView.querySelector(".tree-view")).toHaveFocus()
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toHaveFocus()
+            expect(treeView.querySelector(".tree-view")).toHaveFocus()
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2836,9 +2836,9 @@ describe "TreeView", ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
         fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
-        expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+        expect(treeView.list).toHaveClass('multi-select')
         fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
-        expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+        expect(treeView.list).toHaveClass('full-menu')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
@@ -2904,16 +2904,16 @@ describe "TreeView", ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
           describe 'previous item is selected including the ctrl clicked', ->
             it 'displays the multi-select menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+              expect(treeView.list).not.toHaveClass('full-menu')
+              expect(treeView.list).toHaveClass('multi-select')
 
             it 'does not deselect any of the items', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -2926,8 +2926,8 @@ describe "TreeView", ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
           describe 'when no item is selected', ->
             it 'selects the ctrl clicked item', ->
@@ -2936,8 +2936,8 @@ describe "TreeView", ->
 
             it 'displays the full context menu', ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
         describe "right-clicking", ->
           describe 'when multiple items are selected', ->
@@ -2947,15 +2947,15 @@ describe "TreeView", ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+              expect(treeView.list).not.toHaveClass('full-menu')
+              expect(treeView.list).toHaveClass('multi-select')
 
           describe 'when a single item is selected', ->
             it 'displays the full context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
             it 'selects right clicked item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -2975,8 +2975,8 @@ describe "TreeView", ->
             it 'shows the full context menu', ->
               fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
-              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
+              expect(treeView.list).toHaveClass('full-menu')
+              expect(treeView.list).not.toHaveClass('multi-select')
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
@@ -3337,7 +3337,7 @@ describe "TreeView", ->
         runs ->
           expect(sampleJs).toHaveClass 'selected'
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
         waitsForFileToOpen ->
           sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
@@ -3346,7 +3346,7 @@ describe "TreeView", ->
           expect(sampleTxt).toHaveClass 'selected'
           expect(treeView.element.querySelectorAll('.selected').length).toBe 1
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
+          expect(treeView.list).toMatchSelector(":focus")
 
     describe "opening existing opened files in existing split panes", ->
       beforeEach ->
@@ -3422,7 +3422,7 @@ describe "TreeView", ->
             expect(treeView).toHaveFocus()
 
           it "doesn't open the file in the active pane", ->
-            expect(atom.views.getView(treeView)).toHaveFocus()
+            expect(atom.views.getView(treeView).element).toHaveFocus()
             expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
 
       describe "when a file is double-clicked", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -57,40 +57,42 @@ describe "TreeView", ->
 
     runs ->
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+      treeView = atom.workspace.getLeftPanels()[0].getItem()
+      files = treeView[0].querySelectorAll('.file')
+      root1 = treeView.roots[0]
+      root2 = treeView.roots[1]
+      sampleJs = files[0]
+      sampleTxt = files[1]
 
-      root1 = $(treeView.roots[0])
-      root2 = $(treeView.roots[1])
-      sampleJs = treeView.find('.file:contains(tree-view.js)')
-      sampleTxt = treeView.find('.file:contains(tree-view.txt)')
-
-      expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
+      expect(root1.directory.watchSubscription).toBeTruthy()
 
   afterEach ->
     temp.cleanup()
 
   describe ".initialize(project)", ->
     it "renders the root directories of the project and their contents alphabetically with subdirectories first, in a collapsed state", ->
-      expect(root1.find('> .header .disclosure-arrow')).not.toHaveClass('expanded')
-      expect(root1.find('> .header .name')).toHaveText('root-dir1')
+      expect(root1.querySelector('.header .disclosure-arrow')).not.toHaveClass('expanded')
+      expect(root1.querySelector('.header .name')).toHaveText('root-dir1')
 
-      rootEntries = root1.find('.entries')
-      subdir0 = rootEntries.find('> li:eq(0)')
+      rootEntries = root1.querySelectorAll('.entries li')
+      subdir0 = rootEntries[0]
       expect(subdir0).not.toHaveClass('expanded')
-      expect(subdir0.find('.name')).toHaveText('dir1')
+      expect(subdir0.querySelector('.name')).toHaveText('dir1')
 
-      subdir2 = rootEntries.find('> li:eq(1)')
+      subdir2 = rootEntries[1]
       expect(subdir2).not.toHaveClass('expanded')
-      expect(subdir2.find('.name')).toHaveText('dir2')
+      expect(subdir2.querySelector('.name')).toHaveText('dir2')
 
-      expect(subdir0.find('[data-name="dir1"]')).toExist()
-      expect(subdir2.find('[data-name="dir2"]')).toExist()
+      expect(subdir0.querySelector('[data-name="dir1"]')).toExist()
+      expect(subdir2.querySelector('[data-name="dir2"]')).toExist()
 
-      expect(rootEntries.find('> .file:contains(tree-view.js)')).toExist()
-      expect(rootEntries.find('> .file:contains(tree-view.txt)')).toExist()
+      file1 = root1.querySelector('.file [data-name="tree-view.js"]')
+      expect(file1).toExist()
+      expect(file1).toHaveText('tree-view.js')
 
-      expect(rootEntries.find('> .file [data-name="tree-view.js"]')).toExist()
-      expect(rootEntries.find('> .file [data-name="tree-view.txt"]')).toExist()
+      file2 = root1.querySelector('.file [data-name="tree-view.txt"]')
+      expect(file2).toExist()
+      expect(file2).toHaveText('tree-view.txt')
 
     it "selects the root folder", ->
       expect(treeView.selectedEntry()).toEqual(treeView.roots[0])
@@ -208,10 +210,10 @@ describe "TreeView", ->
         expect(atom.workspace.getLeftPanels().length).toBe(0)
 
     it "restores expanded directories and selected file when deserialized", ->
-      root1.find('.directory:contains(dir1)').click()
+      root1.querySelectorAll('.directory')[0].dispatchEvent(new MouseEvent('click', {detail: 1, bubbles: true}))
 
       waitsForFileToOpen ->
-        sampleJs.click()
+        sampleJs.dispatchEvent(new MouseEvent('click', {detail: 1, bubbles: true}))
 
       runs ->
         atom.packages.deactivatePackage("tree-view")
@@ -220,7 +222,7 @@ describe "TreeView", ->
         atom.packages.activatePackage("tree-view")
 
       runs ->
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         expect($(treeView.selectedEntry())).toMatchSelector(".file:contains(tree-view.js)")
         root1 = $(treeView.roots[0])
@@ -236,7 +238,7 @@ describe "TreeView", ->
         atom.packages.activatePackage("tree-view")
 
       runs ->
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView.list).toMatchSelector ':focus'
 
     it "restores the scroll top when toggled", ->
@@ -322,7 +324,7 @@ describe "TreeView", ->
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
           expect(atom.workspace.getLeftPanels().length).toBe 0
-          treeView = $(atom.workspace.getRightPanels()[0].getItem()).view()
+          treeView = atom.workspace.getRightPanels()[0].getItem()
           expect(treeView).toMatchSelector('[data-show-on-right-side="true"]')
 
   describe "when tree-view:toggle-focus is triggered on the root view", ->
@@ -512,7 +514,7 @@ describe "TreeView", ->
 
   describe "when a directory's disclosure arrow is clicked", ->
     it "expands / collapses the associated directory", ->
-      subdir = root1.find('.entries > li:contains(dir1)')
+      subdir = root1.querySelector('.entries > li')
 
       expect(subdir).not.toHaveClass('expanded')
 
@@ -524,10 +526,10 @@ describe "TreeView", ->
       expect(subdir).not.toHaveClass('expanded')
 
     it "restores the expansion state of descendant directories", ->
-      child = root1.find('.entries > li:contains(dir1)')
+      child = root1.querySelector('.entries > li')
       child.click()
 
-      grandchild = child.find('.entries > li:contains(sub-dir1)')
+      grandchild = child.querySelector('.entries > li')
       grandchild.click()
 
       root1.click()
@@ -535,37 +537,37 @@ describe "TreeView", ->
       root1.click()
 
       # previously expanded descendants remain expanded
-      expect(root1.find('> .entries > li:contains(dir1) > .entries > li:contains(sub-dir1) > .entries').length).toBe 1
+      expect(root1.querySelectorAll('.entries > li > .entries > li > .entries').length).toBe 1
 
       # collapsed descendants remain collapsed
-      expect(root1.find('> .entries > li:contains(dir2) > .entries')).not.toHaveClass('expanded')
+      expect(root1.querySelectorAll('.entries > li')[1].querySelector('.entries')).not.toHaveClass('expanded')
 
     it "when collapsing a directory, removes change subscriptions from the collapsed directory and its descendants", ->
-      child = root1.find('li:contains(dir1)')
+      child = root1.querySelector('li')
       child.click()
 
-      grandchild = child.find('li:contains(sub-dir1)')
+      grandchild = child.querySelector('li')
       grandchild.click()
 
-      expect(treeView.roots[0].directory.watchSubscription).toBeTruthy()
-      expect(child[0].directory.watchSubscription).toBeTruthy()
-      expect(grandchild[0].directory.watchSubscription).toBeTruthy()
+      expect(root1.directory.watchSubscription).toBeTruthy()
+      expect(child.directory.watchSubscription).toBeTruthy()
+      expect(grandchild.directory.watchSubscription).toBeTruthy()
 
       root1.click()
 
-      expect(treeView.roots[0].directory.watchSubscription).toBeFalsy()
-      expect(child[0].directory.watchSubscription).toBeFalsy()
-      expect(grandchild[0].directory.watchSubscription).toBeFalsy()
+      expect(root1.directory.watchSubscription).toBeFalsy()
+      expect(child.directory.watchSubscription).toBeFalsy()
+      expect(grandchild.directory.watchSubscription).toBeFalsy()
 
   describe "when mouse down fires on a file or directory", ->
     it "selects the entry", ->
-      dir = root1.find('li:contains(dir1)')
+      dir = root1.querySelector('li')
       expect(dir).not.toHaveClass 'selected'
-      dir.mousedown()
+      dir.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, detail: 1}))
       expect(dir).toHaveClass 'selected'
 
       expect(sampleJs).not.toHaveClass 'selected'
-      sampleJs.mousedown()
+      sampleJs.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, detail: 1}))
       expect(sampleJs).toHaveClass 'selected'
 
   describe "when the package first activates and there is a file open (regression)", ->
@@ -580,8 +582,8 @@ describe "TreeView", ->
 
       it "does not throw when the file is double clicked", ->
         expect ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
         .not.toThrow()
 
         waitsFor ->
@@ -601,8 +603,8 @@ describe "TreeView", ->
         runs ->
           expect(atom.workspace.getActivePane().getActiveItem()).toBe editor
           expect(atom.workspace.getActivePane().getPendingItem()).toBe editor
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor ->
           atom.workspace.getActivePane().getPendingItem() is null
@@ -638,7 +640,7 @@ describe "TreeView", ->
           spyOn(atom.workspace, 'open')
 
           treeView.focus()
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         it "selects the file and retains focus on tree-view", ->
           expect(sampleJs).toHaveClass 'selected'
@@ -655,7 +657,7 @@ describe "TreeView", ->
           spyOn(atom.workspace, 'open').andCallFake (uri, options) ->
             originalOpen(uri, options).then -> openedCount++
 
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
           treeView.openSelectedEntry()
 
           waitsFor 'open to be called twice', ->
@@ -672,8 +674,8 @@ describe "TreeView", ->
 
       it "opens the file and focuses it", ->
         waitsForFileToOpen ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-          sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor "next tick to avoid race condition", (done) ->
           setImmediate(done)
@@ -690,8 +692,8 @@ describe "TreeView", ->
         spyOn(atom.workspace, 'open').andCallFake (uri, options) ->
           originalOpen(uri, options).then -> openedCount++
 
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
-        sampleJs.trigger clickEvent(originalEvent: {detail: 2})
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
         waitsFor 'open to be called twice', ->
           openedCount is 2
@@ -701,8 +703,8 @@ describe "TreeView", ->
 
   describe "when a directory is single-clicked", ->
     it "is selected", ->
-      subdir = root1.find('.directory:first')
-      subdir.trigger clickEvent(originalEvent: {detail: 1})
+      subdir = root1.querySelector('.directory')
+      subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
       expect(subdir).toHaveClass 'selected'
 
   describe "when a directory is double-clicked", ->
@@ -711,15 +713,15 @@ describe "TreeView", ->
 
       subdir = null
       waitsForFileToOpen ->
-        sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         treeView.focus()
-        subdir = root1.find('.directory:first')
-        subdir.trigger clickEvent(originalEvent: {detail: 1})
+        subdir = root1.querySelector('.directory')
+        subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
         expect(subdir).toHaveClass 'selected'
         expect(subdir).toHaveClass 'expanded'
-        subdir.trigger clickEvent(originalEvent: {detail: 2})
+        subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
         expect(subdir).toHaveClass 'selected'
         expect(subdir).not.toHaveClass 'expanded'
         expect(treeView).toHaveFocus()
@@ -731,36 +733,38 @@ describe "TreeView", ->
         treeView.roots[0].collapse()
 
         expect(treeView.roots[0]).not.toHaveClass 'expanded'
-        root1.trigger clickEvent({altKey: true})
+        root1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1, altKey: true}))
         expect(treeView.roots[0]).toHaveClass 'expanded'
 
-        children = root1.find('.directory')
+        children = root1.querySelectorAll('.directory')
         expect(children.length).toBeGreaterThan 0
-        children.each (index, child) -> expect(child).toHaveClass 'expanded'
+        for child in children
+          expect(child).toHaveClass 'expanded'
 
     describe "when the directory is expanded", ->
       parent    = null
       children  = null
 
       beforeEach ->
-        parent = root1.find('> .entries > .directory').eq(2)
-        parent[0].expand()
-        children = parent.find('.expanded.directory')
-        children.each (index, child) ->
+        parent = root1.querySelectorAll('.entries > .directory')[2]
+        parent.expand()
+        children = parent.querySelectorAll('.expanded.directory')
+        for child in children
           child.expand()
 
       it "recursively collapses the directory", ->
-        parent.click()
-        parent[0].expand()
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+        parent.expand()
         expect(parent).toHaveClass 'expanded'
-        children.each (index, child) ->
-          $(child).click().expand()
-          expect($(child)).toHaveClass 'expanded'
+        for child in children
+          child.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          child.expand()
+          expect(child).toHaveClass 'expanded'
 
-        parent.trigger clickEvent({altKey: true})
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1, altKey: true}))
 
         expect(parent).not.toHaveClass 'expanded'
-        children.each (index, child) ->
+        for child in children
           expect(child).not.toHaveClass 'expanded'
         expect(treeView.roots[0]).toHaveClass 'expanded'
 
@@ -768,21 +772,21 @@ describe "TreeView", ->
     describe "when the item has a path", ->
       it "selects the entry with that path in the tree view if it is visible", ->
         waitsForFileToOpen ->
-          sampleJs.click()
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         waitsForPromise ->
           atom.workspace.open(atom.project.getDirectories()[0].resolve('tree-view.txt'))
 
         runs ->
           expect(sampleTxt).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
+          expect(treeView.querySelectorAll('.selected').length).toBe 1
 
       it "selects the path's parent dir if its entry is not visible", ->
         waitsForPromise ->
           atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
 
         runs ->
-          dirView = root1.find('.directory:contains(dir1)')
+          dirView = root1.querySelector('.directory')
           expect(dirView).toHaveClass 'selected'
 
       describe "when the tree-view.autoReveal config setting is true", ->
@@ -794,20 +798,20 @@ describe "TreeView", ->
             atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
 
           runs ->
-            dirView = root1.find('.directory:contains(dir1)')
-            fileView = root1.find('.file:contains(sub-file1)')
+            dirView = root1.querySelector('.directory')
+            fileView = root1.querySelector('.file')
             expect(dirView).not.toHaveClass 'selected'
             expect(fileView).toHaveClass 'selected'
-            expect(treeView.find('.selected').length).toBe 1
+            expect(treeView[0].querySelectorAll('.selected').length).toBe 1
 
     describe "when the item has no path", ->
       it "deselects the previously selected entry", ->
         waitsForFileToOpen ->
-          sampleJs.click()
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           atom.workspace.getActivePane().activateItem(document.createElement("div"))
-          expect(treeView.find('.selected')).not.toExist()
+          expect(treeView[0].querySelector('.selected')).not.toExist()
 
   describe "when a different editor becomes active", ->
     beforeEach ->
@@ -817,14 +821,14 @@ describe "TreeView", ->
       leftEditorPane = null
 
       waitsForFileToOpen ->
-        sampleJs.click()
+        sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         leftEditorPane = atom.workspace.getActivePane()
         leftEditorPane.splitRight()
 
       waitsForFileToOpen ->
-        sampleTxt.click()
+        sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       runs ->
         expect(sampleTxt).toHaveClass('selected')
@@ -833,64 +837,67 @@ describe "TreeView", ->
 
   describe "keyboard navigation", ->
     afterEach ->
-      expect(treeView.find('.selected').length).toBeLessThan 2
+      expect(treeView[0].querySelectorAll('.selected').length).toBeLessThan 2
 
     describe "core:move-down", ->
       describe "when a collapsed directory is selected", ->
         it "skips to the next directory", ->
-          root1.find('.directory:eq(0)').click()
+          root1.querySelector('.directory').dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           atom.commands.dispatch(treeView.element, 'core:move-down')
-          expect(root1.find('.directory:eq(1)')).toHaveClass 'selected'
+          expect(root1.querySelectorAll('.directory')[1]).toHaveClass 'selected'
 
       describe "when an expanded directory is selected", ->
         it "selects the first entry of the directory", ->
-          subdir = root1.find('.directory:eq(1)')
-          subdir.click()
+          subdir = root1.querySelectorAll('.directory')[1]
+          subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           atom.commands.dispatch(treeView.element, 'core:move-down')
 
-          expect($(subdir[0].entries).find('.entry:first')).toHaveClass 'selected'
+          expect(subdir.querySelector('.entry')).toHaveClass 'selected'
 
       describe "when the last entry of an expanded directory is selected", ->
         it "selects the entry after its parent directory", ->
-          subdir1 = root1.find('.directory:eq(1)')
-          subdir1[0].expand()
+          subdir1 = root1.querySelectorAll('.directory')[1]
+          subdir1.expand()
           waitsForFileToOpen ->
-            $(subdir1[0].entries).find('.entry:last').click()
+            entries = subdir1.querySelectorAll('.entry')
+            entries[entries.length - 1].dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           runs ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(root1.find('.directory:eq(2)')).toHaveClass 'selected'
+            expect(root1.querySelectorAll('.directory')[2]).toHaveClass 'selected'
 
       describe "when the last directory of another last directory is selected", ->
         [nested, nested2] = []
 
         beforeEach ->
-          nested = root1.find('.directory:eq(2)')
-          expect(nested.find('.header').text()).toContain 'nested'
-          nested[0].expand()
-          nested2 = $(nested[0].entries).find('.entry:last')
-          nested2.click()
-          nested2[0].collapse()
+          nested = root1.querySelectorAll('.directory')[2]
+          expect(nested.querySelector('.header').textContent).toContain 'nested'
+          nested.expand()
+          entries = nested.querySelectorAll('.entry')
+          nested2 = entries[entries.length - 1]
+          nested2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          nested2.collapse()
 
         describe "when the directory is collapsed", ->
           it "selects the entry after its grandparent directory", ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(nested.next()).toHaveClass 'selected'
+            expect(nested.nextSibling).toHaveClass 'selected'
 
         describe "when the directory is expanded", ->
           it "selects the entry after its grandparent directory", ->
-            nested2[0].expand()
-            nested2.find('.file').remove() # kill the .gitkeep file, which has to be there but screws the test
+            nested2.expand()
+            nested2.querySelector('.file').remove() # kill the .gitkeep file, which has to be there but screws the test
             atom.commands.dispatch(treeView.element, 'core:move-down')
-            expect(nested.next()).toHaveClass 'selected'
+            expect(nested.nextSibling).toHaveClass 'selected'
 
       describe "when the last entry of the last directory is selected", ->
         it "does not change the selection", ->
-          lastEntry = root2.find('> .entries .entry:last')
+          entries = root2.querySelectorAll('.entries .entry')
+          lastEntry = entries[entries.length - 1]
           waitsForFileToOpen ->
-            lastEntry.click()
+            lastEntry.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
           runs ->
             atom.commands.dispatch(treeView.element, 'core:move-down')
@@ -2395,7 +2402,7 @@ describe "TreeView", ->
   describe "project changes", ->
     beforeEach ->
       atom.project.setPaths([path1])
-      treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+      treeView = atom.workspace.getLeftPanels()[0].getItem()
       root1 = $(treeView.roots[0])
 
     describe "when a root folder is added", ->
@@ -2403,7 +2410,7 @@ describe "TreeView", ->
         root1.find('.directory:contains(dir1)').click()
         atom.project.setPaths([path1, path2])
 
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         root1 = $(treeView.roots[0])
         expect(root1.find(".directory:contains(dir1)")).toHaveClass("expanded")
@@ -2412,7 +2419,7 @@ describe "TreeView", ->
         root1.click()
         atom.project.setPaths([path1, path2])
 
-        treeView = $(atom.workspace.getLeftPanels()[0].getItem()).view()
+        treeView = atom.workspace.getLeftPanels()[0].getItem()
         expect(treeView).toExist()
         root1 = $(treeView.roots[0])
         expect(root1).toHaveClass("collapsed")

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -1852,7 +1852,7 @@ describe "TreeView", ->
                 dirView3.entries.querySelectorAll(".file").length > 1
 
               runs ->
-                expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)
+                expect(treeView.element.querySelector('.file.selected').textContent).toBe path.basename(newPath)
 
           describe "when a file already exists at that location", ->
             it "shows an error message and does not close the dialog", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.querySelector(".tree-view")).toHaveFocus()
+            expect(treeView.list).toMatchSelector(":focus")
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.querySelector(".tree-view")).toHaveFocus()
+            expect(treeView.list).toMatchSelector(":focus")
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2717,7 +2717,7 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(dirView.directory.updateStatus).toHaveBeenCalled()
 
-    describe "when the project is a symbolic link to the repository root", ->
+    describe "on #darwin, when the project is a symbolic link to the repository root", ->
       beforeEach ->
         symlinkPath = temp.path('tree-view-project')
         fs.symlinkSync(projectPath, symlinkPath, 'junction')
@@ -2739,12 +2739,8 @@ describe "TreeView", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          waitsFor ->
-            not treeView.element.querySelector('.file.status-modified')
-
-          runs ->
-            expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
-            expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2557,7 +2557,7 @@ describe "TreeView", ->
       it "squashes two dir names when the first only contains a single dir", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\\\beta")
+          betaDir = findDirectoryContainingText(treeView.roots[0], "alpha\\beta")
         else
           betaDir = findDirectoryContainingText(treeView.roots[0], "alpha#{path.sep}beta")
         betaDir.expand()
@@ -2569,7 +2569,7 @@ describe "TreeView", ->
       it "squashes three dir names when the first and second only contain single dirs", ->
         if path.sep is '\\'
           # First escape the backslashes for Coffeescript, then escape them for jQuery
-          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\\\delta\\\\epsilon")
+          epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma\\delta\\epsilon")
         else
           epsilonDir = findDirectoryContainingText(treeView.roots[0], "gamma#{path.sep}delta#{path.sep}epsilon")
         epsilonDir.expand()

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2739,8 +2739,12 @@ describe "TreeView", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
-          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
+          waitsFor ->
+            not treeView.element.querySelector('.file.status-modified')
+
+          runs ->
+            expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+            expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->
@@ -3414,7 +3418,7 @@ describe "TreeView", ->
             expect(treeView).toHaveFocus()
 
           it "doesn't open the file in the active pane", ->
-            expect(atom.views.getView(treeView).element).toHaveFocus()
+            expect(atom.views.getView(treeView)).toHaveFocus()
             expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
 
       describe "when a file is double-clicked", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -225,7 +225,7 @@ describe "TreeView", ->
     it "restores the focus state of the tree view", ->
       jasmine.attachToDOM(workspaceElement)
       treeView.focus()
-      expect(treeView.list).toMatchSelector ':focus'
+      expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
       atom.packages.deactivatePackage("tree-view")
 
       waitsForPromise ->
@@ -233,7 +233,7 @@ describe "TreeView", ->
 
       runs ->
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView.list).toMatchSelector ':focus'
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     it "restores the scroll top when toggled", ->
       workspaceElement.style.height = '5px'
@@ -294,7 +294,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "when tree-view:toggle-side is triggered on the root view", ->
       describe "when the tree view is on the left", ->
@@ -330,7 +330,7 @@ describe "TreeView", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
         expect(treeView.hasParent()).toBeTruthy()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "when the tree view is shown", ->
       it "focuses the tree view", ->
@@ -342,7 +342,7 @@ describe "TreeView", ->
           expect(treeView).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
           expect(treeView).toBeVisible()
-          expect(treeView.list).toMatchSelector(':focus')
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
       describe "when the tree view is focused", ->
         it "unfocuses the tree view", ->
@@ -354,7 +354,7 @@ describe "TreeView", ->
             expect(treeView).toBeVisible()
             atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
             expect(treeView).toBeVisible()
-            expect(treeView.list).not.toMatchSelector(':focus')
+            expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
 
   describe "when tree-view:reveal-active-file is triggered on the root view", ->
     beforeEach ->
@@ -464,10 +464,10 @@ describe "TreeView", ->
       runs ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        expect(treeView.list).toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
         atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
         expect(treeView).toBeVisible()
-        expect(treeView.list).not.toMatchSelector(':focus')
+        expect(treeView.element.querySelector('.tree-view')).not.toHaveFocus()
         expect(atom.workspace.getActivePane().isActive()).toBe(true)
 
   describe "copy path commands", ->
@@ -2132,7 +2132,7 @@ describe "TreeView", ->
           it "removes the dialog and focuses the tree view", ->
             atom.commands.dispatch moveDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toMatchSelector(':focus')
+            expect(treeView.find(".tree-view")).toHaveFocus()
 
         describe "when the move dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
             jasmine.attachToDOM(treeView.element)
             atom.commands.dispatch copyDialog.element, 'core:cancel'
             expect(atom.workspace.getModalPanels().length).toBe 0
-            expect(treeView.find(".tree-view")).toMatchSelector(':focus')
+            expect(treeView.find(".tree-view")).toHaveFocus()
 
         describe "when the duplicate dialog's editor loses focus", ->
           it "removes the dialog and focuses root view", ->
@@ -2649,14 +2649,6 @@ describe "TreeView", ->
           muEntries = Array.from(muDir.children[1].children).map (element) -> element.innerText
           expect(muEntries).toEqual(["nu#{path.sep}xi", "xi"])
 
-    findDirectoryContainingText = (element, text) ->
-      directories = Array.from(element.querySelectorAll('.entries .directory'))
-      directories.find((directory) -> directory.header.textContent is text)
-
-    findFileContainingText = (element, text) ->
-      files = Array.from(element.querySelectorAll('.entries .file'))
-      files.find((file) -> file.fileName.textContent is text)
-
   describe "Git status decorations", ->
     [projectPath, modifiedFile, originalFileContent] = []
 
@@ -2686,60 +2678,59 @@ describe "TreeView", ->
 
       treeView.useSyncFS = true
       treeView.updateRoots()
-      $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
+      treeView.roots[0].entries.querySelectorAll('.directory')[1].expand()
 
     describe "when the project is the repository root", ->
       it "adds a custom style", ->
-        expect(treeView.find('.icon-repo').length).toBe 1
+        expect(treeView.element.querySelectorAll('.icon-repo').length).toBe 1
 
     describe "when a file is modified", ->
       it "adds a custom style", ->
-        $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
-        expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
+        expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
 
     describe "when a directory if modified", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+        expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
 
     describe "when a file is new", ->
       it "adds a custom style", ->
-        $(treeView.roots[0].entries).find('.directory:contains(dir2)')[0].expand()
-        expect(treeView.find('.file:contains(new2)')).toHaveClass 'status-added'
+        treeView.roots[0].entries.querySelectorAll('.directory')[2].expand()
+        expect(treeView.element.querySelector('.file.status-added')).toHaveText('new2')
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
-        expect(treeView.find('.directory:contains(dir2)')).toHaveClass 'status-added'
+        expect(treeView.element.querySelector('.directory.status-added').header).toHaveText('dir2')
 
     describe "when a file is ignored", ->
       it "adds a custom style", ->
-        expect(treeView.find('.file:contains(ignored.txt)')).toHaveClass 'status-ignored'
+        expect(treeView.element.querySelector('.file.status-ignored')).toHaveText('ignored.txt')
 
     describe "when a file is selected in a directory", ->
       beforeEach ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
-        element.expand() for element in treeView.find('.directory')
-        fileView = treeView.find('.file:contains(new2)')
+        element.expand() for element in treeView.element.querySelectorAll('.directory')
+        fileView = treeView.element.querySelector('.file.status-added')
         expect(fileView).not.toBeNull()
         fileView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
       describe "when the file is deleted", ->
         it "updates the style of the directory", ->
           expect(treeView.selectedEntry().getPath()).toContain(path.join('dir2', 'new2'))
-          dirView = $(treeView.roots[0].entries).find('.directory:contains(dir2)')
+          dirView = findDirectoryContainingText(treeView.roots[0], 'dir2')
           expect(dirView).not.toBeNull()
-          spyOn(dirView[0].directory, 'updateStatus')
+          spyOn(dirView.directory, 'updateStatus')
           spyOn(atom, 'confirm').andCallFake (dialog) ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
-          expect(dirView[0].directory.updateStatus).toHaveBeenCalled()
+          expect(dirView.directory.updateStatus).toHaveBeenCalled()
 
     describe "when the project is a symbolic link to the repository root", ->
       beforeEach ->
         symlinkPath = temp.path('tree-view-project')
         fs.symlinkSync(projectPath, symlinkPath, 'junction')
         atom.project.setPaths([symlinkPath])
-        $(treeView.roots[0].entries).find('.directory:contains(dir)')[0].expand()
+        treeView.roots[0].entries.querySelectorAll('.directory')[1].expand()
 
         waitsFor (done) ->
           disposable = atom.project.getRepositories()[0].onDidChangeStatuses ->
@@ -2748,29 +2739,31 @@ describe "TreeView", ->
 
       describe "when a file is modified", ->
         it "updates its and its parent directories' styles", ->
-          expect(treeView.find('.file:contains(b.txt)')).toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).toHaveClass 'status-modified'
+          expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
+          expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
 
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.find('.file:contains(b.txt)')).not.toHaveClass 'status-modified'
-          expect(treeView.find('.directory:contains(dir)')).not.toHaveClass 'status-modified'
+          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "when the resize handle is double clicked", ->
     beforeEach ->
-      treeView.width(10).find('.list-tree').width 100
+      treeView.element.style.width = '10px'
+      treeView.element.querySelector('.list-tree').style.width = '100px'
+      jasmine.attachToDOM(workspaceElement)
 
     it "sets the width of the tree to be the width of the list", ->
-      expect(treeView.width()).toBe 10
-      treeView.find('.tree-view-resize-handle').trigger 'dblclick'
-      expect(treeView.width()).toBeGreaterThan 10
+      expect(parseInt(treeView.element.style.width)).toBe 10
+      treeView.element.querySelector('.tree-view-resize-handle').dispatchEvent(new MouseEvent('dblclick', {bubbles: true}))
+      expect(parseInt(treeView.element.style.width)).toBeGreaterThan 10
 
-      treeView.width(1000)
-      treeView.find('.tree-view-resize-handle').trigger 'dblclick'
-      expect(treeView.width()).toBeLessThan 1000
+      treeView.element.style.width = '1000px'
+      treeView.element.querySelector('.tree-view-resize-handle').dispatchEvent(new MouseEvent('dblclick', {bubbles: true}))
+      expect(parseInt(treeView.element.style.width)).toBeLessThan 1000
 
   describe "when other panels are added", ->
     beforeEach ->
@@ -2780,20 +2773,20 @@ describe "TreeView", ->
       expect(treeView).toBeVisible()
       expect(atom.workspace.getLeftPanels().length).toBe(1)
 
-      treeView.width(100)
+      treeView.element.style.width = '100px'
 
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       panel = document.createElement('div')
       panel.style.width = '100px'
       atom.workspace.addLeftPanel({item: panel, priority: 10})
 
       expect(atom.workspace.getLeftPanels().length).toBe(2)
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       treeView.resizeTreeView({pageX: 250, which: 1})
 
-      expect(treeView.width()).toBe(150)
+      expect(parseInt(treeView.element.style.width)).toBe(150)
 
     it "should resize normally on the right side", ->
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
@@ -2802,20 +2795,20 @@ describe "TreeView", ->
       expect(treeView).toBeVisible()
       expect(atom.workspace.getRightPanels().length).toBe(1)
 
-      treeView.width(100)
+      treeView.element.style.width = '100px'
 
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
       panel = document.createElement('div')
       panel.style.width = '100px'
       atom.workspace.addRightPanel({item: panel, priority: 10})
 
       expect(atom.workspace.getRightPanels().length).toBe(2)
-      expect(treeView.width()).toBe(100)
+      expect(parseInt(treeView.element.style.width)).toBe(100)
 
-      treeView.resizeTreeView({pageX: $(document.body).width() - 250, which: 1})
+      treeView.resizeTreeView({pageX: document.body.offsetWidth - 250, which: 1})
 
-      expect(treeView.width()).toBe(150)
+      expect(parseInt(treeView.element.style.width)).toBe(150)
 
   describe "selecting items", ->
     [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []
@@ -2835,30 +2828,28 @@ describe "TreeView", ->
 
       atom.project.setPaths([rootDirPath])
 
-      dirView = $(treeView.roots[0].entries).find('.directory:contains(test-dir)')
-      dirView[0].expand()
-      fileView1 = treeView.find('.file:contains(test-file1.txt)')
-      fileView2 = treeView.find('.file:contains(test-file2.txt)')
-      fileView3 = treeView.find('.file:contains(test-file3.txt)')
+      dirView = treeView.entryForPath(dirPath)
+      dirView.expand()
+      [fileView1, fileView2, fileView3] = dirView.querySelectorAll('.file')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-        fileView2.trigger($.Event('mousedown', {shiftKey: true}))
-        expect(treeView.find('.tree-view')).toHaveClass('multi-select')
-        fileView3.trigger($.Event('mousedown'))
-        expect(treeView.find('.tree-view')).toHaveClass('full-menu')
+        fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
+        expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
+        fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+        expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-        fileView2.trigger($.Event('mousedown', {shiftKey: true}))
+        fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
         expect(treeView.find('.tree-view')).toHaveClass('multi-select')
 
       describe 'using the shift key', ->
         it 'selects the items between the already selected item and the shift clicked item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          fileView3.trigger($.Event('mousedown', {shiftKey: true}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
           expect(fileView1).toHaveClass('selected')
           expect(fileView2).toHaveClass('selected')
           expect(fileView3).toHaveClass('selected')
@@ -2866,7 +2857,7 @@ describe "TreeView", ->
       describe 'using the metakey(cmd) key', ->
         it 'selects the cmd clicked item in addition to the original selected item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-          fileView3.trigger($.Event('mousedown', {metaKey: true}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
           expect(fileView1).toHaveClass('selected')
           expect(fileView3).toHaveClass('selected')
           expect(fileView2).not.toHaveClass('selected')
@@ -2885,7 +2876,7 @@ describe "TreeView", ->
         describe 'using the ctrl key', ->
           it 'selects the ctrl clicked item in addition to the original selected item', ->
             fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+            fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
             expect(fileView1).toHaveClass('selected')
             expect(fileView3).toHaveClass('selected')
             expect(fileView2).not.toHaveClass('selected')
@@ -2905,87 +2896,87 @@ describe "TreeView", ->
           describe "previous item is selected but the ctrl clicked item is not", ->
             it 'selects the clicked item, but deselects the previous item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView1).not.toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
               expect(fileView2).not.toHaveClass('selected')
 
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
           describe 'previous item is selected including the ctrl clicked', ->
             it 'displays the multi-select menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).not.toHaveClass('full-menu')
-              expect(treeView.list).toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
 
             it 'does not deselect any of the items', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
 
           describe 'when clicked item is the only item selected', ->
             it 'displays the full contextual menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
           describe 'when no item is selected', ->
             it 'selects the ctrl clicked item', ->
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
               expect(fileView3).toHaveClass('selected')
 
             it 'displays the full context menu', ->
-              fileView3.trigger($.Event('mousedown', {ctrlKey: true}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, ctrlKey: true}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
         describe "right-clicking", ->
           describe 'when multiple items are selected', ->
             it 'displays the multi-select context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {metaKey: true}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).toHaveClass('selected')
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.list).not.toHaveClass('full-menu')
-              expect(treeView.list).toHaveClass('multi-select')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('multi-select')
 
           describe 'when a single item is selected', ->
             it 'displays the full context menu', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
             it 'selects right clicked item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
 
             it 'de-selects the previously selected item', ->
               fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView1).not.toHaveClass('selected')
 
           describe 'when no item is selected', ->
             it 'selects the right clicked item', ->
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
 
             it 'shows the full context menu', ->
-              fileView3.trigger($.Event('mousedown', {button: 2}))
+              fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 2}))
               expect(fileView3).toHaveClass('selected')
-              expect(treeView.list).toHaveClass('full-menu')
-              expect(treeView.list).not.toHaveClass('multi-select')
+              expect(treeView.element.querySelector('.tree-view')).toHaveClass('full-menu')
+              expect(treeView.element.querySelector('.tree-view')).not.toHaveClass('multi-select')
 
   describe "the sortFoldersBeforeFiles config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
@@ -3031,16 +3022,16 @@ describe "TreeView", ->
 
       expect(topLevelEntries).toEqual(["alpha", "gamma", "alpha.txt", "zeta.txt"])
 
-      alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-      alphaDir[0].expand()
-      alphaEntries = [].slice.call(alphaDir[0].children[1].children).map (element) ->
+      alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+      alphaDir.expand()
+      alphaEntries = [].slice.call(alphaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(alphaEntries).toEqual(["eta", "beta.txt"])
 
-      gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-      gammaDir[0].expand()
-      gammaEntries = [].slice.call(gammaDir[0].children[1].children).map (element) ->
+      gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+      gammaDir.expand()
+      gammaEntries = [].slice.call(gammaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(gammaEntries).toEqual(["theta", "delta.txt", "epsilon.txt"])
@@ -3053,16 +3044,16 @@ describe "TreeView", ->
 
       expect(topLevelEntries).toEqual(["alpha", "alpha.txt", "gamma", "zeta.txt"])
 
-      alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-      alphaDir[0].expand()
-      alphaEntries = [].slice.call(alphaDir[0].children[1].children).map (element) ->
+      alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+      alphaDir.expand()
+      alphaEntries = [].slice.call(alphaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(alphaEntries).toEqual(["beta.txt", "eta"])
 
-      gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-      gammaDir[0].expand()
-      gammaEntries = [].slice.call(gammaDir[0].children[1].children).map (element) ->
+      gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+      gammaDir.expand()
+      gammaEntries = [].slice.call(gammaDir.children[1].children).map (element) ->
         element.innerText
 
       expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
@@ -3123,7 +3114,7 @@ describe "TreeView", ->
       waitsForPromise ->
         atom.workspace.open()
       runs ->
-        $(workspaceElement).focus()
+        workspaceElement.focus()
         expect(treeView.showCurrentFileInFileManager()).toBeUndefined()
 
     it "shows file in file manager when some file is opened", ->
@@ -3205,14 +3196,15 @@ describe "TreeView", ->
     describe "when dragging a FileView onto a DirectoryView's header", ->
       it "should add the selected class to the DirectoryView", ->
         # Dragging theta onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        deltaFile = gammaDir[0].entries.children[2]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        deltaFile = gammaDir.entries.children[2]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.find('.header')[0])
+            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'))
         treeView.onDragStart(dragStartEvent)
         treeView.onDragEnter(dragEnterEvent)
         expect(alphaDir).toHaveClass('selected')
@@ -3228,104 +3220,104 @@ describe "TreeView", ->
     describe "when dropping a FileView onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->
         # Dragging delta.txt onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        deltaFile = gammaDir[0].entries.children[2]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        deltaFile = gammaDir.entries.children[2]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.find('.header')[0], alphaDir[0])
+            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'), alphaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       it "should move the directory to the hovered directory", ->
         # Dragging thetaDir onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        thetaDir = gammaDir[0].entries.children[0]
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        thetaDir = gammaDir.entries.children[0]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.find('.header')[0], alphaDir[0])
+            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a file from the OS onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->
         # Dragging delta.txt from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a directory from the OS onto a DirectoryView's header", ->
       it "should move the directory to the hovered directory", ->
         # Dragging gammaDir from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([gammaDirPath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([gammaDirPath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
 
     describe "when dragging a file and directory from the OS onto a DirectoryView's header", ->
       it "should move the file and directory to the hovered directory", ->
         # Dragging delta.txt and gammaDir from OS file explorer onto alphaDir
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir[0])
+        dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir)
 
         runs ->
           treeView.onDrop(dropEvent)
-          expect(alphaDir[0].children.length).toBe 2
+          expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length > 3
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 3
 
         runs ->
-          expect($(treeView.roots[0].entries).find('.directory:contains(alpha):first .entry').length).toBe 4
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
 
   describe "the alwaysOpenExisting config option", ->
     it "defaults to unset", ->
@@ -3340,21 +3332,21 @@ describe "TreeView", ->
         treeView.focus()
 
         waitsForFileToOpen ->
-          sampleJs.trigger clickEvent(originalEvent: {detail: 1})
+          sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           expect(sampleJs).toHaveClass 'selected'
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
-          expect(treeView.list).toHaveFocus()
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
         waitsForFileToOpen ->
-          sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+          sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
         runs ->
           expect(sampleTxt).toHaveClass 'selected'
-          expect(treeView.find('.selected').length).toBe 1
+          expect(treeView.element.querySelectorAll('.selected').length).toBe 1
           expect(atom.workspace.getActivePaneItem().getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-          expect(treeView.list).toHaveFocus()
+          expect(treeView.element.querySelector('.tree-view')).toHaveFocus()
 
     describe "opening existing opened files in existing split panes", ->
       beforeEach ->
@@ -3420,7 +3412,7 @@ describe "TreeView", ->
             treeView.focus()
 
             waitsForFileToOpen ->
-              sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
+              sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
             runs ->
               activePaneItem = atom.workspace.getActivePaneItem()
@@ -3445,8 +3437,8 @@ describe "TreeView", ->
           treeView.focus()
 
           waitsForFileToOpen ->
-            sampleTxt.trigger clickEvent(originalEvent: {detail: 1})
-            sampleTxt.trigger clickEvent(originalEvent: {detail: 2})
+            sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            sampleTxt.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
 
           waits 100
 
@@ -3499,14 +3491,14 @@ describe "TreeView", ->
       describe "when dragging on the top part of the root", ->
         it "should add the placeholder above the directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.top)
-          expect(alphaDir[0].previousSibling).toHaveClass('placeholder')
+          expect(alphaDir.previousSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3515,14 +3507,14 @@ describe "TreeView", ->
       describe "when dragging on the bottom part of the root", ->
         it "should add the placeholder below the directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
-          expect(alphaDir[0].nextSibling).toHaveClass('placeholder')
+          expect(alphaDir.nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3531,16 +3523,16 @@ describe "TreeView", ->
       describe "when below all entries", ->
         it "should add the placeholder below the last directory", ->
           # Dragging gammaDir onto alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          lastDir = $(treeView).find('.project-root:last')
+          alphaDir = treeView.roots[0]
+          lastDir = treeView.roots[treeView.roots.length - 1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(alphaDir.find('.project-root-header')[0], treeView.find('.tree-view')[0])
+            eventHelpers.buildPositionalDragEvents(alphaDir.querySelector('.project-root-header'), treeView.element.querySelector('.tree-view'))
 
-          expect(alphaDir[0]).not.toEqual(lastDir[0])
+          expect(alphaDir).not.toEqual(lastDir)
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDragOver(dragOverEvents.bottom)
-          expect(lastDir[0].nextSibling).toHaveClass('placeholder')
+          expect(lastDir.nextSibling).toHaveClass('placeholder')
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
@@ -3551,10 +3543,10 @@ describe "TreeView", ->
       describe "when dropping on the top part of the header", ->
         it "should add the placeholder above the directory", ->
           # dropping gammaDir above alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          gammaDir = $(treeView).find('.project-root:contains(gamma):first')
+          alphaDir = treeView.roots[0]
+          gammaDir = treeView.roots[1]
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.top)
@@ -3568,10 +3560,10 @@ describe "TreeView", ->
       describe "when dropping on the bottom part of the header", ->
         it "should add the placeholder below the directory", ->
           # dropping thetaDir below alphaDir
-          alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-          thetaDir = $(treeView).find('.project-root:contains(theta):first')
+          alphaDir = treeView.roots[0]
+          thetaDir = treeView.roots[2]
           [dragStartEvent, dragDropEvents] =
-            eventHelpers.buildPositionalDragEvents(thetaDir.find('.project-root-header')[0], alphaDir[0], '.tree-view')
+            eventHelpers.buildPositionalDragEvents(thetaDir.querySelector('.project-root-header'), alphaDir, '.tree-view')
 
           treeView.rootDragAndDrop.onDragStart(dragStartEvent)
           treeView.rootDragAndDrop.onDrop(dragDropEvents.bottom)
@@ -3585,8 +3577,8 @@ describe "TreeView", ->
 
     describe "when a root folder is dragged out of application", ->
       it "should carry the folder's information", ->
-        gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-        [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
+        gammaDir = treeView.roots[1]
+        [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'))
         treeView.rootDragAndDrop.onDragStart(dragStartEvent)
 
         expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual gammaDirPath
@@ -3595,8 +3587,8 @@ describe "TreeView", ->
 
     describe "when a root folder is dropped from another Atom window", ->
       it "adds the root folder to the window", ->
-        alphaDir = $(treeView).find('.project-root:contains(alpha):first')
-        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.find('.project-root-header')[0], '.tree-view')
+        alphaDir = treeView.roots[0]
+        [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.querySelector('.project-root-header'), '.tree-view')
 
         dropEvent = dragDropEvents.bottom
         dropEvent.originalEvent.dataTransfer.setData('atom-tree-view-event', true)
@@ -3620,14 +3612,21 @@ describe "TreeView", ->
 
     describe "when a root folder is dropped to another Atom window", ->
       it "removes the root folder from the first window", ->
-        gammaDir = $(treeView).find('.project-root:contains(gamma):first')
-        [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.find('.project-root-header')[0])
+        gammaDir = treeView.roots[1]
+        [dragStartEvent, dropEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'))
         treeView.rootDragAndDrop.onDragStart(dragStartEvent)
-        treeView.rootDragAndDrop.onDropOnOtherWindow({}, gammaDir.index())
+        treeView.rootDragAndDrop.onDropOnOtherWindow({}, Array.from(gammaDir.parentElement.children).indexOf(gammaDir))
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
         expect('.placeholder').not.toExist()
 
+  findDirectoryContainingText = (element, text) ->
+    directories = Array.from(element.querySelectorAll('.entries .directory'))
+    directories.find((directory) -> directory.header.textContent is text)
+
+  findFileContainingText = (element, text) ->
+    files = Array.from(element.querySelectorAll('.entries .file'))
+    files.find((file) -> file.fileName.textContent is text)
 
 describe 'Icon class handling', ->
   it 'allows multiple classes to be passed', ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -106,12 +106,12 @@ describe "TreeView", ->
           treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
 
       it "does not attach to the workspace or create a root node when initialized", ->
-        expect(treeView.hasParent()).toBeFalsy()
+        expect(treeView.element.parentElement).toBeFalsy()
         expect(treeView.roots).toHaveLength(0)
 
       it "does not attach to the workspace or create a root node when attach() is called", ->
         treeView.attach()
-        expect(treeView.hasParent()).toBeFalsy()
+        expect(treeView.element.parentElement).toBeFalsy()
         expect(treeView.roots).toHaveLength(0)
 
       it "serializes without throwing an exception", ->
@@ -133,7 +133,7 @@ describe "TreeView", ->
 
         runs ->
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-          expect(treeView.hasParent()).toBeFalsy()
+          expect(treeView.element.parentElement).toBeFalsy()
           expect(treeView.roots).toHaveLength(0)
 
       describe "when the project is assigned a path because a new buffer is saved", ->
@@ -144,7 +144,7 @@ describe "TreeView", ->
           runs ->
             projectPath = temp.mkdirSync('atom-project')
             atom.workspace.getActivePaneItem().saveAs(path.join(projectPath, 'test.txt'))
-            expect(treeView.hasParent()).toBeTruthy()
+            expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.roots).toHaveLength(1)
             expect(fs.absolute(treeView.roots[0].getPath())).toBe fs.absolute(projectPath)
 
@@ -161,7 +161,7 @@ describe "TreeView", ->
 
         runs ->
           treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
-          expect(treeView.hasParent()).toBeFalsy()
+          expect(treeView.element.parentElement).toBeFalsy()
           expect(treeView.roots).toHaveLength(2)
 
     describe "when the root view is opened to a directory", ->
@@ -171,7 +171,7 @@ describe "TreeView", ->
 
         runs ->
           treeView = atom.packages.getActivePackage("tree-view").mainModule.createView()
-          expect(treeView.hasParent()).toBeTruthy()
+          expect(treeView.element.parentElement).toBeTruthy()
           expect(treeView.roots).toHaveLength(2)
 
     describe "when the project is a .git folder", ->
@@ -238,36 +238,36 @@ describe "TreeView", ->
     it "restores the scroll top when toggled", ->
       workspaceElement.style.height = '5px'
       jasmine.attachToDOM(workspaceElement)
-      expect(treeView).toBeVisible()
+      expect(treeView.element).toBeVisible()
       treeView.focus()
 
       treeView.scrollTop(10)
       expect(treeView.scrollTop()).toBe(10)
 
       runs -> atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      waitsFor -> treeView.is(':hidden')
+      waitsFor -> treeView.element.offsetHeight is 0
 
       runs -> atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      waitsFor -> treeView.is(':visible')
+      waitsFor -> treeView.element.offsetHeight > 0
 
       runs -> expect(treeView.scrollTop()).toBe(10)
 
     it "restores the scroll left when toggled", ->
-      treeView.width(5)
+      treeView.element.style.width = '5px'
       jasmine.attachToDOM(workspaceElement)
-      expect(treeView).toBeVisible()
+      expect(treeView.element).toBeVisible()
       treeView.focus()
 
-      treeView.scroller.scrollLeft(5)
-      expect(treeView.scroller.scrollLeft()).toBe(5)
+      treeView.scroller.scrollLeft = 5
+      expect(treeView.scroller.scrollLeft).toBe(5)
 
       runs -> atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      waitsFor -> treeView.is(':hidden')
+      waitsFor -> treeView.element.offsetHeight is 0
 
       runs -> atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-      waitsFor -> treeView.is(':visible')
+      waitsFor -> treeView.element.offsetHeight > 0
 
-      runs -> expect(treeView.scroller.scrollLeft()).toBe(5)
+      runs -> expect(treeView.scroller.scrollLeft).toBe(5)
 
   describe "when tree-view:toggle is triggered on the root view", ->
     beforeEach ->
@@ -275,31 +275,31 @@ describe "TreeView", ->
 
     describe "when the tree view is visible", ->
       beforeEach ->
-        expect(treeView).toBeVisible()
+        expect(treeView.element).toBeVisible()
 
       describe "when the tree view is focused", ->
         it "hides the tree view", ->
           treeView.focus()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-          expect(treeView).toBeHidden()
+          expect(treeView.element).toBeHidden()
 
       describe "when the tree view is not focused", ->
         it "hides the tree view", ->
           workspaceElement.focus()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-          expect(treeView).toBeHidden()
+          expect(treeView.element).toBeHidden()
 
     describe "when the tree view is hidden", ->
       it "shows and focuses the tree view", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle')
-        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.element.parentElement).toBeTruthy()
         expect(treeView.list).toHaveFocus()
 
     describe "when tree-view:toggle-side is triggered on the root view", ->
       describe "when the tree view is on the left", ->
         it "moves the tree view to the right", ->
-          expect(treeView).toBeVisible()
+          expect(treeView.element).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
           expect(treeView.element.dataset.showOnRightSide).toBe('true')
 
@@ -308,7 +308,7 @@ describe "TreeView", ->
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
 
         it "moves the tree view to the left", ->
-          expect(treeView).toBeVisible()
+          expect(treeView.element).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
           expect(treeView.element.dataset.showOnRightSide).toBe('false')
 
@@ -329,7 +329,7 @@ describe "TreeView", ->
       it "shows and focuses the tree view", ->
         treeView.detach()
         atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
-        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.element.parentElement).toBeTruthy()
         expect(treeView.list).toHaveFocus()
 
     describe "when the tree view is shown", ->
@@ -339,9 +339,9 @@ describe "TreeView", ->
 
         runs ->
           workspaceElement.focus()
-          expect(treeView).toBeVisible()
+          expect(treeView.element).toBeVisible()
           atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
-          expect(treeView).toBeVisible()
+          expect(treeView.element).toBeVisible()
           expect(treeView.list).toHaveFocus()
 
       describe "when the tree view is focused", ->
@@ -351,9 +351,9 @@ describe "TreeView", ->
 
           runs ->
             treeView.focus()
-            expect(treeView).toBeVisible()
+            expect(treeView.element).toBeVisible()
             atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
-            expect(treeView).toBeVisible()
+            expect(treeView.element).toBeVisible()
             expect(treeView.list).not.toHaveFocus()
 
   describe "when tree-view:reveal-active-file is triggered on the root view", ->
@@ -371,7 +371,7 @@ describe "TreeView", ->
 
           runs ->
             atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-            expect(treeView.hasParent()).toBeTruthy()
+            expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.focus).toHaveBeenCalled()
 
           waitsForPromise ->
@@ -380,7 +380,7 @@ describe "TreeView", ->
 
           runs ->
             atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-            expect(treeView.hasParent()).toBeTruthy()
+            expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.focus).toHaveBeenCalled()
 
       describe "if the tree-view.focusOnReveal config option is false", ->
@@ -392,7 +392,7 @@ describe "TreeView", ->
 
           runs ->
             atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-            expect(treeView.hasParent()).toBeTruthy()
+            expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.focus).not.toHaveBeenCalled()
 
           waitsForPromise ->
@@ -401,7 +401,7 @@ describe "TreeView", ->
 
           runs ->
             atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-            expect(treeView.hasParent()).toBeTruthy()
+            expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.focus).not.toHaveBeenCalled()
 
     describe "if the current file has no path", ->
@@ -412,14 +412,14 @@ describe "TreeView", ->
         runs ->
           expect(atom.workspace.getActivePaneItem().getPath()).toBeUndefined()
           atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-          expect(treeView.hasParent()).toBeTruthy()
+          expect(treeView.element.parentElement).toBeTruthy()
           expect(treeView.focus).toHaveBeenCalled()
 
     describe "if there is no editor open", ->
       it "shows and focuses the tree view, but does not attempt to select a specific file", ->
         expect(atom.workspace.getActivePaneItem()).toBeUndefined()
         atom.commands.dispatch(workspaceElement, 'tree-view:reveal-active-file')
-        expect(treeView.hasParent()).toBeTruthy()
+        expect(treeView.element.parentElement).toBeTruthy()
         expect(treeView.focus).toHaveBeenCalled()
 
     describe 'if there are more items than can be visible in the viewport', ->
@@ -433,7 +433,7 @@ describe "TreeView", ->
           fs.writeFileSync(filepath, "doesn't matter")
 
         atom.project.setPaths([rootDirPath])
-        treeView.height(100)
+        treeView.element.style.height = '100px'
         jasmine.attachToDOM(workspaceElement)
 
       it 'scrolls the selected file into the visible view', ->
@@ -466,7 +466,7 @@ describe "TreeView", ->
         treeView.focus()
         expect(treeView.list).toHaveFocus()
         atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
-        expect(treeView).toBeVisible()
+        expect(treeView.element).toBeVisible()
         expect(treeView.list).not.toHaveFocus()
         expect(atom.workspace.getActivePane().isActive()).toBe(true)
 
@@ -622,7 +622,7 @@ describe "TreeView", ->
 
         it "selects the file and retains focus on tree-view", ->
           expect(sampleJs).toHaveClass 'selected'
-          expect(treeView).toHaveFocus()
+          expect(treeView.element).toHaveFocus()
 
         it "opens the file in a pending state", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.js')
@@ -638,7 +638,7 @@ describe "TreeView", ->
 
         it "selects the file and retains focus on tree-view", ->
           expect(sampleJs).toHaveClass 'selected'
-          expect(treeView).toHaveFocus()
+          expect(treeView.element).toHaveFocus()
 
         it "does not open the file", ->
           expect(atom.workspace.open).not.toHaveBeenCalled()
@@ -718,7 +718,7 @@ describe "TreeView", ->
         subdir.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
         expect(subdir).toHaveClass 'selected'
         expect(subdir).not.toHaveClass 'expanded'
-        expect(treeView).toHaveFocus()
+        expect(treeView.element).toHaveFocus()
 
   describe "when an directory is alt-clicked", ->
     describe "when the directory is collapsed", ->
@@ -954,18 +954,18 @@ describe "TreeView", ->
         treeView.element.style.height = '100px'
         jasmine.attachToDOM(treeView.element)
         element.expand() for element in treeView.element.querySelectorAll('.directory')
-        expect(treeView.element.querySelector('.tree-view').offsetHeight).toBeGreaterThan treeView.element.querySelector('.tree-view-scroller').offsetHeight
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.list.offsetHeight).toBeGreaterThan treeView.scroller.offsetHeight
+        expect(treeView.scroller.scrollTop).toBe(0)
 
         entryCount = treeView.element.querySelectorAll(".entry").length
         _.times entryCount, -> atom.commands.dispatch(treeView.element, 'core:move-down')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBeGreaterThan 0
+        expect(treeView.scroller.scrollTop).toBeGreaterThan 0
 
         atom.commands.dispatch(treeView.element, 'core:move-to-top')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.scroller.scrollTop).toBe(0)
 
       it "selects the root entry", ->
-        entryCount = treeView.find(".entry").length
+        entryCount = treeView.element.querySelectorAll(".entry").length
         _.times entryCount, -> atom.commands.dispatch(treeView.element, 'core:move-down')
 
         expect(treeView.roots[0]).not.toHaveClass 'selected'
@@ -977,16 +977,16 @@ describe "TreeView", ->
         treeView.element.style.height = '100px'
         jasmine.attachToDOM(treeView.element)
         element.expand() for element in treeView.element.querySelectorAll('.directory')
-        expect(treeView.element.querySelector('.tree-view').offsetHeight).toBeGreaterThan treeView.element.querySelector('.tree-view-scroller').offsetHeight
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.list.offsetHeight).toBeGreaterThan treeView.scroller.offsetHeight
+        expect(treeView.scroller.scrollTop).toBe(0)
 
         atom.commands.dispatch(treeView.element, 'core:move-to-bottom')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBeGreaterThan(0)
+        expect(treeView.scroller.scrollTop).toBeGreaterThan(0)
 
         treeView.roots[0].collapse()
         treeView.roots[1].collapse()
         atom.commands.dispatch(treeView.element, 'core:move-to-bottom')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.scroller.scrollTop).toBe(0)
 
       it "selects the last entry", ->
         expect(treeView.roots[0]).toHaveClass 'selected'
@@ -999,45 +999,45 @@ describe "TreeView", ->
         treeView.element.style.height = '5px'
         jasmine.attachToDOM(treeView.element)
         element.expand() for element in treeView.element.querySelectorAll('.directory')
-        expect(treeView.element.querySelector('.tree-view').offsetHeight).toBeGreaterThan treeView.element.querySelector('.tree-view-scroller').offsetHeight
+        expect(treeView.list.offsetHeight).toBeGreaterThan treeView.scroller.offsetHeight
 
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.scroller.scrollTop).toBe(0)
         treeView.scrollToBottom()
-        scrollTop = treeView.element.querySelector('.tree-view-scroller').scrollTop
+        scrollTop = treeView.scroller.scrollTop
         expect(scrollTop).toBeGreaterThan 0
 
         atom.commands.dispatch(treeView.element, 'core:page-up')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe scrollTop - treeView.element.offsetHeight
+        expect(treeView.scroller.scrollTop).toBe scrollTop - treeView.element.offsetHeight
 
     describe "core:page-down", ->
       it "scrolls down a page", ->
         treeView.element.style.height = '5px'
         jasmine.attachToDOM(treeView.element)
         element.expand() for element in treeView.element.querySelectorAll('.directory')
-        expect(treeView.element.querySelector('.tree-view').offsetHeight).toBeGreaterThan treeView.element.querySelector('.tree-view-scroller').offsetHeight
+        expect(treeView.list.offsetHeight).toBeGreaterThan treeView.scroller.offsetHeight
 
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.scroller.scrollTop).toBe(0)
         atom.commands.dispatch(treeView.element, 'core:page-down')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe treeView.element.offsetHeight
+        expect(treeView.scroller.scrollTop).toBe treeView.element.offsetHeight
 
     describe "movement outside of viewable region", ->
       it "scrolls the tree view to the selected item", ->
         treeView.element.style.height = '100px'
         jasmine.attachToDOM(treeView.element)
         element.expand() for element in treeView.element.querySelectorAll('.directory')
-        expect(treeView.element.querySelector('.tree-view').offsetHeight).toBeGreaterThan treeView.element.querySelector('.tree-view-scroller').offsetHeight
+        expect(treeView.list.offsetHeight).toBeGreaterThan treeView.scroller.offsetHeight
 
         atom.commands.dispatch(treeView.element, 'core:move-down')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe(0)
+        expect(treeView.scroller.scrollTop).toBe(0)
 
         entryCount = treeView.element.querySelectorAll(".entry").length
         entryHeight = treeView.element.querySelector('.file').offsetHeight
 
         _.times entryCount, -> atom.commands.dispatch(treeView.element, 'core:move-down')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop + treeView.element.offsetHeight).toBeGreaterThan((entryCount * entryHeight) - 1)
+        expect(treeView.scroller.scrollTop + treeView.element.offsetHeight).toBeGreaterThan((entryCount * entryHeight) - 1)
 
         _.times entryCount, -> atom.commands.dispatch(treeView.element, 'core:move-up')
-        expect(treeView.element.querySelector('.tree-view-scroller').scrollTop).toBe 0
+        expect(treeView.scroller.scrollTop).toBe 0
 
     describe "tree-view:expand-directory", ->
       describe "when a directory entry is selected", ->
@@ -2762,7 +2762,7 @@ describe "TreeView", ->
       jasmine.attachToDOM(workspaceElement)
 
     it "should resize normally", ->
-      expect(treeView).toBeVisible()
+      expect(treeView.element).toBeVisible()
       expect(atom.workspace.getLeftPanels().length).toBe(1)
 
       treeView.element.style.width = '100px'
@@ -2784,7 +2784,7 @@ describe "TreeView", ->
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle-side')
       expect(treeView.element.dataset.showOnRightSide).toBe('true')
 
-      expect(treeView).toBeVisible()
+      expect(treeView.element).toBeVisible()
       expect(atom.workspace.getRightPanels().length).toBe(1)
 
       treeView.element.style.width = '100px'
@@ -2836,7 +2836,7 @@ describe "TreeView", ->
       it 'switches the contextual menu to muli-select mode', ->
         fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
         fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
-        expect(treeView.find('.tree-view')).toHaveClass('multi-select')
+        expect(treeView.list).toHaveClass('multi-select')
 
       describe 'using the shift key', ->
         it 'selects the items between the already selected item and the shift clicked item', ->
@@ -3410,7 +3410,7 @@ describe "TreeView", ->
 
           it "selects the file and retains focus on tree-view", ->
             expect(sampleTxt).toHaveClass 'selected'
-            expect(treeView).toHaveFocus()
+            expect(treeView.element).toHaveFocus()
 
           it "doesn't open the file in the active pane", ->
             expect(atom.views.getView(treeView)).toHaveFocus()
@@ -3517,7 +3517,7 @@ describe "TreeView", ->
           alphaDir = treeView.roots[0]
           lastDir = treeView.roots[treeView.roots.length - 1]
           [dragStartEvent, dragOverEvents, dragEndEvent] =
-            eventHelpers.buildPositionalDragEvents(alphaDir.querySelector('.project-root-header'), treeView.element.querySelector('.tree-view'))
+            eventHelpers.buildPositionalDragEvents(alphaDir.querySelector('.project-root-header'), treeView.list)
 
           expect(alphaDir).not.toEqual(lastDir)
 
@@ -3572,9 +3572,9 @@ describe "TreeView", ->
         [dragStartEvent] = eventHelpers.buildPositionalDragEvents(gammaDir.querySelector('.project-root-header'))
         treeView.rootDragAndDrop.onDragStart(dragStartEvent)
 
-        expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual gammaDirPath
+        expect(dragStartEvent.dataTransfer.getData("text/plain")).toEqual gammaDirPath
         if process.platform in ['darwin', 'linux']
-          expect(dragStartEvent.originalEvent.dataTransfer.getData("text/uri-list")).toEqual "file://#{gammaDirPath}"
+          expect(dragStartEvent.dataTransfer.getData("text/uri-list")).toEqual "file://#{gammaDirPath}"
 
     describe "when a root folder is dropped from another Atom window", ->
       it "adds the root folder to the window", ->
@@ -3582,9 +3582,9 @@ describe "TreeView", ->
         [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.querySelector('.project-root-header'), '.tree-view')
 
         dropEvent = dragDropEvents.bottom
-        dropEvent.originalEvent.dataTransfer.setData('atom-tree-view-event', true)
-        dropEvent.originalEvent.dataTransfer.setData('from-window-id', treeView.rootDragAndDrop.getWindowId() + 1)
-        dropEvent.originalEvent.dataTransfer.setData('from-root-path', etaDirPath)
+        dropEvent.dataTransfer.setData('atom-tree-view-event', true)
+        dropEvent.dataTransfer.setData('from-window-id', treeView.rootDragAndDrop.getWindowId() + 1)
+        dropEvent.dataTransfer.setData('from-root-path', etaDirPath)
 
         # mock browserWindowForId
         browserWindowMock = {webContents: {send: ->}}

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -217,7 +217,7 @@ describe "TreeView", ->
 
       runs ->
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView).toExist()
+        expect(treeView.element).toExist()
         expect(treeView.selectedEntry().textContent).toBe('tree-view.js')
         root1 = treeView.roots[0]
         expect(root1.querySelector(".directory")).toHaveClass("expanded")
@@ -1798,12 +1798,12 @@ describe "TreeView", ->
 
       describe "when a file is selected", ->
         it "opens an add dialog with the file's current directory path populated", ->
-          expect(addDialog).toExist()
-          expect(addDialog.promptText.text()).toBeTruthy()
+          expect(addDialog.element).toExist()
+          expect(addDialog.promptText.textContent).toBeTruthy()
           expect(atom.project.relativize(dirPath)).toMatch(/[^\\\/]$/)
           expect(addDialog.miniEditor.getText()).toBe(atom.project.relativize(dirPath) + path.sep)
-          expect(addDialog.miniEditor.getModel().getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
-          expect(addDialog.miniEditor).toHaveFocus()
+          expect(addDialog.miniEditor.getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
+          expect(addDialog.miniEditor.element).toHaveFocus()
 
         describe "when the parent directory of the selected file changes", ->
           it "still shows the active file as selected", ->
@@ -1816,7 +1816,7 @@ describe "TreeView", ->
               newPath = path.join(dirPath, "new-test-file.txt")
 
               waitsForFileToOpen ->
-                addDialog.miniEditor.getModel().insertText(path.basename(newPath))
+                addDialog.miniEditor.insertText(path.basename(newPath))
                 atom.commands.dispatch addDialog.element, 'core:confirm'
 
               runs ->
@@ -1840,7 +1840,7 @@ describe "TreeView", ->
                 atom.commands.dispatch(treeView.element, "tree-view:add-file")
                 [addPanel] = atom.workspace.getModalPanels()
                 addDialog = addPanel.getItem()
-                addDialog.miniEditor.getModel().insertText(path.basename(newPath))
+                addDialog.miniEditor.insertText(path.basename(newPath))
                 atom.commands.dispatch addDialog.element, 'core:confirm'
 
               runs ->
@@ -1858,11 +1858,11 @@ describe "TreeView", ->
             it "shows an error message and does not close the dialog", ->
               newPath = path.join(dirPath, "new-test-file.txt")
               fs.writeFileSync(newPath, '')
-              addDialog.miniEditor.getModel().insertText(path.basename(newPath))
+              addDialog.miniEditor.insertText(path.basename(newPath))
               atom.commands.dispatch addDialog.element, 'core:confirm'
 
-              expect(addDialog.errorMessage.text()).toContain 'already exists'
-              expect(addDialog).toHaveClass('error')
+              expect(addDialog.errorMessage.textContent).toContain 'already exists'
+              expect(addDialog.element).toHaveClass('error')
               expect(atom.workspace.getModalPanels()[0]).toBe addPanel
 
           describe "when the project has no path", ->
@@ -1874,7 +1874,7 @@ describe "TreeView", ->
               addDialog = addPanel.getItem()
 
               newPath = path.join(fs.realpathSync(temp.mkdirSync()), 'a-file')
-              addDialog.miniEditor.getModel().insertText(newPath)
+              addDialog.miniEditor.insertText(newPath)
 
               waitsForFileToOpen ->
                 atom.commands.dispatch addDialog.element, 'core:confirm'
@@ -1886,11 +1886,11 @@ describe "TreeView", ->
 
         describe "when the path with a trailing '#{path.sep}' is changed and confirmed", ->
           it "shows an error message and does not close the dialog", ->
-            addDialog.miniEditor.getModel().insertText("new-test-file" + path.sep)
+            addDialog.miniEditor.insertText("new-test-file" + path.sep)
             atom.commands.dispatch addDialog.element, 'core:confirm'
 
-            expect(addDialog.errorMessage.text()).toContain 'names must not end with'
-            expect(addDialog).toHaveClass('error')
+            expect(addDialog.errorMessage.textContent).toContain 'names must not end with'
+            expect(addDialog.element).toHaveClass('error')
             expect(atom.workspace.getModalPanels()[0]).toBe addPanel
 
         describe "when 'core:cancel' is triggered on the add dialog", ->
@@ -1908,7 +1908,7 @@ describe "TreeView", ->
         describe "when the path ends with whitespace", ->
           it "removes the trailing whitespace before creating the file", ->
             newPath = path.join(dirPath, "new-test-file.txt")
-            addDialog.miniEditor.getModel().insertText(path.basename(newPath) + "  ")
+            addDialog.miniEditor.insertText(path.basename(newPath) + "  ")
 
             waitsForFileToOpen ->
               atom.commands.dispatch addDialog.element, 'core:confirm'
@@ -1924,12 +1924,12 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, "tree-view:add-file")
           addDialog = atom.workspace.getModalPanels()[0].getItem()
 
-          expect(addDialog).toExist()
-          expect(addDialog.promptText.text()).toBeTruthy()
+          expect(addDialog.element).toExist()
+          expect(addDialog.promptText.textContent).toBeTruthy()
           expect(atom.project.relativize(dirPath)).toMatch(/[^\\\/]$/)
           expect(addDialog.miniEditor.getText()).toBe(atom.project.relativize(dirPath) + path.sep)
-          expect(addDialog.miniEditor.getModel().getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
-          expect(addDialog.miniEditor).toHaveFocus()
+          expect(addDialog.miniEditor.getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
+          expect(addDialog.miniEditor.element).toHaveFocus()
 
       describe "when the root directory is selected", ->
         it "opens an add dialog with no path populated", ->
@@ -1958,7 +1958,7 @@ describe "TreeView", ->
           atom.commands.dispatch(workspaceElement, "tree-view:add-folder")
           [addPanel] = atom.workspace.getModalPanels()
           addDialog = addPanel.getItem()
-          addDialog.miniEditor.getModel().insertText("a-file")
+          addDialog.miniEditor.insertText("a-file")
           atom.commands.dispatch(addDialog.element, 'core:confirm')
           expect(addDialog.element.textContent).toContain("You must open a directory to create a file with a relative path")
 
@@ -1978,18 +1978,18 @@ describe "TreeView", ->
 
       describe "when a file is selected", ->
         it "opens an add dialog with the file's current directory path populated", ->
-          expect(addDialog).toExist()
-          expect(addDialog.promptText.text()).toBeTruthy()
+          expect(addDialog.element).toExist()
+          expect(addDialog.promptText.textContent).toBeTruthy()
           expect(atom.project.relativize(dirPath)).toMatch(/[^\\\/]$/)
           expect(addDialog.miniEditor.getText()).toBe(atom.project.relativize(dirPath) + path.sep)
-          expect(addDialog.miniEditor.getModel().getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
-          expect(addDialog.miniEditor).toHaveFocus()
+          expect(addDialog.miniEditor.getCursorBufferPosition().column).toBe addDialog.miniEditor.getText().length
+          expect(addDialog.miniEditor.element).toHaveFocus()
 
         describe "when the path without a trailing '#{path.sep}' is changed and confirmed", ->
           describe "when no directory exists at the given path", ->
             it "adds a directory and closes the dialog", ->
               newPath = path.join(dirPath, 'new', 'dir')
-              addDialog.miniEditor.getModel().insertText("new#{path.sep}dir")
+              addDialog.miniEditor.insertText("new#{path.sep}dir")
               atom.commands.dispatch addDialog.element, 'core:confirm'
               expect(fs.isDirectorySync(newPath)).toBeTruthy()
               expect(atom.workspace.getModalPanels().length).toBe 0
@@ -2001,7 +2001,7 @@ describe "TreeView", ->
           describe "when no directory exists at the given path", ->
             it "adds a directory and closes the dialog", ->
               newPath = path.join(dirPath, 'new', 'dir')
-              addDialog.miniEditor.getModel().insertText("new#{path.sep}dir#{path.sep}")
+              addDialog.miniEditor.insertText("new#{path.sep}dir#{path.sep}")
               atom.commands.dispatch addDialog.element, 'core:confirm'
               expect(fs.isDirectorySync(newPath)).toBeTruthy()
               expect(atom.workspace.getModalPanels().length).toBe 0
@@ -2018,7 +2018,7 @@ describe "TreeView", ->
               expandedView.expand()
 
               newPath = path.join(dirPath, "new2") + path.sep
-              addDialog.miniEditor.getModel().insertText("new2#{path.sep}")
+              addDialog.miniEditor.insertText("new2#{path.sep}")
               atom.commands.dispatch addDialog.element, 'core:confirm'
               expect(fs.isDirectorySync(newPath)).toBeTruthy()
               expect(atom.workspace.getModalPanels().length).toBe 0
@@ -2035,9 +2035,9 @@ describe "TreeView", ->
                 [addPanel] = atom.workspace.getModalPanels()
                 addDialog = addPanel.getItem()
 
-                expect(addDialog.miniEditor.getModel().getText()).toBe ''
+                expect(addDialog.miniEditor.getText()).toBe ''
                 newPath = temp.path()
-                addDialog.miniEditor.getModel().insertText(newPath)
+                addDialog.miniEditor.insertText(newPath)
                 atom.commands.dispatch addDialog.element, 'core:confirm'
                 expect(fs.isDirectorySync(newPath)).toBeTruthy()
                 expect(atom.workspace.getModalPanels().length).toBe 0
@@ -2046,11 +2046,11 @@ describe "TreeView", ->
             it "shows an error message and does not close the dialog", ->
               newPath = path.join(dirPath, "new-dir")
               fs.makeTreeSync(newPath)
-              addDialog.miniEditor.getModel().insertText("new-dir#{path.sep}")
+              addDialog.miniEditor.insertText("new-dir#{path.sep}")
               atom.commands.dispatch addDialog.element, 'core:confirm'
 
-              expect(addDialog.errorMessage.text()).toContain 'already exists'
-              expect(addDialog).toHaveClass('error')
+              expect(addDialog.errorMessage.textContent).toContain 'already exists'
+              expect(addDialog.element).toHaveClass('error')
               expect(atom.workspace.getModalPanels()[0]).toBe addPanel
 
     describe "tree-view:move", ->
@@ -2073,11 +2073,11 @@ describe "TreeView", ->
         it "opens a move dialog with the file's current path (excluding extension) populated", ->
           extension = path.extname(filePath)
           fileNameWithoutExtension = path.basename(filePath, extension)
-          expect(moveDialog).toExist()
-          expect(moveDialog.promptText.text()).toBe "Enter the new path for the file."
+          expect(moveDialog.element).toExist()
+          expect(moveDialog.promptText.textContent).toBe "Enter the new path for the file."
           expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(moveDialog.miniEditor.getModel().getSelectedText()).toBe path.basename(fileNameWithoutExtension)
-          expect(moveDialog.miniEditor).toHaveFocus()
+          expect(moveDialog.miniEditor.getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(moveDialog.miniEditor.element).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->
           describe "when all the directories along the new path exist", ->
@@ -2124,9 +2124,9 @@ describe "TreeView", ->
 
                 atom.commands.dispatch moveDialog.element, 'core:confirm'
 
-                expect(moveDialog.errorMessage.text()).toContain 'already exists'
-                expect(moveDialog).toHaveClass('error')
-                expect(moveDialog.hasParent()).toBeTruthy()
+                expect(moveDialog.errorMessage.textContent).toContain 'already exists'
+                expect(moveDialog.element).toHaveClass('error')
+                expect(moveDialog.element.parentElement).toBeTruthy()
 
         describe "when 'core:cancel' is triggered on the move dialog", ->
           it "removes the dialog and focuses the tree view", ->
@@ -2158,9 +2158,9 @@ describe "TreeView", ->
             moveDialog = atom.workspace.getModalPanels()[0].getItem()
 
         it "selects the entire file name", ->
-          expect(moveDialog).toExist()
+          expect(moveDialog.element).toExist()
           expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
-          expect(moveDialog.miniEditor.getModel().getSelectedText()).toBe '.dotfile'
+          expect(moveDialog.miniEditor.getSelectedText()).toBe '.dotfile'
 
       describe "when the project is selected", ->
         it "doesn't display the move dialog", ->
@@ -2188,11 +2188,11 @@ describe "TreeView", ->
         it "opens a copy dialog to duplicate with the file's current path populated", ->
           extension = path.extname(filePath)
           fileNameWithoutExtension = path.basename(filePath, extension)
-          expect(copyDialog).toExist()
-          expect(copyDialog.promptText.text()).toBe "Enter the new path for the duplicate."
+          expect(copyDialog.element).toExist()
+          expect(copyDialog.promptText.textContent).toBe "Enter the new path for the duplicate."
           expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(copyDialog.miniEditor.getModel().getSelectedText()).toBe path.basename(fileNameWithoutExtension)
-          expect(copyDialog.miniEditor).toHaveFocus()
+          expect(copyDialog.miniEditor.getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(copyDialog.miniEditor.element).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->
           describe "when all the directories along the new path exist", ->
@@ -2241,9 +2241,9 @@ describe "TreeView", ->
 
                 atom.commands.dispatch copyDialog.element, 'core:confirm'
 
-                expect(copyDialog.errorMessage.text()).toContain 'already exists'
-                expect(copyDialog).toHaveClass('error')
-                expect(copyDialog.hasParent()).toBeTruthy()
+                expect(copyDialog.errorMessage.textContent).toContain 'already exists'
+                expect(copyDialog.element).toHaveClass('error')
+                expect(copyDialog.element.parentElement).toBeTruthy()
 
         describe "when 'core:cancel' is triggered on the copy dialog", ->
           it "removes the dialog and focuses the tree view", ->
@@ -2276,9 +2276,9 @@ describe "TreeView", ->
             copyDialog = atom.workspace.getModalPanels()[0].getItem()
 
         it "selects the entire file name", ->
-          expect(copyDialog).toExist()
+          expect(copyDialog.element).toExist()
           expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
-          expect(copyDialog.miniEditor.getModel().getSelectedText()).toBe '.dotfile'
+          expect(copyDialog.miniEditor.getSelectedText()).toBe '.dotfile'
 
       describe "when the project is selected", ->
         it "doesn't display the copy dialog", ->
@@ -2403,7 +2403,7 @@ describe "TreeView", ->
         atom.project.setPaths([path1, path2])
 
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView).toExist()
+        expect(treeView.element).toExist()
         expect(treeView.roots[0].querySelector(".directory")).toHaveClass("expanded")
 
       it "maintains collapsed (root) folders", ->
@@ -2411,7 +2411,7 @@ describe "TreeView", ->
         atom.project.setPaths([path1, path2])
 
         treeView = atom.workspace.getLeftPanels()[0].getItem()
-        expect(treeView).toExist()
+        expect(treeView.element).toExist()
         expect(treeView.roots[0]).toHaveClass("collapsed")
 
   describe "the hideVcsIgnoredFiles config option", ->
@@ -3493,7 +3493,7 @@ describe "TreeView", ->
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
       describe "when dragging on the bottom part of the root", ->
         it "should add the placeholder below the directory", ->
@@ -3509,7 +3509,7 @@ describe "TreeView", ->
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
       describe "when below all entries", ->
         it "should add the placeholder below the last directory", ->
@@ -3527,7 +3527,7 @@ describe "TreeView", ->
 
           # Is removed when drag ends
           treeView.rootDragAndDrop.onDragEnd(dragEndEvent)
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
 
     describe "when dropping a project root's header onto a different project root", ->
@@ -3546,7 +3546,7 @@ describe "TreeView", ->
           expect(projectPaths[1]).toEqual(alphaDirPath)
 
           # Is removed when drag ends
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
       describe "when dropping on the bottom part of the header", ->
         it "should add the placeholder below the directory", ->
@@ -3564,7 +3564,7 @@ describe "TreeView", ->
           expect(projectPaths[2]).toEqual(gammaDirPath)
 
           # Is removed when drag ends
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
     describe "when a root folder is dragged out of application", ->
       it "should carry the folder's information", ->
@@ -3598,7 +3598,7 @@ describe "TreeView", ->
 
         runs ->
           expect(atom.project.getPaths()).toContain etaDirPath
-          expect('.placeholder').not.toExist()
+          expect(document.querySelector('.placeholder')).not.toExist()
 
 
     describe "when a root folder is dropped to another Atom window", ->
@@ -3609,7 +3609,7 @@ describe "TreeView", ->
         treeView.rootDragAndDrop.onDropOnOtherWindow({}, Array.from(gammaDir.parentElement.children).indexOf(gammaDir))
 
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
-        expect('.placeholder').not.toExist()
+        expect(document.querySelector('.placeholder')).not.toExist()
 
   findDirectoryContainingText = (element, text) ->
     directories = Array.from(element.querySelectorAll('.entries .directory'))


### PR DESCRIPTION
This pull request replaces atom-space-pen-views with manual DOM manipulation. It also changes `DirectoryView` and `FileView` so that they don't register themselves as custom elements, but are simple JavaScript objects managing a DOM element. Feature-wise nothing should change, but this will help remove jQuery from Atom.

/cc: @ungb for 👀 