### PR TITLE
Update editors when containing directory is renamed or removed

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -22,3 +22,10 @@ module.exports =
       fullExtension = extension + fullExtension
       filePath = path.basename(filePath, extension)
     fullExtension
+
+  updateEditorsForPath: (oldPath, newPath) ->
+    editors = atom.workspace.getTextEditors()
+    for editor in editors
+      filePath = editor.getPath()
+      if filePath.startsWith(oldPath)
+        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -27,5 +27,5 @@ module.exports =
     editors = atom.workspace.getTextEditors()
     for editor in editors
       filePath = editor.getPath()
-      if filePath.startsWith(oldPath)
+      if filePath?.startsWith(oldPath)
         editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -36,6 +36,7 @@ class MoveDialog extends Dialog
     try
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
+      @updateEditorForPath(@initialPath, newPath)
       if repo = repoForPath(newPath)
         repo.getPathStatus(@initialPath)
         repo.getPathStatus(newPath)
@@ -56,3 +57,10 @@ class MoveDialog extends Dialog
         oldStat.ino is newStat.ino
     catch
       true # new path does not exist so it is valid
+
+  updateEditorForPath: (oldPath, newPath) ->
+    editors = atom.workspace.getTextEditors()
+    for editor in editors
+      filePath = editor.getPath()
+      if filePath.startsWith(oldPath)
+        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 fs = require 'fs-plus'
 Dialog = require './dialog'
-{repoForPath} = require "./helpers"
+{repoForPath, updateEditorsForPath} = require "./helpers"
 
 module.exports =
 class MoveDialog extends Dialog
@@ -36,7 +36,7 @@ class MoveDialog extends Dialog
     try
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
-      @updateEditorForPath(@initialPath, newPath)
+      updateEditorsForPath(@initialPath, newPath)
       if repo = repoForPath(newPath)
         repo.getPathStatus(@initialPath)
         repo.getPathStatus(newPath)
@@ -57,10 +57,3 @@ class MoveDialog extends Dialog
         oldStat.ino is newStat.ino
     catch
       true # new path does not exist so it is valid
-
-  updateEditorForPath: (oldPath, newPath) ->
-    editors = atom.workspace.getTextEditors()
-    for editor in editors
-      filePath = editor.getPath()
-      if filePath.startsWith(oldPath)
-        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -795,6 +795,7 @@ class TreeView
     try
       fs.makeTreeSync(newDirectoryPath) unless fs.existsSync(newDirectoryPath)
       fs.moveSync(initialPath, newPath)
+      @updateEditorForPath(initialPath, newPath)
 
       if repo = repoForPath(newPath)
         repo.getPathStatus(initialPath)
@@ -802,6 +803,13 @@ class TreeView
 
     catch error
       atom.notifications.addWarning("Failed to move entry #{initialPath} to #{newDirectoryPath}", detail: error.message)
+
+  updateEditorForPath: (oldPath, newPath) ->
+    editors = atom.workspace.getTextEditors()
+    for editor in editors
+      filePath = editor.getPath()
+      if filePath.startsWith(oldPath)
+        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))
 
   onStylesheetsChanged: =>
     return unless @isVisible()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable} = require 'atom'
-{repoForPath, getStyleObject, getFullExtension} = require "./helpers"
+{repoForPath, getStyleObject, getFullExtension, updateEditorsForPath} = require "./helpers"
 fs = require 'fs-plus'
 
 AddDialog = require './add-dialog'
@@ -795,7 +795,7 @@ class TreeView
     try
       fs.makeTreeSync(newDirectoryPath) unless fs.existsSync(newDirectoryPath)
       fs.moveSync(initialPath, newPath)
-      @updateEditorForPath(initialPath, newPath)
+      updateEditorsForPath(initialPath, newPath)
 
       if repo = repoForPath(newPath)
         repo.getPathStatus(initialPath)
@@ -803,13 +803,6 @@ class TreeView
 
     catch error
       atom.notifications.addWarning("Failed to move entry #{initialPath} to #{newDirectoryPath}", detail: error.message)
-
-  updateEditorForPath: (oldPath, newPath) ->
-    editors = atom.workspace.getTextEditors()
-    for editor in editors
-      filePath = editor.getPath()
-      if filePath.startsWith(oldPath)
-        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))
 
   onStylesheetsChanged: =>
     return unless @isVisible()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -607,7 +607,7 @@ class TreeView
           for selectedPath in selectedPaths
             if shell.moveItemToTrash(selectedPath)
               for editor in atom.workspace.getTextEditors()
-                if editor?.getPath() is selectedPath
+                if editor?.getPath()?.startsWith(selectedPath)
                   editor.destroy()
             else
               failedDeletions.push "#{selectedPath}"

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -3191,6 +3191,7 @@ describe "TreeView", ->
   describe "Dragging and dropping files", ->
     deltaFilePath = null
     gammaDirPath = null
+    thetaFilePath = null
 
     beforeEach ->
       rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
@@ -3206,6 +3207,7 @@ describe "TreeView", ->
       deltaFilePath = path.join(gammaDirPath, "delta.txt")
       epsilonFilePath = path.join(gammaDirPath, "epsilon.txt")
       thetaDirPath = path.join(gammaDirPath, "theta")
+      thetaFilePath = path.join(thetaDirPath, "theta.txt")
 
       fs.writeFileSync(alphaFilePath, "doesn't matter")
       fs.writeFileSync(zetaFilePath, "doesn't matter")
@@ -3218,6 +3220,7 @@ describe "TreeView", ->
       fs.writeFileSync(deltaFilePath, "doesn't matter")
       fs.writeFileSync(epsilonFilePath, "doesn't matter")
       fs.makeTreeSync(thetaDirPath)
+      fs.writeFileSync(thetaFilePath, "doesn't matter")
 
       atom.project.setPaths([rootDirPath])
 
@@ -3278,11 +3281,14 @@ describe "TreeView", ->
         gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
         gammaDir.expand()
         thetaDir = gammaDir.entries.children[0]
+        thetaDir.expand()
 
-        [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
+        waitsForFileToOpen ->
+          atom.workspace.open(thetaFilePath)
 
         runs ->
+          [dragStartEvent, dragEnterEvent, dropEvent] =
+            eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
           expect(alphaDir.children.length).toBe 2
@@ -3292,6 +3298,8 @@ describe "TreeView", ->
 
         runs ->
           expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          editor = atom.workspace.getActiveTextEditor()
+          expect(editor.getPath()).toBe(thetaFilePath.replace('gamma', 'alpha'))
 
     describe "when dragging a file from the OS onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->

--- a/spec/tree-view-spec.coffee
+++ b/spec/tree-view-spec.coffee
@@ -2401,6 +2401,29 @@ describe "TreeView", ->
         expect(atom.confirm.mostRecentCall).not.toExist
         expect(atom.notifications.getNotifications().length).toBe 0
 
+      describe "when a directory is removed", ->
+        it "closes editors with files belonging to the removed folder", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          waitsForFileToOpen ->
+            atom.workspace.open(filePath2)
+
+          waitsForFileToOpen ->
+            atom.workspace.open(filePath3)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((e) -> e.getPath())
+            expect(openFilePaths).toEqual([filePath2, filePath3])
+            dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.toggleFocus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) ->
+              dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = (editor.getPath() for editor in atom.workspace.getTextEditors())
+            expect(openFilePaths).toEqual([])
+
   describe "file system events", ->
     temporaryFilePath = null
 


### PR DESCRIPTION
Fixes #948.
Fixes atom/tabs#12.
Fixes atom/tabs#413.
Fixes atom/atom#9875.

Prior to this PR, renaming or removing a folder would not result in open text editors being updated appropriately. 

**Changes introduced in this PR include:**
* folder renames result in updating the paths for editors corresponding to files within the renamed folder (for both drag & drop and move dialog renames)
* folder deletions result in the closing of editors corresponding to files within the deleted folder

**Alternative approaches were discussed and ultimately dismissed for the reasons outlined:**
* Use a directory-watching library such as [nsfw](https://github.com/Axosoft/nsfw/) to catch rename and delete events
  * Benefits: We would additionally be able to support the case where folders are renamed or deleted outside of Atom. 
  * Possible drawbacks: Watching large directories on Linux is too costly so we would only be able to support this on Mac and Windows. Thus, we would have to implement a solution such as the one in this PR to fix these issues on Linux.
* Centralize file system operations in Atom core and create new APIs such as `atom.project.rename` or `atom.fs.rename`
  * Benefits: Other could rely on these APIs and trust that Atom will take care of updating editors appropriately 
  * Possible drawbacks: This would take careful thought and API design as we would be introducing APIs that we would have to continue to support.