### PR TITLE
Update editors when containing directory is renamed or removed (redux)

### DIFF
--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -5,7 +5,7 @@ Dialog = require './dialog'
 
 module.exports =
 class CopyDialog extends Dialog
-  constructor: (@initialPath) ->
+  constructor: (@initialPath, {@onCopyCallback}) ->
     super
       prompt: 'Enter the new path for the duplicate.'
       initialPath: atom.project.relativize(@initialPath)
@@ -32,10 +32,10 @@ class CopyDialog extends Dialog
     try
       if fs.isDirectorySync(@initialPath)
         fs.copySync(@initialPath, newPath)
-        @emitter.emit 'entry-copied', [@initialPath, newPath]
+        @onCopyCallback?({initialPath: @initialPath, newPath: newPath})
       else
         fs.copy @initialPath, newPath, =>
-          @emitter.emit 'entry-copied', [@initialPath, newPath]
+          @onCopyCallback?({initialPath: @initialPath, newPath: newPath})
           atom.workspace.open newPath,
             activatePane: true
             initialLine: activeEditor?.getLastCursor().getBufferRow()

--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -32,8 +32,10 @@ class CopyDialog extends Dialog
     try
       if fs.isDirectorySync(@initialPath)
         fs.copySync(@initialPath, newPath)
+        @emitter.emit 'entry-copied', [@initialPath, newPath]
       else
-        fs.copy @initialPath, newPath, ->
+        fs.copy @initialPath, newPath, =>
+          @emitter.emit 'entry-copied', [@initialPath, newPath]
           atom.workspace.open newPath,
             activatePane: true
             initialLine: activeEditor?.getLastCursor().getBufferRow()

--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -5,7 +5,7 @@ Dialog = require './dialog'
 
 module.exports =
 class CopyDialog extends Dialog
-  constructor: (@initialPath, {@onCopyCallback}) ->
+  constructor: (@initialPath, {@onCopy}) ->
     super
       prompt: 'Enter the new path for the duplicate.'
       initialPath: atom.project.relativize(@initialPath)
@@ -32,10 +32,10 @@ class CopyDialog extends Dialog
     try
       if fs.isDirectorySync(@initialPath)
         fs.copySync(@initialPath, newPath)
-        @onCopyCallback?({initialPath: @initialPath, newPath: newPath})
+        @onCopy?({initialPath: @initialPath, newPath: newPath})
       else
         fs.copy @initialPath, newPath, =>
-          @onCopyCallback?({initialPath: @initialPath, newPath: newPath})
+          @onCopy?({initialPath: @initialPath, newPath: newPath})
           atom.workspace.open newPath,
             activatePane: true
             initialLine: activeEditor?.getLastCursor().getBufferRow()

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -22,3 +22,10 @@ module.exports =
       fullExtension = extension + fullExtension
       filePath = path.basename(filePath, extension)
     fullExtension
+
+  updateEditorsForPath: (oldPath, newPath) ->
+    editors = atom.workspace.getTextEditors()
+    for editor in editors
+      filePath = editor.getPath()
+      if filePath?.startsWith(oldPath)
+        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -5,7 +5,7 @@ Dialog = require './dialog'
 
 module.exports =
 class MoveDialog extends Dialog
-  constructor: (@initialPath, {@onMoveCallback}) ->
+  constructor: (@initialPath, {@onMove}) ->
     if fs.isDirectorySync(@initialPath)
       prompt = 'Enter the new path for the directory.'
     else
@@ -36,7 +36,7 @@ class MoveDialog extends Dialog
     try
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
-      @onMoveCallback?(initialPath: @initialPath, newPath: newPath)
+      @onMove?(initialPath: @initialPath, newPath: newPath)
       if repo = repoForPath(newPath)
         repo.getPathStatus(@initialPath)
         repo.getPathStatus(newPath)

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -5,7 +5,7 @@ Dialog = require './dialog'
 
 module.exports =
 class MoveDialog extends Dialog
-  constructor: (@initialPath) ->
+  constructor: (@initialPath, {@onMoveCallback}) ->
     if fs.isDirectorySync(@initialPath)
       prompt = 'Enter the new path for the directory.'
     else
@@ -36,7 +36,7 @@ class MoveDialog extends Dialog
     try
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
-      @emitter.emit 'entry-moved', [@initialPath, newPath]
+      @onMoveCallback?(initialPath: @initialPath, newPath: newPath)
       if repo = repoForPath(newPath)
         repo.getPathStatus(@initialPath)
         repo.getPathStatus(newPath)

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -36,6 +36,7 @@ class MoveDialog extends Dialog
     try
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
+      @emitter.emit 'entry-moved', [@initialPath, newPath]
       if repo = repoForPath(newPath)
         repo.getPathStatus(@initialPath)
         repo.getPathStatus(newPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -824,7 +824,6 @@ class TreeView
     try
       fs.makeTreeSync(newDirectoryPath) unless fs.existsSync(newDirectoryPath)
       fs.moveSync(initialPath, newPath)
-      console.log "MOVED!", initialPath, newPath
       @emitter.emit 'entry-moved', {initialPath, newPath}
 
       if repo = repoForPath(newPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -509,9 +509,9 @@ class TreeView
       oldPath = @getActivePath()
 
     if oldPath
-      dialog = new MoveDialog(oldPath)
-      dialog.emitter.on 'entry-moved', ([oldPath, newPath]) =>
-        @emitter.emit 'entry-moved', {oldPath, newPath}
+      dialog = new MoveDialog oldPath,
+        onMoveCallback: ({initialPath, newPath}) =>
+          @emitter.emit 'entry-moved', {initialPath, newPath}
       dialog.attach()
 
   # Get the outline of a system call to the current platform's file manager.
@@ -598,9 +598,9 @@ class TreeView
       oldPath = @getActivePath()
     return unless oldPath
 
-    dialog = new CopyDialog(oldPath)
-    dialog.emitter.on 'entry-copied', (oldPath, newPath) =>
-      @emitter.emit 'entry-copied', {oldPath, newPath}
+    dialog = new CopyDialog oldPath,
+      onCopyCallback: ({initialPath, newPath}) =>
+        @emitter.emit 'entry-copied', {initialPath, newPath}
     dialog.attach()
 
   removeSelectedEntries: ->

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -510,7 +510,7 @@ class TreeView
 
     if oldPath
       dialog = new MoveDialog oldPath,
-        onMoveCallback: ({initialPath, newPath}) =>
+        onMove: ({initialPath, newPath}) =>
           @emitter.emit 'entry-moved', {initialPath, newPath}
       dialog.attach()
 
@@ -599,7 +599,7 @@ class TreeView
     return unless oldPath
 
     dialog = new CopyDialog oldPath,
-      onCopyCallback: ({initialPath, newPath}) =>
+      onCopy: ({initialPath, newPath}) =>
         @emitter.emit 'entry-copied', {initialPath, newPath}
     dialog.attach()
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -77,6 +77,11 @@ class TreeView
     @disposables.add @onEntryMoved ({initialPath, newPath}) ->
       updateEditorsForPath(initialPath, newPath)
 
+    @disposables.add @onEntryDeleted ({path}) ->
+      for editor in atom.workspace.getTextEditors()
+        if editor?.getPath()?.startsWith(path)
+          editor.destroy()
+
   serialize: ->
     directoryExpansionStates: new ((roots) ->
       @[root.directory.path] = root.directory.serializeExpansionState() for root in roots
@@ -630,9 +635,6 @@ class TreeView
           for selectedPath in selectedPaths
             if shell.moveItemToTrash(selectedPath)
               @emitter.emit 'entry-deleted', {path: selectedPath}
-              for editor in atom.workspace.getTextEditors()
-                if editor?.getPath()?.startsWith(selectedPath)
-                  editor.destroy()
             else
               failedDeletions.push "#{selectedPath}"
             if repo = repoForPath(selectedPath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -721,19 +721,19 @@ class TreeView
             # use fs.copy to copy directories since read/write will fail for directories
             catchAndShowFileErrors =>
               fs.copySync(initialPath, newPath)
-              @emitter.emit 'entry-copied', {oldPath: initialPath, newPath}
+              @emitter.emit 'entry-copied', {initialPath, newPath}
           else
             # read the old file and write a new one at target location
             catchAndShowFileErrors =>
               fs.writeFileSync(newPath, fs.readFileSync(initialPath))
-              @emitter.emit 'entry-copied', {oldPath: initialPath, newPath}
+              @emitter.emit 'entry-copied', {initialPath, newPath}
         else if cutPaths
           # Only move the target if the cut target doesn't exist and if the newPath
           # is not within the initial path
           unless fs.existsSync(newPath) or newPath.startsWith(initialPath)
             catchAndShowFileErrors =>
               fs.moveSync(initialPath, newPath)
-              @emitter.emit 'entry-moved', {oldPath: initialPath, newPath}
+              @emitter.emit 'entry-moved', {initialPath, newPath}
 
   add: (isCreatingFile) ->
     selectedEntry = @selectedEntry() ? @roots[0]
@@ -824,7 +824,8 @@ class TreeView
     try
       fs.makeTreeSync(newDirectoryPath) unless fs.existsSync(newDirectoryPath)
       fs.moveSync(initialPath, newPath)
-      @emitter.emit 'entry-moved', {oldPath: initialPath, newPath}
+      console.log "MOVED!", initialPath, newPath
+      @emitter.emit 'entry-moved', {initialPath, newPath}
 
       if repo = repoForPath(newPath)
         repo.getPathStatus(initialPath)


### PR DESCRIPTION
This is another pass at https://github.com/atom/tree-view/pull/1044, but basing the work on @Alhadis' changes at https://github.com/atom/tree-view/pull/966 (which fit in perfectly with this feature). See the former PR for more details on the feature.

Katrina and I are moving on to other projects, but since we didn't get to this in the past week, I wanted to take care of it now.

@Alhadis, I pulled in the changes from your PR and made some changes on top. Namely:

* `CopyDialog` and `MoveDialog` now take callbacks instead of relying on the emitter directly
* I've standardized the key names from the new event objects so that if there are two paths they are always `initialPath` and `newPath`, and if there is only one it's always `path`
* I modified the tests to use the new public methods directly instead of reaching into the emtiter internals

Let me know if that causes any conern for you, and thank you so much for your work on this!

Closes https://github.com/atom/tree-view/pull/1044
Closes https://github.com/atom/tree-view/pull/966

Fixes #948
Fixes atom/tabs#12
Fixes atom/tabs#413
Fixes atom/atom#9875

/cc @kuychaco 