### PR TITLE
Display the correct drag image on Electron >= 1.14

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -931,6 +931,10 @@ class TreeView
       fileNameElement.style.position = 'absolute'
       fileNameElement.style.top = 0
       fileNameElement.style.left = 0
+      # Ensure the cloned file name element is rendered on a separate GPU layer
+      # to prevent overlapping elements located at (0px, 0px) from being used as
+      # the drag image.
+      fileNameElement.style.willChange = 'transform'
 
       document.body.appendChild(fileNameElement)
 


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/12696

This commit ensures that the cloned file name element (i.e. the element that is shown next to the cursor while dragging) is rendered on a separate GPU layer. This will prevent overlapping elements located at (0px, 0px) from being used as the drag image.

Before:

![screen shot 2017-03-29 at 14 31 30](https://cloud.githubusercontent.com/assets/482957/24454934/13d12fd8-148e-11e7-95a7-5c857cc51fd2.png)

After:

![screen shot 2017-03-29 at 14 44 22](https://cloud.githubusercontent.com/assets/482957/24454969/3b9e370e-148e-11e7-8757-53171cd6d8e3.png)

/cc: @atom/maintainers 