### PR TITLE
Fix missing drop indicator on Electron >= 1.14

### DIFF
--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -71,7 +71,7 @@ class RootDragAndDropHandler
   onDragOver: (e) =>
     return unless @treeView.list.contains(e.target)
 
-    unless e.dataTransfer.getData('atom-tree-view-event') is 'true'
+    unless @isAtomTreeViewEvent(e)
       return
 
     e.preventDefault()
@@ -121,7 +121,7 @@ class RootDragAndDropHandler
     {dataTransfer} = e
 
     # TODO: support dragging folders from the filesystem -- electron needs to add support first
-    return unless dataTransfer.getData('atom-tree-view-event') is 'true'
+    return unless @isAtomTreeViewEvent(e)
 
     fromWindowId = parseInt(dataTransfer.getData('from-window-id'))
     fromRootPath  = dataTransfer.getData('from-root-path')
@@ -171,7 +171,18 @@ class RootDragAndDropHandler
     e.target.closest('.project-root-header')
 
   isDragging: (e) ->
-    Boolean e.dataTransfer.getData 'from-root-path'
+    for item in e.dataTransfer.items
+      if item.type is 'from-root-path'
+        return true
+
+    return false
+
+  isAtomTreeViewEvent: (e) ->
+    for item in e.dataTransfer.items
+      if item.type is 'atom-tree-view-event'
+        return true
+
+    return false
 
   getPlaceholder: ->
     unless @placeholderEl

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -5,6 +5,13 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
     getData: (key) -> @data[key]
     setDragImage: (@image) -> return
 
+  Object.defineProperty(
+    dataTransfer,
+    'items',
+    get: ->
+      Object.keys(dataTransfer.data).map((key) -> {type: key})
+  )
+
   dragStartEvent = new DragEvent('dragstart')
   Object.defineProperty(dragStartEvent, 'target', value: dragged)
   Object.defineProperty(dragStartEvent, 'currentTarget', value: dragged)
@@ -28,6 +35,13 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
     files: []
+
+  Object.defineProperty(
+    dataTransfer,
+    'items',
+    get: ->
+      Object.keys(dataTransfer.data).map((key) -> {type: key})
+  )
 
   dropEvent = new DragEvent('drop')
   Object.defineProperty(dropEvent, 'target', value: dropTarget)
@@ -72,6 +86,13 @@ module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelect
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
     setDragImage: (@image) -> return
+
+  Object.defineProperty(
+    dataTransfer,
+    'items',
+    get: ->
+      Object.keys(dataTransfer.data).map((key) -> {type: key})
+  )
 
   dragStartEvent = new DragEvent('dragstart')
   Object.defineProperty(dragStartEvent, 'target', value: dragged)


### PR DESCRIPTION
The security model of new Chromium versions forbids all event listeners, except for `onDragStart` and `onDrop`, to inspect the data values that have been previously set on the event's `dataTransfer` object.

To circumvent this problem we can exploit the fact that all we need to do is checking whether a boolean has been set or not. To do so, we will simply list all the items contained in the `dataTransfer` object and read their `type` property (that we use as a dictionary key), verifying that at least one of them contains the key we are searching for.

Before: 

![screen shot 2017-03-29 at 16 30 51](https://cloud.githubusercontent.com/assets/482957/24459997/3e9f6b1c-149d-11e7-97c5-683aaa18221a.png)

After: 
![screen shot 2017-03-29 at 16 31 16](https://cloud.githubusercontent.com/assets/482957/24459995/3e78d498-149d-11e7-8037-dab5a8312822.png)

/cc: @atom/maintainers 