### PR TITLE
Add feature to select previous sibling or parent folder after delete

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -612,6 +612,9 @@ class TreeView
     dialog.attach()
 
   removeSelectedEntries: ->
+    selectedEntry = @selectedEntry()
+    if selectedEntry?
+      entryToSelectAfterDelete = @previousEntry(selectedEntry) ? selectedEntry.parentElement.closest('.directory')
     if @hasFocus()
       selectedPaths = @selectedPaths()
     else if activePath = @getActivePath()
@@ -645,6 +648,7 @@ class TreeView
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
           @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
+          @selectEntry(entryToSelectAfterDelete)
         "Cancel": null
 
   formatTrashFailureMessage: (failedDeletions) ->


### PR DESCRIPTION
Reference issue #60 and pull request #230

### Description of the Change

When removeSelectedEntries is called, get the first selectedEntry and save the previousEntry (if it exists) relative to the selectedEntry or the closest parent directory (in the other case) so one of these can be selected after the file is deleted.

### Alternate Designs

None

### Benefits

Fixes the problem described in issue #60 where no entry was selected after a file was deleted.  In this case, the cursor is at the top of the tree-view and you have to use the arrow key to get back to where you were before the deletion.

### Possible Drawbacks

None

### Applicable Issues

None
