### PR TITLE
Pass {} to options of openSelectedEntry instead of true

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -486,7 +486,7 @@ class TreeView
         split = pane.split orientation, side
         atom.workspace.openURIInPane selectedEntry.getPath(), split
       else
-        @openSelectedEntry yes
+        @openSelectedEntry({}, yes)
 
   openSelectedEntryRight: ->
     @openSelectedEntrySplit 'horizontal', 'after'


### PR DESCRIPTION
### Description of the Change

Fixes #1080.
The original code called `@openSelectedEntry` with one argument `yes`, which resulted to setting the `options` dictionary to a boolean `true`. When pending tabs are not allowed, [Atom tries to add `pending` to options](https://github.com/atom/atom/blob/master/src/workspace.js#L865), which will result in a TypeError.

### Alternate Designs

None?

### Benefits

This fix will enable opening of new tabs with "Split Up/Down/Left/Right" when pending tabs are not turned on.

### Possible Drawbacks

None?

### Applicable Issues

#1080