### PR TITLE
Added Toggle Buttons To "Right Click" Menus & Changed the Toggle Menu Label

### DIFF
--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -11,7 +11,7 @@
       'label': 'Tree View'
       'submenu': [
         { 'label': 'Focus', 'command': 'tree-view:toggle-focus' }
-        { 'label': 'Toggle', 'command': 'tree-view:toggle' }
+        { 'label': 'Toggle Tree View', 'command': 'tree-view:toggle' }
         { 'label': 'Reveal Active File', 'command': 'tree-view:reveal-active-file' }
         { 'label': 'Toggle Tree Side', 'command': 'tree-view:toggle-side' }
       ]
@@ -39,6 +39,9 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
+    {'type': 'separator'}
+    
+    { 'label': 'Toggle Tree View', 'command': 'tree-view:toggle' }
   ]
 
   '.tree-view.full-menu [is="tree-view-file"]': [
@@ -69,6 +72,9 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
+    {'type': 'separator'}
+
+    { 'label': 'Toggle Tree View', 'command': 'tree-view:toggle' }
   ]
 
   '.platform-darwin .tree-view.full-menu': [


### PR DESCRIPTION
### Description of the Change

**Change 1:** 
I added a "Toggle Tree View" options to the tree view right click options. This allows the user to quickly toggle the tree view without having to dig through menus.

<img src="https://cloud.githubusercontent.com/assets/14244868/25566686/ec384f42-2d92-11e7-839c-c0f629addb59.jpg" alt="change1" width="250" height="450">

**Change 2:**
I also made a minor naming change to the "Toggle" option in the Packages > Tree View menu. This change is merely to ensure a consistent naming convention.

<img src="https://cloud.githubusercontent.com/assets/14244868/25566704/7f0d135c-2d93-11e7-83bb-d05863891b07.jpg" alt="change2" width="400" height="250">

### Alternate Designs

N/A

### Benefits

With the first change, the user is able to toggle the tree-view much more quickly.

With the second change, consistent naming conventions are enforced. This allows the user to clearly understand terms used throughout the tree-view package.

### Possible Drawbacks

This change adds one menu item to the "right-click" options. Over time, if we continue to add more and more options to this menu, we may see reduced performance.

### Applicable Issues

N/A