### PR TITLE
Make list inherit its container's width

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -112,7 +112,10 @@ class TreeView
   isPermanentDockItem: -> true
 
   getPreferredWidth: ->
-    @list.offsetWidth
+    @list.style.width = 'min-content'
+    result = @list.offsetWidth
+    @list.style.width = ''
+    result
 
   onDirectoryCreated: (callback) ->
     @emitter.on('directory-created', callback)

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -23,7 +23,6 @@
      * auto-created layer.
      */
     isolation: isolate;
-    width: min-content;
     padding-left: @component-icon-padding;
     padding-right: @component-padding;
     background-color: inherit;


### PR DESCRIPTION
Fixes #1075

/cc @nathansobo - What do you think of my new implementation of `getPreferredWidth`? We talked about doing it this way, but I'm not sure if there's a better way to compute an element's min-content width value.