### PR TITLE
Fix empty context menu

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -8,6 +8,8 @@
   contain: size;
   overflow: auto;
   z-index: 2;
+  display: flex;
+  flex-direction: column;
   -webkit-user-select: none;
 
   > ol {
@@ -34,6 +36,8 @@
 
   .list-tree {
     position: static;
+    flex-grow: 1;
+    flex-shrink: 0;
   }
 
   .entry {


### PR DESCRIPTION
### Description of the Change

This expands the tree-view to full height.

### Benefits

Allows the context menu to appear also underneath the files.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/5027156/26228050/9e22175e-3c36-11e7-8ab3-f123d8107fcd.png) | ![image](https://cloud.githubusercontent.com/assets/5027156/26228044/99273dba-3c36-11e7-9b84-793965eebb74.png)

### Possible Drawbacks

It's the same as https://github.com/atom/tree-view/pull/602, but this time flexbox is added one level deeper (`.tree-view-scroller` -> `tree-view`). Haven't seen any issues, but something to keep in mind.

### Applicable Issues

Fixes https://github.com/atom/tree-view/issues/1073
Regressed by moving to a dock item https://github.com/atom/tree-view/pull/1056 
