### PR TITLE
Expand to full width/height

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -10,7 +10,10 @@
   z-index: 2;
   -webkit-user-select: none;
 
-  > ol {
+  display: flex;
+  flex-direction: column;
+
+  .full-menu {
     /*
      * Force a new stacking context to prevent a large, duplicate paint layer from
      * being created for tree-view's scrolling contents that can make the cost of
@@ -26,6 +29,12 @@
     padding-left: @component-icon-padding;
     padding-right: @component-padding;
     background-color: inherit;
+
+    // Expands .full-menu to take up full height.
+    // This makes sure that the context menu can still be openend in the empty
+    // area underneath the files.
+    flex-grow: 1;
+  }
   }
 
   .header {

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -35,6 +35,12 @@
     // area underneath the files.
     flex-grow: 1;
   }
+
+  .full-menu.list-tree {
+    // Expands .full-menu to take up as much width as needed by the content.
+    // This makes sure that the selected item's "bar/background" expands to full width.
+    position: relative;
+    min-width: min-content;
   }
 
   .header {


### PR DESCRIPTION
### Description of the Change

This expands the tree-view to full width and height.

### Benefits

Makes sure that the selected item's "bar" isn't cut off when scrolling horizontally.

Before | After
--- | ---
![screen shot 2017-05-20 at 4 28 04 pm](https://cloud.githubusercontent.com/assets/378023/26274025/649aef62-3d79-11e7-9752-335f9bdd67df.png) | ![screen shot 2017-05-20 at 4 28 21 pm](https://cloud.githubusercontent.com/assets/378023/26274026/649de992-3d79-11e7-92a7-796fcab41396.png)

Allows the context menu to appear also underneath the files.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/5027156/26228050/9e22175e-3c36-11e7-8ab3-f123d8107fcd.png) | ![image](https://cloud.githubusercontent.com/assets/5027156/26228044/99273dba-3c36-11e7-9b84-793965eebb74.png)

### Possible Drawbacks

These fixes might still have side effects that only get discovered with more testing/using. But so far seems fine.

### Applicable Issues

Fixes #1073
Fixes #1110

Regressed by moving to a dock item https://github.com/atom/tree-view/pull/1056 