### PR TITLE
Restore ability for `escape` to return focus to center

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -68,6 +68,7 @@
   'alt-left': 'tree-view:recursive-collapse-directory'
   'h': 'tree-view:collapse-directory'
   'enter': 'tree-view:open-selected-entry'
+  'escape': 'tree-view:unfocus'
   'ctrl-C': 'tree-view:copy-full-path'
   'm': 'tree-view:move'
   'f2': 'tree-view:move'

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -169,7 +169,7 @@ class TreeView
      'tree-view:show-in-file-manager': => @showSelectedEntryInFileManager()
      'tree-view:open-in-new-window': => @openSelectedEntryInNewWindow()
      'tree-view:copy-project-path': => @copySelectedEntryPath(true)
-     'tool-panel:unfocus': => @unfocus()
+     'tree-view:unfocus': => @unfocus()
      'tree-view:toggle-vcs-ignored-files': -> toggleConfig 'tree-view.hideVcsIgnoredFiles'
      'tree-view:toggle-ignored-names': -> toggleConfig 'tree-view.hideIgnoredNames'
      'tree-view:remove-project-folder': (e) => @removeProjectFolder(e)

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -401,16 +401,16 @@ describe "TreeView", ->
         runs ->
           expect(treeView.scrollTop()).toEqual 0
 
-  describe "when tool-panel:unfocus is triggered on the tree view", ->
+  describe "when tree-view:unfocus is triggered on the tree view", ->
     it "surrenders focus to the workspace but remains open", ->
       waitsForPromise ->
-        atom.workspace.open() # When we trigger 'tool-panel:unfocus' below, we want an editor to become focused
+        atom.workspace.open() # When we trigger 'tree-view:unfocus' below, we want an editor to become focused
 
       runs ->
         jasmine.attachToDOM(workspaceElement)
         treeView.focus()
         expect(treeView.element).toHaveFocus()
-        atom.commands.dispatch(treeView.element, 'tool-panel:unfocus')
+        atom.commands.dispatch(treeView.element, 'tree-view:unfocus')
         expect(atom.workspace.getLeftDock().isVisible()).toBe(true)
         expect(treeView.element).not.toHaveFocus()
         expect(atom.workspace.getCenter().getActivePane().isActive()).toBe(true)


### PR DESCRIPTION
Closes #1113.

---

### Description of the Change

In Atom 1.16 and earlier, the tree view lived in a [`Panel`](https://atom.io/docs/api/v1.17.2/Panel). With the tree-view focused, hitting `escape` triggered [this keybinding defined in atom/atom](https://github.com/atom/atom/blob/1a60c450caac364203510fbbaf4cd07b3df41088/keymaps/base.cson#L21-L22):

```cson
'.tool-panel.panel-left, .tool-panel.panel-right':
  'escape': 'tool-panel:unfocus'
```

In Atom 1.17, the tree view moved to a [`Dock`](https://atom.io/docs/api/v1.17.2/Dock). As a result, the keybinding above no longer works. With the tree-view focused, hitting `escape` currently triggers no keybindings at all.

This PR renames the existing `tool-panel:unfocus` command to `tree-view:unfocus` and it adds a keybinding to allow `escape` to trigger that command.

### Alternate Designs

See https://github.com/atom/tree-view/issues/1113#issuecomment-307240732

### Benefits

Restores ability for `escape` to return focus to the workspace center

### Possible Drawbacks

None that I can think of

### Applicable Issues

#1113
