### PR TITLE
Fix multi-select shifting

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -31,7 +31,7 @@ class TreeView
     @element.tabIndex = -1
 
     @list = document.createElement('ol')
-    @list.classList.add('full-menu', 'list-tree', 'has-collapsable-children', 'focusable-panel')
+    @list.classList.add('tree-view-root', 'full-menu', 'list-tree', 'has-collapsable-children', 'focusable-panel')
     @element.appendChild(@list)
 
     @disposables = new CompositeDisposable

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -13,7 +13,11 @@
   display: flex;
   flex-direction: column;
 
-  .full-menu {
+  .tree-view-root {
+    padding-left: @component-icon-padding;
+    padding-right: @component-padding;
+    background-color: inherit;
+
     /*
      * Force a new stacking context to prevent a large, duplicate paint layer from
      * being created for tree-view's scrolling contents that can make the cost of
@@ -26,18 +30,13 @@
      * auto-created layer.
      */
     isolation: isolate;
-    padding-left: @component-icon-padding;
-    padding-right: @component-padding;
-    background-color: inherit;
 
-    // Expands .full-menu to take up full height.
+    // Expands tree-view root to take up full height.
     // This makes sure that the context menu can still be openend in the empty
     // area underneath the files.
     flex-grow: 1;
-  }
 
-  .full-menu.list-tree {
-    // Expands .full-menu to take up as much width as needed by the content.
+    // Expands tree-view root to take up as much width as needed by the content.
     // This makes sure that the selected item's "bar/background" expands to full width.
     position: relative;
     min-width: min-content;
@@ -47,7 +46,8 @@
     position: relative;
   }
 
-  .list-tree {
+  .tree-view-root .list-tree {
+    // Keeps selections expanded while dragging
     position: static;
   }
 


### PR DESCRIPTION
### Description of the Change

This fixes the tree-view from shifting to the left when selecting multiple files.

|Full Menu|Multi Select|
|-----------|-------------|
|![full-menu](https://user-images.githubusercontent.com/2766036/27203782-7f623c20-51f5-11e7-982e-a805ade30ef7.png)|![multi-select](https://user-images.githubusercontent.com/2766036/27203772-6fd68cac-51f5-11e7-84d1-68e5de710c7b.png)|

### Alternate Designs

We could use a child selector like `.tree-view > .list-tree` or both "states" `.full-menu, .multi-select`, but having just a single class seems simpler and communicates its intend better.

### Benefits

No shifting.

### Possible Drawbacks

None

### Applicable Issues

Raised in https://github.com/atom/tree-view/pull/1115#issuecomment-308879413
Possibly regressed in https://github.com/atom/tree-view/pull/1111