### PR TITLE
Add option to close after opening file with keyboard

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -429,6 +429,7 @@ class TreeView
       if atom.config.get('tree-view.alwaysOpenExisting')
         options = Object.assign searchAllPanes: true, options
       @openAfterPromise(selectedEntry.getPath(), options)
+      @toggle() if atom.config.get('tree-view.closeOnKeyboardFileOpen')
 
   openSelectedEntrySplit: (orientation, side) ->
     selectedEntry = @selectedEntry()

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
       "type": "boolean",
       "default": false,
       "description": "When opening a file, always focus an already-existing view of the file even if it's in a another pane."
+    },
+    "closeOnKeyboardFileOpen": {
+      "type": "boolean",
+      "default": false,
+      "description": "Close the tree view after opening a file using the keyboard."
     }
   }
 }

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3465,6 +3465,60 @@ describe "TreeView", ->
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
           expect(atom.views.getView(getCenter().getPanes()[1])).toHaveFocus()
 
+  describe "the closeOnKeyboardFileOpen config option", ->
+    it "defaults to false", ->
+      expect(atom.config.get("tree-view.closeOnKeyboardFileOpen")).toBeFalsy()
+
+    describe "when tree view is open", ->
+      beforeEach ->
+        jasmine.attachToDOM(workspaceElement)
+
+      describe "tree-view:open-selected-entry (closeOnKeyboardFileOpen off)", ->
+        beforeEach ->
+          atom.config.set "tree-view.closeOnKeyboardFileOpen", false
+
+        describe "when opening file using the keyboard", ->
+          beforeEach ->
+            selectEntry 'tree-view.txt'
+            waitForWorkspaceOpenEvent ->
+              atom.commands.dispatch treeView.element, "tree-view:open-selected-entry"
+
+          it "doesn't hide the tree view", ->
+            expect(atom.workspace.getLeftDock().isVisible()).toBe(true)
+
+      describe "tree-view:open-selected-entry (closeOnKeyboardFileOpen on)", ->
+        beforeEach ->
+          atom.config.set "tree-view.closeOnKeyboardFileOpen", true
+
+        describe "when opening file using the keyboard", ->
+          beforeEach ->
+            selectEntry 'tree-view.txt'
+            waitForWorkspaceOpenEvent ->
+              atom.commands.dispatch treeView.element, "tree-view:open-selected-entry"
+
+          it "hides the tree view", ->
+            expect(atom.workspace.getLeftDock().isVisible()).toBe(false)
+
+        describe "when opening file with single click", ->
+          beforeEach ->
+            waitForWorkspaceOpenEvent ->
+              sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+          it "doesn't hide the tree view", ->
+            expect(atom.workspace.getLeftDock().isVisible()).toBe(true)
+
+        describe "when opening file with double-click", ->
+          beforeEach ->
+            waitForWorkspaceOpenEvent ->
+              sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+              sampleJs.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 2}))
+
+            waitsFor "next tick to avoid race condition", (done) ->
+              setImmediate(done)
+
+          it "doesn't hide the tree view", ->
+            expect(atom.workspace.getLeftDock().isVisible()).toBe(true)
+
   describe "Dragging and dropping root folders", ->
     [alphaDirPath, gammaDirPath, thetaDirPath, etaDirPath] = []
     beforeEach ->


### PR DESCRIPTION
I don't like having the tree view always open.  I usually close it as
soon as I open the file I'm looking for.  I think it would be
useful if the tree view automatically closes after I toggle the tree
view open and hit enter on a file.  This change does not effect mouse
clicks.

* Add option `closeAfterKeyboardFileOpen`
* Toggle tree view after running command `openSelectedEntry`
