### PR TITLE
Improve expandDirectory logic

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -403,10 +403,12 @@ class TreeView
     selectedEntry = @selectedEntry()
     return unless selectedEntry?
 
-    if isRecursive is false and selectedEntry.isExpanded
-      @moveDown() if selectedEntry.directory.getEntries().length > 0
+    directory = selectedEntry.closest('.directory')
+    if isRecursive is false and directory.isExpanded
+      # Select the first entry in the expanded folder if it exists
+      @moveDown() if directory.directory.getEntries().length > 0
     else
-      selectedEntry.expand(isRecursive)
+      directory.expand(isRecursive)
 
   collapseDirectory: (isRecursive=false) ->
     selectedEntry = @selectedEntry()

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1029,6 +1029,24 @@ describe "TreeView", ->
           for child in children
             expect(child).toHaveClass 'expanded'
 
+      describe "when a file is selected and ordered to recursively expand", ->
+        it "recursively expands the selected file's parent directory", ->
+          dir1 = root1.querySelector('.entries > .directory')
+          dir2 = root1.querySelectorAll('.entries > .directory')[1]
+          dir1.expand()
+          file1 = dir1.querySelector('.file')
+          subdir1 = dir1.querySelector('.entries > .directory')
+
+          waitForWorkspaceOpenEvent ->
+            file1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+          runs ->
+            atom.commands.dispatch(treeView.element, 'tree-view:recursive-expand-directory')
+            expect(dir1).toHaveClass 'expanded'
+            expect(subdir1).toHaveClass 'expanded'
+            expect(file1).toHaveClass 'selected'
+            expect(dir2).toHaveClass 'collapsed'
+
     describe "tree-view:collapse-directory", ->
       subdir = null
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Instead of trying to expand a file and throwing, search for its parent directory and recursively expand that.

### Alternate Designs

Perform no action when a file is selected.  This introduces inconsistencies with how `recursive-collapse-directory` operates.

### Benefits

No more errors when attempting to recursively expand a file, and improved consistency with `recursive-collapse-directory`.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #921
Supersedes and closes #970
Supersedes and closes #1022