### PR TITLE
Remove docks cleanup TODO from specs

### DIFF
--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -36,9 +36,6 @@ setupPaneFiles = ->
 
 getPaneFileName = (index) -> "test-file-#{index}.txt"
 
-# TODO: Remove this after atom/atom#13977 lands in favor of unguarded `getCenter()` calls
-getCenter = -> atom.workspace.getCenter?() ? atom.workspace
-
 describe "TreeView", ->
   [treeView, path1, path2, root1, root2, sampleJs, sampleTxt, workspaceElement] = []
 
@@ -1268,7 +1265,7 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-right')
 
     it "should have opened all windows", ->
-      expect(getCenter().getPanes().length).toBe 9
+      expect(atom.workspace.getCenter().getPanes().length).toBe 9
 
     [0..8].forEach (index) ->
       paneNumber = index + 1
@@ -1282,7 +1279,7 @@ describe "TreeView", ->
               atom.commands.dispatch treeView.element, command
 
           it "opens the file in pane #{paneNumber} and focuses it", ->
-            pane = getCenter().getPanes()[index]
+            pane = atom.workspace.getCenter().getPanes()[index]
             item = atom.workspace.getCenter().getActivePaneItem()
             expect(atom.views.getView(pane)).toHaveFocus()
             expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
@@ -1300,7 +1297,7 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-right')
 
     it "should have opened all windows", ->
-      expect(getCenter().getPanes().length).toBe 9
+      expect(atom.workspace.getCenter().getPanes().length).toBe 9
 
     [0..8].forEach (index) ->
       paneNumber = index + 1
@@ -1316,7 +1313,7 @@ describe "TreeView", ->
                 atom.commands.dispatch treeView.element, command
 
             it "opens the file in pane #{paneNumber} and focuses it", ->
-              pane = getCenter().getPanes()[index]
+              pane = atom.workspace.getCenter().getPanes()[index]
               item = atom.workspace.getCenter().getActivePaneItem()
               expect(atom.views.getView(pane)).toHaveFocus()
               expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)
@@ -3394,21 +3391,21 @@ describe "TreeView", ->
           atom.commands.dispatch(treeView.element, 'tree-view:open-selected-entry-right')
 
       it "should have opened both panes", ->
-        expect(getCenter().getPanes().length).toBe 2
+        expect(atom.workspace.getCenter().getPanes().length).toBe 2
 
       describe "tree-view:open-selected-entry", ->
         beforeEach ->
           atom.config.set "tree-view.alwaysOpenExisting", true
         describe "when the first pane is focused, a file is opened that is already open in the second pane", ->
           beforeEach ->
-            firstPane = getCenter().getPanes()[0]
+            firstPane = atom.workspace.getCenter().getPanes()[0]
             firstPane.activate()
             selectEntry 'tree-view.txt'
             waitForWorkspaceOpenEvent ->
               atom.commands.dispatch treeView.element, "tree-view:open-selected-entry"
 
           it "opens the file in the second pane and focuses it", ->
-            pane = getCenter().getPanes()[1]
+            pane = atom.workspace.getCenter().getPanes()[1]
             item = atom.workspace.getCenter().getActivePaneItem()
             expect(atom.views.getView(pane)).toHaveFocus()
             expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
@@ -3421,7 +3418,7 @@ describe "TreeView", ->
         describe "when the first pane is focused, a file is opened that is already open in the second pane", ->
           firstPane = null
           beforeEach ->
-            firstPane = getCenter().getPanes()[0]
+            firstPane = atom.workspace.getCenter().getPanes()[0]
             firstPane.activate()
             selectEntry 'tree-view.txt'
             waitForWorkspaceOpenEvent ->
@@ -3439,7 +3436,7 @@ describe "TreeView", ->
         describe "when core.allowPendingPaneItems is set to true (default)", ->
           firstPane = activePaneItem = null
           beforeEach ->
-            firstPane = getCenter().getPanes()[0]
+            firstPane = atom.workspace.getCenter().getPanes()[0]
             firstPane.activate()
 
             treeView.focus()
@@ -3464,7 +3461,7 @@ describe "TreeView", ->
         activePaneItem = null
 
         beforeEach ->
-          firstPane = getCenter().getPanes()[0]
+          firstPane = atom.workspace.getCenter().getPanes()[0]
           firstPane.activate()
 
           treeView.focus()
@@ -3481,7 +3478,7 @@ describe "TreeView", ->
         it "opens the file and focuses it", ->
 
           expect(activePaneItem.getPath()).toBe atom.project.getDirectories()[0].resolve('tree-view.txt')
-          expect(atom.views.getView(getCenter().getPanes()[1])).toHaveFocus()
+          expect(atom.views.getView(atom.workspace.getCenter().getPanes()[1])).toHaveFocus()
 
   describe "Dragging and dropping root folders", ->
     [alphaDirPath, gammaDirPath, thetaDirPath, etaDirPath] = []

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -9,7 +9,7 @@ eventHelpers = require "./event-helpers"
 DefaultFileIcons = require '../lib/default-file-icons'
 FileIcons = require '../lib/file-icons'
 
-waitForPackageActivation = (expectDockItem) ->
+waitForPackageActivation = ->
   waitsForPromise ->
     atom.packages.activatePackage('tree-view')
   waitsForPromise ->


### PR DESCRIPTION
Replace `getCenter()` calls with `atom.workspace.getCenter()` now that Docks has fully shipped.