### PR TITLE
Use getFullExtension for move, copy dialogs

### DIFF
--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -1,5 +1,6 @@
 {TextEditor, CompositeDisposable, Disposable, Emitter, Range, Point} = require 'atom'
 path = require 'path'
+{getFullExtension} = require "./helpers"
 
 module.exports =
 class Dialog
@@ -35,7 +36,7 @@ class Dialog
     @miniEditor.setText(initialPath)
 
     if select
-      extension = path.extname(initialPath)
+      extension = getFullExtension(initialPath)
       baseName = path.basename(initialPath)
       selectionStart = initialPath.length - baseName.length
       if baseName is extension

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2095,7 +2095,7 @@ describe "TreeView", ->
           expect(moveDialog.element).toExist()
           expect(moveDialog.promptText.textContent).toBe "Enter the new path for the file."
           expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(moveDialog.miniEditor.getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(moveDialog.miniEditor.getSelectedText()).toBe fileNameWithoutExtension
           expect(moveDialog.miniEditor.element).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->
@@ -2250,7 +2250,7 @@ describe "TreeView", ->
           expect(copyDialog.element).toExist()
           expect(copyDialog.promptText.textContent).toBe "Enter the new path for the duplicate."
           expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(filePath))
-          expect(copyDialog.miniEditor.getSelectedText()).toBe path.basename(fileNameWithoutExtension)
+          expect(copyDialog.miniEditor.getSelectedText()).toBe fileNameWithoutExtension
           expect(copyDialog.miniEditor.element).toHaveFocus()
 
         describe "when the path is changed and confirmed", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2184,6 +2184,28 @@ describe "TreeView", ->
           expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
           expect(moveDialog.miniEditor.getSelectedText()).toBe '.dotfile'
 
+      describe "when a file is selected that has multiple extensions", ->
+        [dotFilePath, dotFileView, moveDialog] = []
+
+        beforeEach ->
+          dotFilePath = path.join(dirPath, "test.file.txt")
+          fs.writeFileSync(dotFilePath, "dot dot")
+          dirView.collapse()
+          dirView.expand()
+          dotFileView = treeView.entryForPath(dotFilePath)
+
+          waitForWorkspaceOpenEvent ->
+            dotFileView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+          runs ->
+            atom.commands.dispatch(treeView.element, "tree-view:move")
+            moveDialog = atom.workspace.getModalPanels()[0].getItem()
+
+        it "selects only the part of the filename up to the first extension", ->
+          expect(moveDialog.element).toExist()
+          expect(moveDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
+          expect(moveDialog.miniEditor.getSelectedText()).toBe 'test'
+
       describe "when a subdirectory is selected", ->
         moveDialog = null
 
@@ -2338,6 +2360,28 @@ describe "TreeView", ->
           expect(copyDialog.element).toExist()
           expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
           expect(copyDialog.miniEditor.getSelectedText()).toBe '.dotfile'
+
+      describe "when a file is selected that has multiple extensions", ->
+        [dotFilePath, dotFileView, copyDialog] = []
+
+        beforeEach ->
+          dotFilePath = path.join(dirPath, "test.file.txt")
+          fs.writeFileSync(dotFilePath, "dot dot")
+          dirView.collapse()
+          dirView.expand()
+          dotFileView = treeView.entryForPath(dotFilePath)
+
+          waitForWorkspaceOpenEvent ->
+            dotFileView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+          runs ->
+            atom.commands.dispatch(treeView.element, "tree-view:duplicate")
+            copyDialog = atom.workspace.getModalPanels()[0].getItem()
+
+        it "selects only the part of the filename up to the first extension", ->
+          expect(copyDialog.element).toExist()
+          expect(copyDialog.miniEditor.getText()).toBe(atom.project.relativize(dotFilePath))
+          expect(copyDialog.miniEditor.getSelectedText()).toBe 'test'
 
       describe "when the project is selected", ->
         it "doesn't display the copy dialog", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Use `getFullExtension` to determine the file's extension in dialogs.  Using `test.file.txt` as an example, before `test.file` would be selected by the dialog, whereas with this PR only `test` is.

### Alternate Designs

None.

### Benefits

Ease of usage of move and copy dialogs.

### Possible Drawbacks

Some people might prefer the old behavior.  I think the behavior introduced in this PR should help the majority case however.

### Applicable Issues

Fixes #838
Supersedes and closes #839