### PR TITLE
Focus parent on deletion

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -568,15 +568,14 @@ class TreeView
     dialog.attach()
 
   removeSelectedEntries: ->
-    parents = _.uniq(_.map(@selectedPaths(),  (selectedPath) ->
-      return selectedPath.substring(0, selectedPath.lastIndexOf(path.sep))
-    ))
     if @hasFocus()
       selectedPaths = @selectedPaths()
+      selectedEntries = @getSelectedEntries()
     else if activePath = @getActivePath()
       selectedPaths = [activePath]
+      selectedEntries = [@entryForPath(activePath)]
 
-    return unless selectedPaths and selectedPaths.length > 0
+    return unless selectedPaths?.length > 0
 
     for root in @roots
       if root.getPath() in selectedPaths
@@ -596,14 +595,18 @@ class TreeView
               @emitter.emit 'entry-deleted', {path: selectedPath}
             else
               failedDeletions.push "#{selectedPath}"
+
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)
+
           if failedDeletions.length > 0
             atom.notifications.addError @formatTrashFailureMessage(failedDeletions),
               description: @formatTrashEnabledMessage()
               detail: "#{failedDeletions.join('\n')}"
               dismissable: true
-          @selectEntry(@list.find("[data-path='#{parents[0]}']").parents('li').first()?[0])
+
+          # Focus the first parent folder
+          @selectEntry(selectedEntries[0].closest('.directory:not(.selected)'))
           @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
         "Cancel": null
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2482,17 +2482,72 @@ describe "TreeView", ->
             openFilePaths = atom.workspace.getTextEditors().map((e) -> e.getPath())
             expect(openFilePaths).toEqual([filePath2, filePath3])
             dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
 
-          waitsForPromise ->
-            treeView.toggleFocus()
-
-          runs ->
             spyOn(atom, 'confirm').andCallFake (dialog) ->
               dialog.buttons["Move to Trash"]()
 
             atom.commands.dispatch(treeView.element, 'tree-view:remove')
             openFilePaths = (editor.getPath() for editor in atom.workspace.getTextEditors())
             expect(openFilePaths).toEqual([])
+
+        it "focuses the directory's parent folder", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          treeView.focus()
+
+          spyOn(atom, 'confirm').andCallFake (dialog) ->
+            dialog.buttons["Move to Trash"]()
+
+          atom.commands.dispatch(treeView.element, 'tree-view:remove')
+          expect(root1).toHaveClass('selected')
+
+      describe "when a file is removed", ->
+        it "closes editors with filepaths belonging to the removed file", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath2)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((e) -> e.getPath())
+            expect(openFilePaths).toEqual([filePath2])
+            fileView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) ->
+              dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = (editor.getPath() for editor in atom.workspace.getTextEditors())
+            expect(openFilePaths).toEqual([])
+
+        it "focuses the file's parent folder", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          fileView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+          runs ->
+            spyOn(atom, 'confirm').andCallFake (dialog) ->
+              dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            expect(dirView2).toHaveClass('selected')
+
+      describe "when multiple files and folders are deleted", ->
+        it "focuses the first selected entry's parent folder", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          dirView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+          treeView.focus()
+
+          spyOn(atom, 'confirm').andCallFake (dialog) ->
+            dialog.buttons["Move to Trash"]()
+
+          atom.commands.dispatch(treeView.element, 'tree-view:remove')
+          expect(root1).toHaveClass('selected')
 
   describe "file system events", ->
     temporaryFilePath = null


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

After deleting a file or folder, focus its immediate parent directory.  When multiple folders/files are selected, focus the first entry's parent directory.  Re-implementation of #230, now with :sparkles:specs:sparkles:.

### Alternate Designs

Focusing the previous/next file.  Windows Explorer focuses the parent directory, and the existing PRs also focused the parent directory, so that is what I went with.

### Benefits

Selection context is maintained rather than losing the selection and having to start over from the root.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #60
Supersedes and closes #230
Supersedes and closes #1062

/cc @deiga, @mtp13