### PR TITLE
Don't try to delete entries which no longer exist

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -591,6 +591,12 @@ class TreeView
         "Move to Trash": =>
           failedDeletions = []
           for selectedPath in selectedPaths
+            # Don't delete entries which no longer exist. This can happen, for example, when:
+            # * The entry is deleted outside of Atom before "Move to Trash" is selected
+            # * A folder and one of its children are both selected for deletion,
+            #   but the parent folder is deleted first
+            continue unless fs.existsSync(selectedPath)
+
             if shell.moveItemToTrash(selectedPath)
               @emitter.emit 'entry-deleted', {path: selectedPath}
             else


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Do not attempt to delete files/folders that no longer exist.  This can happen when:
* The entry is deleted outside of Atom before "Move to Trash" is selected
* A folder and one of its children are both selected for deletion, but the parent folder is deleted first

### Alternate Designs

None.

### Benefits

Since the file no longer exists, we don't have to try deleting it!  And hence no error will be shown.

### Possible Drawbacks

This won't keep track of renames.

### Applicable Issues

Couldn't find any.

Additional info: the existing spec to make sure error notifications were displayed was actually using this behavior to trigger the notification.  I have rewritten it to spy on the actual trash method and return false from there, tricking Tree View into thinking that the operation failed.