### PR TITLE
Fix empty label for drive paths

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -282,7 +282,7 @@ class TreeView
         stats[key] = stats[key].getTime()
 
       directory = new Directory({
-        name: path.basename(projectPath)
+        name: path.basename(projectPath) or projectPath
         fullPath: projectPath
         symlink: false
         isRoot: true


### PR DESCRIPTION
### Description of the Change

Fix empty label for drive paths as stated in the issue. https://github.com/atom/tree-view/issues/903#issuecomment-311930641

### Alternate Designs

Issue been open for a long time, no other solution at this moment.

### Benefits

Not having a . as label in the project root.

### Possible Drawbacks

None that i am aware off.

### Applicable Issues

https://github.com/atom/tree-view/issues/903 partial https://github.com/atom/tree-view/issues/700
