### PR TITLE
Repo status color on project root directory

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -56,8 +56,9 @@ class DirectoryView
       @header.classList.add('project-root-header')
     else
       @element.draggable = true
-      @subscriptions.add @directory.onDidStatusChange => @updateStatus()
-      @updateStatus()
+
+    @subscriptions.add @directory.onDidStatusChange => @updateStatus()
+    @updateStatus()
 
     @expand() if @directory.expansionState.isExpanded
 

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -93,14 +93,14 @@ class Directory
     else
       status = 0
       if @isRoot
-          # repo.getDirectoryStatus will always fail for the
-          # root because the path is relativized + concatenated with '/'
-          # making the matching string be '/'.  Then path.indexOf('/')
-          # is run and will never match beginning of string with a leading '/'
-          for statusPath, statusId of repo.statuses
-            status |= parseInt(statusId, 10)
+        # repo.getDirectoryStatus will always fail for the
+        # root because the path is relativized + concatenated with '/'
+        # making the matching string be '/'.  Then path.indexOf('/')
+        # is run and will never match beginning of string with a leading '/'
+        for statusPath, statusId of repo.statuses
+          status |= parseInt(statusId, 10)
       else
-          status = repo.getDirectoryStatus(@path)
+        status = repo.getDirectoryStatus(@path)
 
       if repo.isStatusModified(status)
         newStatus = 'modified'

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -91,7 +91,17 @@ class Directory
     if repo.isPathIgnored(@path)
       newStatus = 'ignored'
     else
-      status = repo.getDirectoryStatus(@path)
+      status = 0
+      if @isRoot
+          # repo.getDirectoryStatus will always fail for the
+          # root because the path is relativized + concatenated with '/'
+          # making the matching string be '/'.  Then path.indexOf('/')
+          # is run and will never match beginning of string with a leading '/'
+          for statusPath, statusId of repo.statuses
+            status |= parseInt(statusId, 10)
+      else
+          status = repo.getDirectoryStatus(@path)
+
       if repo.isStatusModified(status)
         newStatus = 'modified'
       else if repo.isStatusNew(status)

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2549,7 +2549,7 @@ describe "TreeView", ->
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
-          
+
         it "focuses the first selected entry's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
 
@@ -2894,24 +2894,40 @@ describe "TreeView", ->
 
     describe "when a file is modified", ->
       it "adds a custom style", ->
-        expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
+        expect(treeView.element.querySelector('.project-root .file.status-modified')).toHaveText('b.txt')
+
+    describe "when a file is modified", ->
+      it "adds a custom style to the project root", ->
+        expect(treeView.element.querySelector('.project-root')).toHaveClass('status-modified')
 
     describe "when a directory is modified", ->
       it "adds a custom style", ->
-        expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
+        expect(treeView.element.querySelector('.project-root .directory.status-modified').header).toHaveText('dir')
+
+    describe "when a directory is modified", ->
+      it "adds a custom style to the project root", ->
+        expect(treeView.element.querySelector('.project-root')).toHaveClass('status-modified')
 
     describe "when a file is new", ->
       it "adds a custom style", ->
         treeView.roots[0].entries.querySelectorAll('.directory')[2].expand()
-        expect(treeView.element.querySelector('.file.status-added')).toHaveText('new2')
+        expect(treeView.element.querySelector('.project-root .file.status-added')).toHaveText('new2')
+
+    describe "when a file is new", ->
+      it "adds a custom style to the project root", ->
+        expect(treeView.element.querySelector('.project-root')).toHaveClass('status-modified')
 
     describe "when a directory is new", ->
       it "adds a custom style", ->
-        expect(treeView.element.querySelector('.directory.status-added').header).toHaveText('dir2')
+        expect(treeView.element.querySelector('.project-root .directory.status-added').header).toHaveText('dir2')
+
+    describe "when a directory is new", ->
+      it "adds a custom style to the project root", ->
+        expect(treeView.element.querySelector('.project-root')).toHaveClass('status-modified')
 
     describe "when a file is ignored", ->
       it "adds a custom style", ->
-        expect(treeView.element.querySelector('.file.status-ignored')).toHaveText('ignored.txt')
+        expect(treeView.element.querySelector('.project-root .file.status-ignored')).toHaveText('ignored.txt')
 
     describe "when a file is selected in a directory", ->
       beforeEach ->
@@ -2952,16 +2968,18 @@ describe "TreeView", ->
 
       describe "when a file is modified", ->
         it "updates its and its parent directories' styles", ->
-          expect(treeView.element.querySelector('.file.status-modified')).toHaveText('b.txt')
-          expect(treeView.element.querySelector('.directory.status-modified').header).toHaveText('dir')
+          expect(treeView.element.querySelector('.project-root .file.status-modified')).toHaveText('b.txt')
+          expect(treeView.element.querySelector('.project-root .directory.status-modified').header).toHaveText('dir')
+          expect(treeView.element.querySelector('.project-root')).toHaveClass('status-modified')
 
       describe "when a file loses its modified status", ->
         it "updates its and its parent directories' styles", ->
           fs.writeFileSync(modifiedFile, originalFileContent)
           atom.project.getRepositories()[0].getPathStatus(modifiedFile)
 
-          expect(treeView.element.querySelector('.file.status-modified')).not.toExist()
-          expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.project-root .file.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.project-root .directory.status-modified')).not.toExist()
+          expect(treeView.element.querySelector('.project-root.status-modified')).not.toExist()
 
   describe "selecting items", ->
     [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []


### PR DESCRIPTION
This makes it easier to identify which projects have uncommitted
changes when working with more than one project.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I occasionally work with software projects that have more than one project folder added to them.

In these cases, it is difficult to identify which repositories I have uncommitted changed on.

This change bubbles up the '.status-modified' and '.status-added' CSS classes to the '.project-root' elements so that the repo modification status can be clearly seen when all folders are collapsed.

### Alternate Designs

The code changes in the `directory.coffee` file could alternatively be put into the atom core.  It would require a change to the logic of 'repo.getDirectoryStatus()'  method.

The reason I avoided changin Atom core are twofold:
- first is my concern with unexpected consequences for other plugin developers who use the repo.getDirectoryStatus (is the root folder coming back with a status of 0 a feature or a bug?)
- second, an update here allows people to get this new feature by updating the plugin instead of all of Atom

In short, there is a bug(?) in repo.getDirectoryStatus('/my/root') which will calculate the relative path as @relativize("/my/root") + "/" resulting in the string "/".  Then all of the git statuses (formatted like "subdir/file.txt") are evaluated and if statusPath.indexOf(relative_git_root) == 0 then it will consider the status of the parent folder to be of a particular value.

The problem is that, in the case of the root folder, it will never match character 0 since none of the status paths ever have a leading "/".

### Benefits

People who want to see the repo status at the root level will be able to do so - especially useful for those who use multi-project often.

### Possible Drawbacks

It is aesthetic and people are opinionated -- so some people might not like it.

### Applicable Issues

n/a