### PR TITLE
Sort Files Before Folder

### DIFF
--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -203,7 +203,7 @@ class Directory
         else
           files.push(new File({name, fullPath, symlink, realpathCache, @useSyncFS, stats: statFlat}))
 
-    @sortEntries(directories.concat(files))
+    @sortEntries(directories, files)
 
   normalizeEntryName: (value) ->
     normalizedValue = value.name
@@ -213,11 +213,14 @@ class Directory
       normalizedValue = normalizedValue.toLowerCase()
     normalizedValue
 
-  sortEntries: (combinedEntries) ->
-    if atom.config.get('tree-view.sortFoldersBeforeFiles')
-      combinedEntries
+  sortEntries: (directories, files) ->
+    sortFolders = atom.config.get('tree-view.sortFolders')
+    if sortFolders is "Before Files"
+      directories.concat(files)
+    else if sortFolders is "After Files"
+      files.concat(directories)
     else
-      combinedEntries.sort (first, second) =>
+      directories.concat(files).sort (first, second) =>
         firstName = @normalizeEntryName(first)
         secondName = @normalizeEntryName(second)
         firstName.localeCompare(secondName)

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -7,6 +7,16 @@ const TreeView = require('./tree-view')
 module.exports =
 class TreeViewPackage {
   activate () {
+    const oldSort = atom.config.get('tree-view.sortFoldersBeforeFiles')
+    if (oldSort !== undefined) {
+      console.log('Migrating settings....')
+      atom.config.unset('tree-view.sortFoldersBeforeFiles')
+      if (oldSort) {
+        atom.config.set('tree-view.sortFolders', 'Before Files')
+      } else {
+        atom.config.set('tree-view.sortFolders', 'Alongside Files')
+      }
+    }
     this.disposables = new CompositeDisposable()
     this.disposables.add(atom.commands.add('atom-workspace', {
       'tree-view:show': () => this.getTreeViewInstance().show(),

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -189,7 +189,7 @@ class TreeView
       @updateRoots()
     @disposables.add atom.config.onDidChange 'core.ignoredNames', =>
       @updateRoots() if atom.config.get('tree-view.hideIgnoredNames')
-    @disposables.add atom.config.onDidChange 'tree-view.sortFoldersBeforeFiles', =>
+    @disposables.add atom.config.onDidChange 'tree-view.sortFolders', =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.squashDirectoryNames', =>
       @updateRoots()

--- a/package.json
+++ b/package.json
@@ -48,10 +48,15 @@
       "default": false,
       "description": "Don't show items matched by the `Ignored Names` core config setting."
     },
-    "sortFoldersBeforeFiles": {
-      "type": "boolean",
-      "default": true,
-      "description": "When listing directory items, list subdirectories before listing files."
+    "sortFolders": {
+      "type": "string",
+      "default": "Before Files",
+      "description": "When listing directory items, where subdirectories will be listed.",
+      "enum": [
+        "Before Files",
+        "After Files",
+        "Alongside Files"
+      ]
     },
     "autoReveal": {
       "type": "boolean",

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2549,7 +2549,7 @@ describe "TreeView", ->
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
-          
+
         it "focuses the first selected entry's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
 
@@ -3131,7 +3131,7 @@ describe "TreeView", ->
               expect(treeView.list).toHaveClass('full-menu')
               expect(treeView.list).not.toHaveClass('multi-select')
 
-  describe "the sortFoldersBeforeFiles config option", ->
+  describe "the sortFolders config option", ->
     [dirView, fileView, dirView2, fileView2, fileView3, rootDirPath, dirPath, filePath, dirPath2, filePath2, filePath3] = []
 
     beforeEach ->
@@ -3164,11 +3164,11 @@ describe "TreeView", ->
       atom.project.setPaths([rootDirPath])
 
 
-    it "defaults to set", ->
-      expect(atom.config.get("tree-view.sortFoldersBeforeFiles")).toBeTruthy()
+    it "defaults to Before Files", ->
+      expect(atom.config.get("tree-view.sortFolders")).toBe("Before Files")
 
-    it "lists folders first if the option is set", ->
-      atom.config.set "tree-view.sortFoldersBeforeFiles", true
+    it "lists folders first if the option is set to Before Files", ->
+      atom.config.set "tree-view.sortFolders", "Before Files"
 
       topLevelEntries = [].slice.call(treeView.roots[0].entries.children).map (element) ->
         element.innerText
@@ -3189,8 +3189,30 @@ describe "TreeView", ->
 
       expect(gammaEntries).toEqual(["theta", "delta.txt", "epsilon.txt"])
 
-    it "sorts folders as files if the option is not set", ->
-      atom.config.set "tree-view.sortFoldersBeforeFiles", false
+    it "lists folders last if the option is set to After Files", ->
+      atom.config.set "tree-view.sortFolders", "After Files"
+
+      topLevelEntries = [].slice.call(treeView.roots[0].entries.children).map (element) ->
+        element.innerText
+
+      expect(topLevelEntries).toEqual(["alpha.txt", "zeta.txt", "alpha", "gamma"])
+
+      alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+      alphaDir.expand()
+      alphaEntries = [].slice.call(alphaDir.children[1].children).map (element) ->
+        element.innerText
+
+      expect(alphaEntries).toEqual(["beta.txt", "eta"])
+
+      gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+      gammaDir.expand()
+      gammaEntries = [].slice.call(gammaDir.children[1].children).map (element) ->
+        element.innerText
+
+      expect(gammaEntries).toEqual(["delta.txt", "epsilon.txt", "theta"])
+
+    it "sorts folders as files if the option is set to Alongside Files", ->
+      atom.config.set "tree-view.sortFolders", "Alongside Files"
 
       topLevelEntries = [].slice.call(treeView.roots[0].entries.children).map (element) ->
         element.innerText


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

These changes make it possible to sort all files before all folders in the tree view. Previously, it was only possible to sort folders before files or mix folders with files. Migration code has been added so that users who have set the old sortFoldersBeforeFiles option will see their preferences reflected in the sortFolders option after updating.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

A dual checkbox design was considered that wouldn't have changed the sortFoldersBeforeFiles option, but a dropdown was used instead for simplicity.

### Benefits

<!-- What benefits will be realized by the code change? -->
Easier for some users to find their files in a sea of folders.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None.

### Applicable Issues

<!-- Enter any applicable Issues here -->
 This additional option was requested in issue #1066.
