### PR TITLE
Toggle drag and drop with env variable

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -55,7 +55,7 @@ class DirectoryView
       @element.classList.add('project-root')
       @header.classList.add('project-root-header')
     else
-      @element.draggable = true
+      @element.draggable = (not process.env.atom_tree_view_disable_drag_drop)
       @subscriptions.add @directory.onDidStatusChange => @updateStatus()
       @updateStatus()
 

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -9,7 +9,7 @@ class FileView
 
     @element = document.createElement('li')
     @element.setAttribute('is', 'tree-view-file')
-    @element.draggable = true
+    @element.draggable = (not process.env.atom_tree_view_disable_drag_drop)
     @element.classList.add('file', 'entry', 'list-item')
 
     @fileName = document.createElement('span')


### PR DESCRIPTION
Minimal fix for #566 only using environment variable.
As suggested by @warren-bank in https://github.com/atom/tree-view/issues/566#issuecomment-319284053

### Description of the Change

Does the minimum needed change to make drag and drop disableable by optionally setting the environment variable `atom_tree_view_disable_drag_drop`.

- defaults to: true
- to disable globally, append to ~/.bashrc:
 `export atom_tree_view_disable_drag_drop='1'`

- to disable for a single run:
  `(export atom_tree_view_disable_drag_drop='1'; atom)` 

- to re-enable for a single run: 
 `(export atom_tree_view_disable_drag_drop=''; atom)`


### Alternate Designs

There have been other suggested fixes such as https://github.com/atom/tree-view/pull/623 and https://github.com/atom/tree-view/pull/748 that were closed as _wontfix_ because it added configuration.

### Benefits

- Makes users who do not want drag and drop, able to disable this without having to maintain their own fork.
- This fix does not add any visible settings; thus no clutter.
- It only changes two hardcoded `true`'s into `(not process.env.atom_tree_view_disable_drag_drop)` which also defaults to `true`; thus not adding measurably to cost of maintenance.

### Possible Drawbacks

None unless the user sets the `atom_tree_view_disable_drag_drop` variable.

### Applicable Issues
Some related issues: https://github.com/atom/tree-view/issues/566 https://github.com/atom/tree-view/issues/996 https://github.com/atom/tree-view/issues/919
