### PR TITLE
Fix flaky tests re: adding new file

### DIFF
--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1814,6 +1814,7 @@ describe "TreeView", ->
 
               waitsFor "tree view selection to be updated", ->
                 treeView.element.querySelector('.file.selected')
+
               runs ->
                 expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)
                 expect(callback).toHaveBeenCalledWith({path: newPath})

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1837,11 +1837,14 @@ describe "TreeView", ->
                 expect(atom.workspace.getModalPanels().length).toBe 0
                 expect(atom.workspace.getCenter().getActivePaneItem().getPath()).toBe newPath
 
-              waitsFor "tree view to be updated", ->
+              waitsFor "file to be added to tree view", ->
                 dirView3.entries.querySelectorAll(".file").length > 1
 
+              waitsFor "tree view selection to be updated", ->
+                treeView.element.querySelector('.file.selected') isnt null
+
               runs ->
-                expect(treeView.element.querySelector('.file.selected').textContent).toBe path.basename(newPath)
+                expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)
                 expect(callback).toHaveBeenCalledWith({path: newPath})
 
           describe "when a file already exists at that location", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1809,9 +1809,11 @@ describe "TreeView", ->
                 expect(atom.workspace.getModalPanels().length).toBe 0
                 expect(atom.workspace.getCenter().getActivePaneItem().getPath()).toBe newPath
 
-              waitsFor "tree view to be updated", ->
+              waitsFor "file to be added to tree view", ->
                 dirView.entries.querySelectorAll(".file").length > 1
 
+              waitsFor "tree view selection to be updated", ->
+                treeView.element.querySelector('.file.selected')
               runs ->
                 expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)
                 expect(callback).toHaveBeenCalledWith({path: newPath})

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1813,7 +1813,7 @@ describe "TreeView", ->
                 dirView.entries.querySelectorAll(".file").length > 1
 
               waitsFor "tree view selection to be updated", ->
-                treeView.element.querySelector('.file.selected')
+                treeView.element.querySelector('.file.selected') isnt null
 
               runs ->
                 expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(newPath)


### PR DESCRIPTION
Fixes https://github.com/atom/tree-view/issues/1155.

## TODO

- [x] Fix intermittent failure in "it adds a file, closes the dialog, selects the file in the tree-view, and emits an event" https://github.com/atom/tree-view/issues/1155#issue-247146435 

  Resolved in 55e1b25bc5315d60143859606523fd55cbef5f96. Please see the commit message for details.

- [x] Fix intermittent failure in "it adds file in any project path" https://github.com/atom/tree-view/issues/1155#issuecomment-319471558

  Resolved in 6bb70056fab19c0adae4aa627ec2dec6438cbaed. Please see the commit message for details.

