### PR TITLE
Project root does not need a rename operation.

### DIFF
--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -54,7 +54,6 @@
     {'label': 'New Folder', 'command': 'tree-view:add-folder'}
     {'type': 'separator'}
 
-    {'label': 'Rename', 'command': 'tree-view:move'}
     {'label': 'Duplicate', 'command': 'tree-view:duplicate'}
     {'label': 'Delete', 'command': 'tree-view:remove'}
     {'label': 'Copy', 'command': 'tree-view:copy'}

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -54,10 +54,7 @@
     {'label': 'New Folder', 'command': 'tree-view:add-folder'}
     {'type': 'separator'}
 
-    {'label': 'Duplicate', 'command': 'tree-view:duplicate'}
-    {'label': 'Delete', 'command': 'tree-view:remove'}
     {'label': 'Copy', 'command': 'tree-view:copy'}
-    {'label': 'Cut', 'command': 'tree-view:cut'}
     {'label': 'Paste', 'command': 'tree-view:paste'}
     {'type': 'separator'}
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Remove the `rename` operation in project root's context menu.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Maintain that operation, and when user right click on an entry, first find out whether the entry is project's root, if it is, disable the menuItem, make it gray.
This alternate design will increase the complexity of code. 

### Benefits

<!-- What benefits will be realized by the code change? -->

The context menu of tree-view become less confusing to users. User can only see what they can do. And I guess when calling the function of rename, there is no need to judge whether the entry is a root.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

If the config in the selector `'.tree-view .full-menu .project-root > .header'` is not only used for root entry, the other places depends on this config item will be affected.

### Applicable Issues

<!-- Enter any applicable Issues here -->
