### PR TITLE
Provide treeView service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ When the tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>,
 ![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)
 
 ## API
+This package provides a service that you can use in other Atom packages.
+To use it, include `tree-view` in the `consumedServices` section of your
+`package.json`:
+
+``` json
+{
+  "name": "my-package",
+  "consumedServices": {
+    "tree-view": {
+      "versions": {
+        "^1.0.0": "consumeTreeView"
+      }
+    }
+  }
+}
+```
+
+Then, in your package's main module, call methods on the service:
+
+``` coffee
+module.exports =
+  activate: -> # ...
+
+  consumeTreeView: (treeView) ->
+    selectedPaths = treeView.selectedPaths()
+    # Do something with the paths...
+```
+
+The `tree-view` API has two methods:
+* `selectedPaths()` - Returns the paths to the selected tree view entries.
+* `entryForPath(entryPath)` - Returns a tree view entry for the given path.
+
+## Customization
 The tree view displays icons next to files. These icons are customizable by
 installing a package that provides an `atom.file-icons` service.
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Tree View package
 [![OS X Build Status](https://travis-ci.org/atom/tree-view.svg?branch=master)](https://travis-ci.org/atom/tree-view)
-[![Windows Build Status](https://ci.appveyor.com/api/projects/status/com793ehi0hajrkd/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/tree-view/branch/master) [![Dependency Status](https://david-dm.org/atom/tree-view.svg)](https://david-dm.org/atom/tree-view)
-
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/com793ehi0hajrkd/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/tree-view/branch/master)
+[![Dependency Status](https://david-dm.org/atom/tree-view.svg)](https://david-dm.org/atom/tree-view)
 
 Explore and open files in the current project.
 
-Press <kbd>ctrl-\\</kbd> or <kbd>cmd-\\</kbd> to open/close the Tree view and <kbd>alt-\\</kbd> or <kbd>ctrl-0</kbd> to focus it.
+Press <kbd>ctrl-\\</kbd> or <kbd>cmd-\\</kbd> to open/close the tree view and
+<kbd>alt-\\</kbd> or <kbd>ctrl-0</kbd> to focus it.
 
-When the Tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>, <kbd>m</kbd>, or <kbd>delete</kbd> to add, move
-or delete files and folders.
+When the tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>,
+<kbd>m</kbd>, or <kbd>delete</kbd> to add, move or delete files and folders.
 
 ![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)
 
 ## API
-
-The Tree View displays icons next to files. These icons are customizable by installing a package that provides an `atom.file-icons` service.
+The tree view displays icons next to files. These icons are customizable by
+installing a package that provides an `atom.file-icons` service.
 
 The `atom.file-icons` service must provide the following methods:
-
-* `iconClassForPath(path)` - Returns a CSS class name to add to the file view
+* `iconClassForPath(path)` - Returns a CSS class name to add to the file view.

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -54,7 +54,7 @@ class TreeViewPackage {
 
   provideTreeView () {
     return {
-      getTreeViewInstance: () => this.getTreeViewInstance()
+      getSelectedPaths: () => this.getTreeViewInstance().selectedPaths()
     };
   }
 

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -52,6 +52,12 @@ class TreeViewPackage {
     )
   }
 
+  provideTreeView () {
+    return {
+      getTreeViewInstance: () => this.getTreeViewInstance()
+    };
+  }
+
   getTreeViewInstance (state = {}) {
     if (this.treeView == null) {
       this.treeView = new TreeView(state)

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -54,7 +54,8 @@ class TreeViewPackage {
 
   provideTreeView () {
     return {
-      getSelectedPaths: () => this.getTreeViewInstance().selectedPaths()
+      getSelectedPaths: () => this.getTreeViewInstance().selectedPaths(),
+      getEntry: (path) => this.getTreeViewInstance().entryForPath(path)
     };
   }
 

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -54,8 +54,8 @@ class TreeViewPackage {
 
   provideTreeView () {
     return {
-      getSelectedPaths: () => this.getTreeViewInstance().selectedPaths(),
-      getEntry: (path) => this.getTreeViewInstance().entryForPath(path)
+      selectedPaths: () => this.getTreeViewInstance().selectedPaths(),
+      entryForPath: (path) => this.getTreeViewInstance().entryForPath(path)
     };
   }
 

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -55,7 +55,7 @@ class TreeViewPackage {
   provideTreeView () {
     return {
       selectedPaths: () => this.getTreeViewInstance().selectedPaths(),
-      entryForPath: (path) => this.getTreeViewInstance().entryForPath(path)
+      entryForPath: (entryPath) => this.getTreeViewInstance().entryForPath(entryPath)
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
       }
     }
   },
+  "providedServices": {
+    "tree-view": {
+      "description": "Get treeView Instance",
+      "versions": {
+        "1.0.0": "provideTreeView"
+      }
+    }
+  },
   "configSchema": {
     "squashDirectoryNames": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "providedServices": {
     "tree-view": {
-      "description": "Get treeView Instance",
+      "description": "A tree-like view of directories and files",
       "versions": {
         "1.0.0": "provideTreeView"
       }

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3848,15 +3848,21 @@ describe "TreeView", ->
     files.find((file) -> file.fileName.textContent is text)
 
 describe "Service provider", ->
-  [provideTreeView] = []
+  [provideTreeView, treeView] = []
   beforeEach ->
     waitForPackageActivation()
 
     runs ->
       provideTreeView = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
+      treeView = atom.workspace.getLeftDock().getActivePaneItem()
 
   it "should provide selected paths", ->
     expect(provideTreeView.getSelectedPaths()).toEqual([atom.project.getPaths()[0]])
+
+  it "should provide entry for a path", ->
+    root = atom.project.getPaths()[0]
+    expect(provideTreeView.getEntry(root)).toEqual(treeView.roots[0])
+
 
 describe 'Icon class handling', ->
   it 'allows multiple classes to be passed', ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3857,11 +3857,11 @@ describe "Service provider", ->
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
 
   it "should provide selected paths", ->
-    expect(provideTreeView.getSelectedPaths()).toEqual([atom.project.getPaths()[0]])
+    expect(provideTreeView.selectedPaths()).toEqual([atom.project.getPaths()[0]])
 
   it "should provide entry for a path", ->
     root = atom.project.getPaths()[0]
-    expect(provideTreeView.getEntry(root)).toEqual(treeView.roots[0])
+    expect(provideTreeView.entryForPath(root)).toEqual(treeView.roots[0])
 
 
 describe 'Icon class handling', ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3856,10 +3856,10 @@ describe "Service provider", ->
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
       treeViewService = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
 
-  it "should provide selected paths", ->
+  it "provides the `selectedPaths` method which should return the selected paths in the Tree View", ->
     expect(treeViewService.selectedPaths()).toEqual([atom.project.getPaths()[0]])
 
-  it "should provide entry for a path", ->
+  it "provides the `entryForPath` method which should return the Tree View entry for a given path", ->
     root = atom.project.getPaths()[0]
     expect(treeViewService.entryForPath(root)).toEqual(treeView.roots[0])
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3848,20 +3848,20 @@ describe "TreeView", ->
     files.find((file) -> file.fileName.textContent is text)
 
 describe "Service provider", ->
-  [provideTreeView, treeView] = []
+  [treeView, treeViewService] = []
   beforeEach ->
     waitForPackageActivation()
 
     runs ->
-      provideTreeView = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
+      treeViewService = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
 
   it "should provide selected paths", ->
-    expect(provideTreeView.selectedPaths()).toEqual([atom.project.getPaths()[0]])
+    expect(treeViewService.selectedPaths()).toEqual([atom.project.getPaths()[0]])
 
   it "should provide entry for a path", ->
     root = atom.project.getPaths()[0]
-    expect(provideTreeView.entryForPath(root)).toEqual(treeView.roots[0])
+    expect(treeViewService.entryForPath(root)).toEqual(treeView.roots[0])
 
 
 describe 'Icon class handling', ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3847,6 +3847,18 @@ describe "TreeView", ->
     files = Array.from(element.querySelectorAll('.entries .file'))
     files.find((file) -> file.fileName.textContent is text)
 
+describe "Service provider", ->
+  [provideTreeView] = []
+  beforeEach ->
+    waitForPackageActivation()
+
+    runs ->
+      provideTreeView = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
+
+  it "should provide selected paths", ->
+    console.log()
+    expect(provideTreeView.getSelectedPaths()).toEqual([atom.project.getPaths()[0]])
+
 describe 'Icon class handling', ->
   it 'allows multiple classes to be passed', ->
     rootDirPath = fs.absolute(temp.mkdirSync('tree-view-root1'))

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3856,7 +3856,6 @@ describe "Service provider", ->
       provideTreeView = atom.packages.getActivePackage('tree-view').mainModule.provideTreeView()
 
   it "should provide selected paths", ->
-    console.log()
     expect(provideTreeView.getSelectedPaths()).toEqual([atom.project.getPaths()[0]])
 
 describe 'Icon class handling', ->


### PR DESCRIPTION
### Description of the Change

Provided a service that lets other packages consume the treeView instance.

At the moment any package that interacts with the tree-view package to get selected files or other information are doing so by getting the active package's `mainModule` or checking classes and data attributes on elements.

There is a standard way to get this information through the [Services API](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

We may want to change what actually get provided if there are unstable features in the tree-view module.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Other packages can interact with this package in a standard way.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#433 

<!-- Enter any applicable Issues here -->
