### PR TITLE
Improve tree-view:remove-project-folder logic

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -727,12 +727,13 @@ class TreeView
     dialog.attach()
 
   removeProjectFolder: (e) ->
+    # Remove the targeted project folder (generally this only happens through the context menu)
     pathToRemove = e.target.closest(".project-root > .header")?.querySelector(".name")?.dataset.path
-
-    # TODO: remove this conditional once the addition of Project::removePath
-    # is released.
-    if atom.project.removePath?
-      atom.project.removePath(pathToRemove) if pathToRemove?
+    # If an entry is selected, remove that entry's project folder
+    pathToRemove ?= @selectedEntry()?.closest(".project-root")?.querySelector(".header")?.querySelector(".name")?.dataset.path
+    # Finally, if only one project folder exists and nothing is selected, remove that folder
+    pathToRemove ?= @roots[0].querySelector(".header")?.querySelector(".name")?.dataset.path if @roots.length is 1
+    atom.project.removePath(pathToRemove) if pathToRemove?
 
   selectedEntry: ->
     @list.querySelector('.selected')

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1319,10 +1319,29 @@ describe "TreeView", ->
               expect(item.getPath()).toBe atom.project.getDirectories()[0].resolve(fileName)
 
   describe "removing a project folder", ->
-    it "removes the folder from the project", ->
-      rootHeader = treeView.roots[1].querySelector(".header")
-      atom.commands.dispatch(rootHeader, "tree-view:remove-project-folder")
-      expect(atom.project.getPaths()).toHaveLength(1)
+    describe "when the project folder is selected", ->
+      it "removes the folder from the project", ->
+        rootHeader = treeView.roots[1].querySelector(".header")
+        atom.commands.dispatch(rootHeader, "tree-view:remove-project-folder")
+        expect(atom.project.getPaths()).toEqual [path1]
+
+    describe "when an entry is selected", ->
+      it "removes the project folder containing the entry", ->
+        treeView.selectEntry(treeView.roots[1].querySelector(".entries").querySelector("li"))
+        atom.commands.dispatch(treeView.element, "tree-view:remove-project-folder")
+        expect(atom.project.getPaths()).toEqual [path1]
+
+    describe "when nothing is selected and there is only one project folder", ->
+      it "removes the project folder", ->
+        atom.project.removePath(path2)
+        atom.commands.dispatch(treeView.element, "tree-view:remove-project-folder")
+        expect(atom.project.getPaths()).toHaveLength 0
+
+    describe "when nothing is selected and there are multiple project folders", ->
+      it "does nothing", ->
+        treeView.deselect(treeView.getSelectedEntries())
+        atom.commands.dispatch(treeView.element, "tree-view:remove-project-folder")
+        expect(atom.project.getPaths()).toHaveLength 2
 
   describe "file modification", ->
     [dirView, dirView2, dirView3, fileView, fileView2, fileView3, fileView4] = []
@@ -2555,7 +2574,7 @@ describe "TreeView", ->
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
-          
+
         it "focuses the first selected entry's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, `tree-view:remove-project-folder` was only able to remove project folders if the event target was the project folder itself.  This generally only happened when the context menu was initiated on the project folder (i.e. right-clicking).  Other methods, such as keybindings or through the command palette, targeted the overarching Tree View element and so didn't work.

With this PR, the logic behind determining which project folder to remove has been improved.  When the event target is not the project folder, but there is a selected entry in the Tree View, the project folder containing the selected entry will be removed.  When nothing is selected, but only one project folder exists, then that project folder will be removed.

### Alternate Designs

None.

### Benefits

The `tree-view:remove-project-folder` command should now work in more cases, especially when not using context menus.

### Possible Drawbacks

I don't really see any with these changes.

### Applicable Issues

Fixes #665