### PR TITLE
Factor the root folder into account when revealing the active file

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -304,8 +304,7 @@ class TreeView
       @selectEntryForPath(activeFilePath)
 
   revealActiveFile: (focus) ->
-    if _.isEmpty(atom.project.getPaths())
-      return Promise.resolve()
+    return Promise.resolve() unless atom.project.getPaths().length
 
     @show(focus ? atom.config.get('tree-view.focusOnReveal')).then =>
       return unless activeFilePath = @getActivePath()
@@ -314,7 +313,10 @@ class TreeView
       return unless rootPath?
 
       activePathComponents = relativePath.split(path.sep)
-      currentPath = rootPath
+      # Add the root folder to the path components
+      activePathComponents.unshift(rootPath.substr(rootPath.lastIndexOf(path.sep) + 1))
+      # And remove it from the current path
+      currentPath = rootPath.substr(0, rootPath.lastIndexOf(path.sep))
       for pathComponent in activePathComponents
         currentPath += path.sep + pathComponent
         entry = @entryForPath(currentPath)

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -288,7 +288,7 @@ describe "TreeView", ->
           atom.config.set "tree-view.focusOnReveal", true
 
           waitsForPromise ->
-            atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+            atom.workspace.open(path.join(path1, 'dir1', 'file1'))
 
           waitsForPromise ->
             treeView.revealActiveFile()
@@ -299,7 +299,7 @@ describe "TreeView", ->
 
           waitsForPromise ->
             treeView.focus.reset()
-            atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+            atom.workspace.open(path.join(path2, 'dir3', 'file3'))
 
           waitsForPromise ->
             treeView.revealActiveFile()
@@ -313,7 +313,7 @@ describe "TreeView", ->
           atom.config.set "tree-view.focusOnReveal", false
 
           waitsForPromise ->
-            atom.workspace.open(path.join(atom.project.getPaths()[0], 'dir1', 'file1'))
+            atom.workspace.open(path.join(path1, 'dir1', 'file1'))
 
           waitsForPromise ->
             treeView.revealActiveFile()
@@ -324,7 +324,7 @@ describe "TreeView", ->
 
           waitsForPromise ->
             treeView.focus.reset()
-            atom.workspace.open(path.join(atom.project.getPaths()[1], 'dir3', 'file3'))
+            atom.workspace.open(path.join(path2, 'dir3', 'file3'))
 
           waitsForPromise ->
             treeView.revealActiveFile()
@@ -332,6 +332,24 @@ describe "TreeView", ->
           runs ->
             expect(treeView.element.parentElement).toBeTruthy()
             expect(treeView.focus).not.toHaveBeenCalled()
+
+      describe "if the file is located under collapsed folders", ->
+        it "expands all the folders and selects the file", ->
+          waitsForPromise ->
+            atom.workspace.open(path.join(path1, 'dir1', 'file1'))
+
+          runs ->
+            treeView.selectEntry(root1)
+            treeView.collapseDirectory(true) # Recursively collapse all directories
+
+          waitsForPromise ->
+            treeView.revealActiveFile()
+
+          runs ->
+            expect(treeView.entryForPath(path1).classList.contains('expanded')).toBe true
+            expect(treeView.entryForPath(path.join(path1, 'dir1')).classList.contains('expanded')).toBe true
+            expect(treeView.selectedEntry()).toBeTruthy()
+            expect(treeView.selectedEntry().getPath()).toBe path.join(path1, 'dir1', 'file1')
 
     describe "if the current file has no path", ->
       it "shows and focuses the tree view, but does not attempt to select a specific file", ->
@@ -2555,7 +2573,7 @@ describe "TreeView", ->
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
-          
+
         it "focuses the first selected entry's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, if the root folder was collapsed and the `tree-view:reveal-active-file` command was triggered, the function wouldn't attempt to explicitly expand the root folder, leading to an off-by-one error and the file not getting focused.  To fix this, some manual adjustment of the paths has been introduced.

### Alternate Designs

None.

### Benefits

`tree-view:reveal-active-file` will work correctly when the root folder is collapsed.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #188