### PR TITLE
Switch internal directory representation to use maps

### DIFF
--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -108,10 +108,12 @@ class DirectoryView
       view = new FileView(entry)
 
     subscription = @directory.onDidRemoveEntries (removedEntries) ->
-      for removedName, removedEntry of removedEntries when entry is removedEntry
+      removedEntries.forEach (removedEntry, removedName) ->
+        return unless entry is removedEntry
         view.element.remove()
         subscription.dispose()
-        break
+        # TODO: When this file is converted to JS, convert this forEach loop
+        # to a for...of loop and add a break here for performance
     @subscriptions.add(subscription)
 
     view

--- a/lib/directory-view.coffee
+++ b/lib/directory-view.coffee
@@ -108,12 +108,9 @@ class DirectoryView
       view = new FileView(entry)
 
     subscription = @directory.onDidRemoveEntries (removedEntries) ->
-      removedEntries.forEach (removedEntry, removedName) ->
-        return unless entry is removedEntry
+      if removedEntries.has(entry)
         view.element.remove()
         subscription.dispose()
-        # TODO: When this file is converted to JS, convert this forEach loop
-        # to a for...of loop and add a break here for performance
     @subscriptions.add(subscription)
 
     view

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -263,7 +263,8 @@ class Directory
       if @expansionState.entries.has(name)
         @expansionState.entries.delete(name)
 
-    @emitter.emit('did-remove-entries', removedEntries) if entriesRemoved
+    # Convert removedEntries to a Set containing only the entries for O(1) lookup
+    @emitter.emit('did-remove-entries', new Set(removedEntries.values())) if entriesRemoved
 
     if newEntries.length > 0
       @entries.set(entry.name, entry) for entry in newEntries

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -31,10 +31,14 @@ class Directory
     # of time has passed since @expansionState.entries
     # has been converted to a Map
     unless @expansionState.entries instanceof Map
-      temp = new Map()
-      for name, entry of @expansionState.entries
-        temp.set(name, entry)
-      @expansionState.entries = temp
+      convertEntriesToMap = (entries) ->
+        temp = new Map()
+        for name, entry of entries
+          entry.entries = convertEntriesToMap(entry.entries) if entry.entries?
+          temp.set(name, entry)
+        return temp
+
+      @expansionState.entries = convertEntriesToMap(@expansionState.entries)
 
     @expansionState.entries ?= new Map()
     @status = null

--- a/lib/directory.coffee
+++ b/lib/directory.coffee
@@ -26,6 +26,16 @@ class Directory
     @isRoot ?= false
     @expansionState ?= {}
     @expansionState.isExpanded ?= false
+
+    # TODO: This can be removed after a sufficient amount
+    # of time has passed since @expansionState.entries
+    # has been converted to a Map
+    unless @expansionState.entries instanceof Map
+      temp = new Map()
+      for name, entry of @expansionState.entries
+        temp.set(name, entry)
+      @expansionState.entries = temp
+
     @expansionState.entries ?= new Map()
     @status = null
     @entries = new Map()

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -31,13 +31,13 @@ describe "FileStats", ->
       temp.cleanup()
 
     it "passes stats to File instances", ->
-      stats = treeView.roots[0].directory.entries["file1.txt"].stats
+      stats = treeView.roots[0].directory.entries.get("file1.txt").stats
       expect(stats).toBeDefined()
       expect(stats.mtime).toBeDefined()
       expect(stats.size).toEqual(file1Data.length)
 
     it "passes stats to Directory instances", ->
-      stats = treeView.roots[0].directory.entries["subdir"].stats
+      stats = treeView.roots[0].directory.entries.get("subdir").stats
       expect(stats).toBeDefined()
       expect(stats.mtime).toBeDefined()
 
@@ -46,20 +46,20 @@ describe "FileStats", ->
 
     it "passes stats to File instances in subdirectories", ->
       treeView.element.querySelector(".entries > li").expand()
-      subdir = treeView.roots[0].directory.entries["subdir"]
-      stats = subdir.entries["file2.txt"].stats
+      subdir = treeView.roots[0].directory.entries.get("subdir")
+      stats = subdir.entries.get("file2.txt").stats
       expect(stats).toBeDefined()
       expect(stats.size).toEqual(file2Data.length)
 
     it "converts date-stats to timestamps", ->
-      stats = treeView.roots[0].directory.entries["file1.txt"].stats
+      stats = treeView.roots[0].directory.entries.get("file1.txt").stats
       stamp = stats.mtime
       expect(_.isDate stamp).toBe(false)
       expect(typeof stamp).toBe("number")
       expect(Number.isNaN stamp).toBe(false)
 
     it "accurately converts timestamps", ->
-      stats = treeView.roots[0].directory.entries["file1.txt"].stats
+      stats = treeView.roots[0].directory.entries.get("file1.txt").stats
       # Two minutes should be enough
       expect(Math.abs stats.mtime - timeStarted).toBeLessThan(120000)
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1844,7 +1844,7 @@ describe "TreeView", ->
 
         describe "when the parent directory of the selected file changes", ->
           it "still shows the active file as selected", ->
-            dirView.directory.emitter.emit 'did-remove-entries', {'deleted.txt': {}}
+            dirView.directory.emitter.emit 'did-remove-entries', new Map().set('deleted.txt', {})
             expect(treeView.element.querySelector('.selected').textContent).toBe path.basename(filePath)
 
         describe "when the path without a trailing '#{path.sep}' is changed and confirmed", ->
@@ -3336,25 +3336,23 @@ describe "TreeView", ->
       treeView.roots[0].expand()
       expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
         isExpanded: true
-        entries:
-          entries:
-            isExpanded: false
-            entries: {}
+        entries: new Map().set('entries',
+          isExpanded: false
+          entries: new Map())
 
       fs.removeSync(entriesPath)
       treeView.roots[0].reload()
       expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
         isExpanded: true
-        entries: {}
+        entries: new Map()
 
       fs.mkdirSync(path.join(projectPath, 'other'))
       treeView.roots[0].reload()
       expect(treeView.roots[0].directory.serializeExpansionState()).toEqual
         isExpanded: true
-        entries:
-          other:
-            isExpanded: false
-            entries: {}
+        entries: new Map().set('other',
+          isExpanded: false
+          entries: new Map())
 
   describe "Dragging and dropping files", ->
     deltaFilePath = null

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3822,6 +3822,14 @@ describe "TreeView", ->
         expect(atom.project.getPaths()).toEqual [alphaDirPath, thetaDirPath]
         expect(document.querySelector('.placeholder')).not.toExist()
 
+  describe "when there is a __proto__ entry present", ->
+    it "does not break anything", ->
+      # No assertions needed - multiple exceptions will be thrown if this test fails
+      projectPath = temp.mkdirSync('atom-project')
+      protoPath = path.join(projectPath, "__proto__")
+      fs.writeFileSync(protoPath, 'test')
+      atom.project.setPaths([projectPath])
+
   describe "directory expansion serialization", ->
     it "converts legacy expansion serialization Objects to Maps", ->
       # The conversion actually happens when a new Directory


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR switches the internal representations of directory entries to use `Map`s instead of `Object`s.  While they are very similar, there is one big disadvantage to using Objects - Objects have internal and inherited properties/keys.  Since setting object keys sets the key directly, this means that certain directory names can conflict and override the existing Object properties.  A notable example of this is `__proto__`.  Naming a directory `__proto__` causes Tree View to override the base Object prototype, which leads to Very Bad Things(tm).  Maps do not have this limitation.

### Alternate Designs

Switching to `Map` was the first thing I considered, and it worked.

### Benefits

The name of a directory should no longer render Atom unusable.

### Possible Drawbacks

This changes the output of `onDidRemoveEntries` from an Object to a Map.  I'm unaware if that's being used anywhere outside of Tree View.  In addition, the serialized expansion state has also changed from an Object to a Map, meaning that extra conversion code will need to be added for a smooth transition.

### Applicable Issues

Fixes #1079

/cc @Alhadis to make sure that this doesn't affect file-icons (in my testing it didn't)
/cc @Daniel15

TODO:
* [x] Specs
* [x] Serialization conversion
* [x] Make sure this doesn't break any packages