### PR TITLE
Fix scroll jerking

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -353,7 +353,7 @@ class TreeView
     if selectedEntry?
       if selectedEntry.classList.contains('directory')
         if @selectEntry(selectedEntry.entries.children[0])
-          @scrollToEntry(@selectedEntry())
+          @scrollToEntry(@selectedEntry(), false)
           return
 
       if nextEntry = @nextEntry(selectedEntry)
@@ -361,7 +361,7 @@ class TreeView
     else
       @selectEntry(@roots[0])
 
-    @scrollToEntry(@selectedEntry())
+    @scrollToEntry(@selectedEntry(), false)
 
   moveUp: (event) ->
     event.stopImmediatePropagation()
@@ -377,7 +377,7 @@ class TreeView
       entries = @list.querySelectorAll('.entry')
       @selectEntry(entries[entries.length - 1])
 
-    @scrollToEntry(@selectedEntry())
+    @scrollToEntry(@selectedEntry(), false)
 
   nextEntry: (entry) ->
     currentEntry = entry
@@ -767,9 +767,9 @@ class TreeView
     else
       @element.scrollTop + @element.offsetHeight
 
-  scrollToEntry: (entry) ->
+  scrollToEntry: (entry, center = true) ->
     element = if entry?.classList.contains('directory') then entry.header else entry
-    element?.scrollIntoViewIfNeeded(false) # false = just enough to make the item visible
+    element?.scrollIntoViewIfNeeded(center)
 
   scrollToBottom: ->
     if lastEntry = _.last(@list.querySelectorAll('.entry'))

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -769,7 +769,7 @@ class TreeView
 
   scrollToEntry: (entry) ->
     element = if entry?.classList.contains('directory') then entry.header else entry
-    element?.scrollIntoViewIfNeeded(true) # true = center around item if possible
+    element?.scrollIntoViewIfNeeded(false) # false = just enough to make the item visible
 
   scrollToBottom: ->
     if lastEntry = _.last(@list.querySelectorAll('.entry'))

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -767,7 +767,7 @@ class TreeView
     else
       @element.scrollTop + @element.offsetHeight
 
-  scrollToEntry: (entry, center = true) ->
+  scrollToEntry: (entry, center=true) ->
     element = if entry?.classList.contains('directory') then entry.header else entry
     element?.scrollIntoViewIfNeeded(center)
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -382,6 +382,12 @@ describe "TreeView", ->
           treeView.revealActiveFile()
         runs ->
           expect(treeView.scrollTop()).toBeGreaterThan 400
+          entries = treeView.element.querySelectorAll('.entry')
+          scrollTop = treeView.element.scrollTop
+          for i in [0...entries.length]
+            atom.commands.dispatch(treeView.element, 'core:move-up')
+            expect(treeView.element.scrollTop - scrollTop).toBeLessThan entries[i].clientHeight
+            scrollTop = treeView.element.scrollTop
 
         # Open file in the middle, should be centered in scroll
         waitsForPromise -> atom.workspace.open(path.join(rootDirPath, 'file-10.txt'))
@@ -2555,7 +2561,7 @@ describe "TreeView", ->
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
-          
+
         it "focuses the first selected entry's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
 


### PR DESCRIPTION
### Description of the Change

I originally reported the issue in #1165 and subsequently implemented the fix.

The scroll jerking is caused by centering around the item. We only want to scroll just enough to make the item visible, not center around it, otherwise keyboard navigation becomes awkward.

VS Code works this way using custom code in place of scrollIntoViewIfNeeded, because that is a Chrome only function. VS Code is based off of VS Team Services IDE which supports non-webkit browsers, such as Firefox, which don't have scrollIntoViewIfNeeded.

You could say that centering the scroll around the item leads to quicker keyboard navigation. I, however, do believe this is incorrect because if a keyboard user just wants to move the view a few items up it shouldn't move the whole view so much. It makes it easy to loose your place in the tree. That's the part that makes it awkward and probably why most GUI frameworks with tree/list widgets don't center the scroll with the keyboard navigation (I've tested Swing/Windows Forms/JavaFX).

### Alternate Designs

The only alternative I considered was making the center option a parameter of the scrollToEntry method. In a later commit (c39b672), I changed this PR to function this way.

### Benefits

Smoother and less awkward keyboard navigation of the tree-view.

### Possible Drawbacks

I have addressed the original concern that this would not be appropriate in all situations.

### Applicable Issues

#1165 is the original issue I filed.
