### PR TITLE
Drag multiple items in tree-view

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1025,14 +1025,17 @@ class TreeView
       dragImage.style.willChange = "transform"
 
       for target in @getSelectedEntries()
-        nameElement = target.querySelector(".name")
-        entryPath = nameElement.dataset.path
+        entryPath = target.querySelector(".name").dataset.path
         unless path.dirname(entryPath) in initialPaths
           initialPaths.push(entryPath)
-          newNameElement = nameElement.cloneNode(true)
-          for key, value of getStyleObject(nameElement)
-            newNameElement.style[key] = value
-          dragImage.append(newNameElement)
+          newElement = target.cloneNode(true)
+          if newElement.classList.contains("directory")
+            newElement.querySelector(".entries").remove()
+          for key, value of getStyleObject(target)
+            newElement.style[key] = value
+          newElement.style.paddingLeft = "1em"
+          newElement.style.paddingRight = "1em"
+          dragImage.append(newElement)
 
 
       document.body.appendChild(dragImage)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1058,7 +1058,8 @@ class TreeView
 
       if initialPaths
         # Drop event from Atom
-        for initialPath in initialPaths.split(',')
+        # iterate backwards so files in a dir are moved before the dir itself
+        for initialPath in initialPaths.split(',') by -1
           @moveEntry(initialPath, newDirectoryPath)
       else
         # Drop event from OS

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1014,11 +1014,10 @@ class TreeView
         entryPath = nameElement.dataset.path
         unless path.dirname(entryPath) in initialPaths
           initialPaths.push(entryPath)
-        entry.collapse() if entry instanceof DirectoryView
-        newNameElement = nameElement.cloneNode(true)
-        for key, value of getStyleObject(nameElement)
-          newNameElement.style[key] = value
-        dragImage.append(newNameElement)
+          newNameElement = nameElement.cloneNode(true)
+          for key, value of getStyleObject(nameElement)
+            newNameElement.style[key] = value
+          dragImage.append(newNameElement)
 
 
       document.body.appendChild(dragImage)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1066,22 +1066,26 @@ class TreeView
       e.preventDefault()
       e.stopPropagation()
 
-      entry.classList.remove('selected')
-
       return unless entry.classList.contains('directory')
 
       newDirectoryPath = entry.querySelector('.name')?.dataset.path
       return false unless newDirectoryPath
 
-      initialPaths = e.dataTransfer.getData("initialPaths")
+      initialPaths = e.dataTransfer.getData('initialPaths')
 
       if initialPaths
         # Drop event from Atom
+        initialPaths = initialPaths.split(',')
+        return if initialPaths.includes(newDirectoryPath)
+
+        entry.classList.remove('selected')
+
         # iterate backwards so files in a dir are moved before the dir itself
-        for initialPath in initialPaths.split(',') by -1
+        for initialPath in initialPaths by -1
           @moveEntry(initialPath, newDirectoryPath)
       else
         # Drop event from OS
+        entry.classList.remove('selected')
         for file in e.dataTransfer.files
           @moveEntry(file.path, newDirectoryPath)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1011,8 +1011,9 @@ class TreeView
 
       for target in @getSelectedEntries()
         nameElement = target.querySelector(".name")
-        initialPaths.push(nameElement.dataset.path)
-
+        entryPath = nameElement.dataset.path
+        unless path.dirname(entryPath) in initialPaths
+          initialPaths.push(entryPath)
         newNameElement = nameElement.cloneNode(true)
         for key, value of getStyleObject(nameElement)
           newNameElement.style[key] = value

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -925,8 +925,11 @@ class TreeView
 
   onMouseUp: (e) ->
     if @selectOnMouseUp
-      @selectEntry(entryToSelect)
-      @showFullMenu()
+      @selectOnMouseUp = false
+
+      if entryToSelect = e.target.closest('.entry')
+        @selectEntry(entryToSelect)
+        @showFullMenu()
 
   # Public: Return an array of paths from all selected items
   #

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1014,6 +1014,7 @@ class TreeView
         entryPath = nameElement.dataset.path
         unless path.dirname(entryPath) in initialPaths
           initialPaths.push(entryPath)
+        entry.collapse() if entry instanceof DirectoryView
         newNameElement = nameElement.cloneNode(true)
         for key, value of getStyleObject(nameElement)
           newNameElement.style[key] = value

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -970,6 +970,7 @@ class TreeView
   selectContinuousEntries: (entry, deselectOthers = true) ->
     currentSelectedEntry = @lastFocusedElement ? @selectedEntry()
     parentContainer = entry.parentElement
+    elements = []
     if parentContainer.contains(currentSelectedEntry)
       entries = Array.from(parentContainer.querySelectorAll('.entry'))
       entryIndex = entries.indexOf(entry)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1134,6 +1134,7 @@ class TreeView
 
         # iterate backwards so files in a dir are moved before the dir itself
         for initialPath in initialPaths by -1
+          @entryForPath(initialPath).collapse?()
           @moveEntry(initialPath, newDirectoryPath)
       else
         # Drop event from OS

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1069,11 +1069,13 @@ class TreeView
       # the drag image.
       dragImage.style.willChange = "transform"
 
+      initialPaths = []
       for target in @getSelectedEntries()
         entryPath = target.querySelector(".name").dataset.path
         parentSelected = target.parentNode.closest(".entry.selected")
         @dragPaths.push(entryPath)
         unless parentSelected
+          initialPaths.push(entryPath)
           newElement = target.cloneNode(true)
           if newElement.classList.contains("directory")
             newElement.querySelector(".entries").remove()
@@ -1088,7 +1090,7 @@ class TreeView
 
       e.dataTransfer.effectAllowed = "move"
       e.dataTransfer.setDragImage(dragImage, 0, 0)
-      e.dataTransfer.setData("initialPaths", @dragPaths)
+      e.dataTransfer.setData("initialPaths", initialPaths)
 
       window.requestAnimationFrame ->
         dragImage.remove()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1071,7 +1071,7 @@ class TreeView
 
       for target in @getSelectedEntries()
         entryPath = target.querySelector(".name").dataset.path
-        parentSelected = @dragPaths.some (path) -> entryPath.startsWith path
+        parentSelected = target.parentNode.closest(".entry.selected")
 
         if parentSelected
           @deselect [target]
@@ -1130,8 +1130,7 @@ class TreeView
         return if initialPaths.includes(newDirectoryPath)
 
         entry.classList.remove('selected')
-
-        parentSelected = initialPaths.some (path) -> newDirectoryPath.startsWith path
+        parentSelected = entry.parentNode.closest('.entry.selected')
         return if parentSelected
 
         # iterate backwards so files in a dir are moved before the dir itself

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1024,12 +1024,11 @@ class TreeView
     @list.classList.contains('multi-select')
 
   onDragEnter: (e) =>
-    if header = e.target.closest('.entry.directory > .header')
+    if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
 
       e.stopPropagation()
 
-      entry = header.parentNode
       @dragEventCounts.set(entry, 0) unless @dragEventCounts.get(entry)
       unless @dragEventCounts.get(entry) isnt 0 or entry.classList.contains('selected')
         entry.classList.add('drag-over', 'selected')
@@ -1037,12 +1036,11 @@ class TreeView
       @dragEventCounts.set(entry, @dragEventCounts.get(entry) + 1)
 
   onDragLeave: (e) =>
-    if header = e.target.closest('.entry.directory > .header')
+    if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
 
       e.stopPropagation()
 
-      entry = header.parentNode
       @dragEventCounts.set(entry, @dragEventCounts.get(entry) - 1)
       if @dragEventCounts.get(entry) is 0 and entry.classList.contains('drag-over')
         entry.classList.remove('drag-over', 'selected')
@@ -1094,7 +1092,7 @@ class TreeView
 
   # Handle entry dragover event; reset default dragover actions
   onDragOver: (e) ->
-    if entry = e.target.closest('.entry')
+    if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
 
       e.preventDefault()
@@ -1106,13 +1104,11 @@ class TreeView
   # Handle entry drop event
   onDrop: (e) ->
     @dragEventCounts = new WeakMap
-    if entry = e.target.closest('.entry')
+    if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
 
       e.preventDefault()
       e.stopPropagation()
-
-      return unless entry.classList.contains('directory')
 
       newDirectoryPath = entry.querySelector('.name')?.dataset.path
       return false unless newDirectoryPath

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -39,7 +39,7 @@ class TreeView
     @roots = []
     @selectedPath = null
     @selectOnMouseUp = null
-    @lastFocusedElement = null
+    @lastFocusedEntry = null
     @ignoredPatterns = []
     @useSyncFS = false
     @currentlyOpening = new Map
@@ -822,7 +822,7 @@ class TreeView
     return unless entry?
 
     @selectedPath = entry.getPath()
-    @lastFocusedElement = entry
+    @lastFocusedEntry = entry
 
     selectedEntries = @getSelectedEntries()
     if selectedEntries.length > 1 or selectedEntries[0] isnt entry
@@ -873,7 +873,7 @@ class TreeView
       return
 
     entryName = path.basename(initialPath)
-    newPath = "#{newDirectoryPath}#{path.sep}#{entryName}".replace(/\s+$/, '')
+    newPath = "#{newDirectoryPath}/#{entryName}".replace(/\s+$/, '')
 
     try
       @emitter.emit 'will-move-entry', {initialPath, newPath}
@@ -910,7 +910,6 @@ class TreeView
 
     # return early if clicking on a selected entry
     if entryToSelect.classList.contains('selected')
-
       # mouse right click or ctrl click as right click on darwin platforms
       if e.button is 2 or (e.ctrlKey and process.platform is 'darwin')
         return
@@ -921,18 +920,18 @@ class TreeView
         return
 
     if e.shiftKey and cmdKey
-      # select continuous from @lastFocusedElement but leave others
+      # select continuous from @lastFocusedEntry but leave others
       @selectContinuousEntries(entryToSelect, false)
-      @toggleMultiSelectMenu()
+      @showMultiSelectMenuIfNecessary()
     else if e.shiftKey
-      # select continuous from @lastFocusedElement and deselect rest
+      # select continuous from @lastFocusedEntry and deselect rest
       @selectContinuousEntries(entryToSelect)
-      @toggleMultiSelectMenu()
+      @showMultiSelectMenuIfNecessary()
     # only allow ctrl click for multi selection on non darwin systems
     else if cmdKey
       @selectMultipleEntries(entryToSelect)
-      @lastFocusedElement = entryToSelect
-      @toggleMultiSelectMenu()
+      @lastFocusedEntry = entryToSelect
+      @showMultiSelectMenuIfNecessary()
     else
       @selectEntry(entryToSelect)
       @showFullMenu()
@@ -948,18 +947,18 @@ class TreeView
     e.stopPropagation()
 
     if shiftKey and cmdKey
-      # select continuous from @lastFocusedElement but leave others
+      # select continuous from @lastFocusedEntry but leave others
       @selectContinuousEntries(entryToSelect, false)
-      @toggleMultiSelectMenu()
+      @showMultiSelectMenuIfNecessary()
     else if shiftKey
-      # select continuous from @lastFocusedElement and deselect rest
+      # select continuous from @lastFocusedEntry and deselect rest
       @selectContinuousEntries(entryToSelect)
-      @toggleMultiSelectMenu()
+      @showMultiSelectMenuIfNecessary()
     # only allow ctrl click for multi selection on non darwin systems
     else if cmdKey
       @deselect([entryToSelect])
-      @lastFocusedElement = entryToSelect
-      @toggleMultiSelectMenu()
+      @lastFocusedEntry = entryToSelect
+      @showMultiSelectMenuIfNecessary()
     else
       @selectEntry(entryToSelect)
       @showFullMenu()
@@ -977,7 +976,7 @@ class TreeView
   #
   # Returns array of selected elements
   selectContinuousEntries: (entry, deselectOthers = true) ->
-    currentSelectedEntry = @lastFocusedElement ? @selectedEntry()
+    currentSelectedEntry = @lastFocusedEntry ? @selectedEntry()
     parentContainer = entry.parentElement
     elements = []
     if parentContainer is currentSelectedEntry.parentElement
@@ -1011,7 +1010,7 @@ class TreeView
     @list.classList.remove('full-menu')
     @list.classList.add('multi-select')
 
-  toggleMultiSelectMenu: ->
+  showMultiSelectMenuIfNecessary: ->
     if @getSelectedEntries().length > 1
       @showMultiSelectMenu()
     else
@@ -1079,7 +1078,6 @@ class TreeView
           newElement.style.paddingLeft = "1em"
           newElement.style.paddingRight = "1em"
           dragImage.append(newElement)
-
 
       document.body.appendChild(dragImage)
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1072,11 +1072,8 @@ class TreeView
       for target in @getSelectedEntries()
         entryPath = target.querySelector(".name").dataset.path
         parentSelected = target.parentNode.closest(".entry.selected")
-
-        if parentSelected
-          @deselect [target]
-        else
-          @dragPaths.push(entryPath)
+        @dragPaths.push(entryPath)
+        unless parentSelected
           newElement = target.cloneNode(true)
           if newElement.classList.contains("directory")
             newElement.querySelector(".entries").remove()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -47,7 +47,6 @@ class TreeView
     @editorsToDestroy = []
 
     @dragEventCounts = new WeakMap
-    @dragPaths = []
     @rootDragAndDrop = new RootDragAndDrop(this)
 
     @handleEvents()
@@ -1032,7 +1031,9 @@ class TreeView
 
       entry = header.parentNode
       @dragEventCounts.set(entry, 0) unless @dragEventCounts.get(entry)
-      entry.classList.add('selected') if @dragEventCounts.get(entry) is 0
+      unless @dragEventCounts.get(entry) isnt 0 or entry.classList.contains('selected')
+        entry.classList.add('drag-over', 'selected')
+
       @dragEventCounts.set(entry, @dragEventCounts.get(entry) + 1)
 
   onDragLeave: (e) =>
@@ -1042,16 +1043,13 @@ class TreeView
       e.stopPropagation()
 
       entry = header.parentNode
-      directoryPath = entry.querySelector('.name')?.dataset.path
-      directorySelected = directoryPath? and @dragPaths.includes(directoryPath)
-
       @dragEventCounts.set(entry, @dragEventCounts.get(entry) - 1)
-      entry.classList.remove('selected') if @dragEventCounts.get(entry) is 0 and not directorySelected
+      if @dragEventCounts.get(entry) is 0 and entry.classList.contains('drag-over')
+        entry.classList.remove('drag-over', 'selected')
 
   # Handle entry name object dragstart event
   onDragStart: (e) ->
     @dragEventCounts = new WeakMap
-    @dragPaths = []
     @selectOnMouseUp = null
     if entry = e.target.closest('.entry')
       e.stopPropagation()
@@ -1073,7 +1071,6 @@ class TreeView
       for target in @getSelectedEntries()
         entryPath = target.querySelector(".name").dataset.path
         parentSelected = target.parentNode.closest(".entry.selected")
-        @dragPaths.push(entryPath)
         unless parentSelected
           initialPaths.push(entryPath)
           newElement = target.cloneNode(true)
@@ -1104,12 +1101,11 @@ class TreeView
       e.stopPropagation()
 
       if @dragEventCounts.get(entry) > 0 and not entry.classList.contains('selected')
-        entry.classList.add('selected')
+        entry.classList.add('drag-over', 'selected')
 
   # Handle entry drop event
   onDrop: (e) ->
     @dragEventCounts = new WeakMap
-    @dragPaths = []
     if entry = e.target.closest('.entry')
       return if @rootDragAndDrop.isDragging(e)
 
@@ -1128,7 +1124,7 @@ class TreeView
         initialPaths = initialPaths.split(',')
         return if initialPaths.includes(newDirectoryPath)
 
-        entry.classList.remove('selected')
+        entry.classList.remove('drag-over', 'selected')
         parentSelected = entry.parentNode.closest('.entry.selected')
         return if parentSelected
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1071,7 +1071,11 @@ class TreeView
 
       for target in @getSelectedEntries()
         entryPath = target.querySelector(".name").dataset.path
-        unless path.dirname(entryPath) in @dragPaths
+        parentSelected = @dragPaths.some (path) -> entryPath.startsWith path
+
+        if parentSelected
+          @deselect [target]
+        else
           @dragPaths.push(entryPath)
           newElement = target.cloneNode(true)
           if newElement.classList.contains("directory")
@@ -1126,6 +1130,9 @@ class TreeView
         return if initialPaths.includes(newDirectoryPath)
 
         entry.classList.remove('selected')
+
+        parentSelected = initialPaths.some (path) -> newDirectoryPath.startsWith path
+        return if parentSelected
 
         # iterate backwards so files in a dir are moved before the dir itself
         for initialPath in initialPaths by -1

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -981,7 +981,7 @@ class TreeView
     currentSelectedEntry = @lastFocusedElement ? @selectedEntry()
     parentContainer = entry.parentElement
     elements = []
-    if parentContainer.contains(currentSelectedEntry)
+    if parentContainer is currentSelectedEntry.parentElement
       entries = Array.from(parentContainer.querySelectorAll('.entry'))
       entryIndex = entries.indexOf(entry)
       selectedIndex = entries.indexOf(currentSelectedEntry)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1124,7 +1124,7 @@ class TreeView
 
         # iterate backwards so files in a dir are moved before the dir itself
         for initialPath in initialPaths by -1
-          @entryForPath(initialPath).collapse?()
+          @entryForPath(initialPath)?.collapse?()
           @moveEntry(initialPath, newDirectoryPath)
       else
         # Drop event from OS

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -104,8 +104,4 @@ module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelect
   Object.defineProperty(dragEndEvent, 'currentTarget', value: dragged)
   Object.defineProperty(dragEndEvent, 'dataTransfer', value: dataTransfer)
 
-<<<<<<< HEAD
   [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer, currentTargetSelector), dragEndEvent]
-=======
-  dropEvent
->>>>>>> refactor event helpers for multiple targets in drag

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -104,4 +104,8 @@ module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelect
   Object.defineProperty(dragEndEvent, 'currentTarget', value: dragged)
   Object.defineProperty(dragEndEvent, 'dataTransfer', value: dataTransfer)
 
+<<<<<<< HEAD
   [dragStartEvent, buildElementPositionalDragEvents(target, dataTransfer, currentTargetSelector), dragEndEvent]
+=======
+  dropEvent
+>>>>>>> refactor event helpers for multiple targets in drag

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -1,4 +1,4 @@
-module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
+module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, treeView) ->
   dataTransfer =
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
@@ -12,8 +12,9 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
       Object.keys(dataTransfer.data).map((key) -> {type: key})
   )
 
+  treeView.deselect()
   for entry in dragged
-    entry.classList.add('selected')
+    treeView.selectMultipleEntries(entry)
 
   dragStartEvent = new DragEvent('dragstart')
   Object.defineProperty(dragStartEvent, 'target', value: dragged[0])

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -12,9 +12,12 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget) ->
       Object.keys(dataTransfer.data).map((key) -> {type: key})
   )
 
+  for entry in dragged
+    entry.classList.add('selected')
+
   dragStartEvent = new DragEvent('dragstart')
-  Object.defineProperty(dragStartEvent, 'target', value: dragged)
-  Object.defineProperty(dragStartEvent, 'currentTarget', value: dragged)
+  Object.defineProperty(dragStartEvent, 'target', value: dragged[0])
+  Object.defineProperty(dragStartEvent, 'currentTarget', value: dragged[0])
   Object.defineProperty(dragStartEvent, 'dataTransfer', value: dataTransfer)
 
   dropEvent = new DragEvent('drop')

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3244,6 +3244,22 @@ describe "TreeView", ->
         fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
         expect(treeView.list).toHaveClass('full-menu')
 
+      describe 'selecting one of the selected items', ->
+        it 'maintains multi-select for dragging', ->
+          fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
+          fileView1.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+          expect(treeView.list).not.toHaveClass('full-menu')
+          expect(treeView.list).toHaveClass('multi-select')
+
+        it 'switches to full-menu on mouseup', ->
+          fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
+          fileView1.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+          fileView1.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}))
+          expect(treeView.list).toHaveClass('full-menu')
+          expect(treeView.list).not.toHaveClass('multi-select')
+
       describe 'using the shift key', ->
         it 'selects the items between the already selected item and the shift clicked item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3700,8 +3700,6 @@ describe "TreeView", ->
           gammaDir.expand()
           deltaFile = gammaDir.entries.children[1]
 
-          treeView.deselect()
-
           [dragStartEvent, dragEnterEvent, dropEvent] =
               eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir, treeView)
           console.log treeView.getSelectedEntries()
@@ -3775,9 +3773,6 @@ describe "TreeView", ->
       beforeEach ->
         waitForWorkspaceOpenEvent ->
           atom.workspace.open(thetaFilePath)
-
-        runs ->
-          treeView.deselect()
 
       it "should move the directory to the hovered directory", ->
         # Dragging thetaDir onto alphaDir

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3805,6 +3805,24 @@ describe "TreeView", ->
             expect(editors[0].getPath()).toBe thetaFilePath.replace('gamma', 'alpha')
             expect(editors[1].getPath()).toBe thetaFilePath2
 
+    describe "when dropping a DirectoryView and FileViews onto the same DirectoryView's header", ->
+      it "should not move the files and directory to the hovered directory", ->
+        # Dragging alpha.txt and alphaDir into alphaDir
+        alphaFile = treeView.roots[0].entries.children[2]
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
+
+        dragged = [alphaFile, alphaDir]
+
+        [dragStartEvent, dragEnterEvent, dropEvent] =
+            eventHelpers.buildInternalDragEvents(dragged, alphaDir.querySelector('.header'), alphaDir)
+
+        spyOn(treeView, 'moveEntry')
+
+        treeView.onDragStart(dragStartEvent)
+        treeView.onDrop(dropEvent)
+        expect(treeView.moveEntry).not.toHaveBeenCalled()
+
     describe "when dragging a file from the OS onto a DirectoryView's header", ->
       it "should move the file to the hovered directory", ->
         # Dragging delta.txt from OS file explorer onto alphaDir

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3215,7 +3215,7 @@ describe "TreeView", ->
           expect(treeView.element.querySelector('.directory.status-modified')).not.toExist()
 
   describe "selecting items", ->
-    [dirView, fileView1, fileView2, fileView3, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3] = []
+    [dirView, fileView1, fileView2, fileView3, fileView4, fileView5, treeView, rootDirPath, dirPath, filePath1, filePath2, filePath3, filePath4, filePath5] = []
 
     beforeEach ->
       rootDirPath = fs.absolute(temp.mkdirSync('tree-view'))
@@ -3224,17 +3224,21 @@ describe "TreeView", ->
       filePath1 = path.join(dirPath, "test-file1.txt")
       filePath2 = path.join(dirPath, "test-file2.txt")
       filePath3 = path.join(dirPath, "test-file3.txt")
+      filePath4 = path.join(dirPath, "test-file4.txt")
+      filePath5 = path.join(dirPath, "test-file5.txt")
 
       fs.makeTreeSync(dirPath)
       fs.writeFileSync(filePath1, "doesn't matter")
       fs.writeFileSync(filePath2, "doesn't matter")
       fs.writeFileSync(filePath3, "doesn't matter")
+      fs.writeFileSync(filePath4, "doesn't matter")
+      fs.writeFileSync(filePath5, "doesn't matter")
 
       atom.project.setPaths([rootDirPath])
 
       dirView = treeView.entryForPath(dirPath)
       dirView.expand()
-      [fileView1, fileView2, fileView3] = dirView.querySelectorAll('.file')
+      [fileView1, fileView2, fileView3, fileView4, fileView5] = dirView.querySelectorAll('.file')
 
     describe 'selecting multiple items', ->
       it 'switches the contextual menu to muli-select mode', ->
@@ -3273,8 +3277,29 @@ describe "TreeView", ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
           fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
           expect(fileView1).toHaveClass('selected')
-          expect(fileView3).toHaveClass('selected')
           expect(fileView2).not.toHaveClass('selected')
+          expect(fileView3).toHaveClass('selected')
+
+      describe 'using the metakey(cmd) key on already selected item', ->
+        it 'deselects just the cmd-clicked item', ->
+          fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+          fileView1.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+          fileView1.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, metaKey: true}))
+          expect(fileView1).not.toHaveClass('selected')
+          expect(fileView2).not.toHaveClass('selected')
+          expect(fileView3).toHaveClass('selected')
+
+      describe 'using the shift and metakey(cmd) keys', ->
+        it 'selects the items between the last cmd-clicked item and the clicked item', ->
+          fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
+          fileView5.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true, shiftKey: true}))
+          expect(fileView1).toHaveClass('selected')
+          expect(fileView2).not.toHaveClass('selected')
+          expect(fileView3).toHaveClass('selected')
+          expect(fileView4).toHaveClass('selected')
+          expect(fileView5).toHaveClass('selected')
 
       describe 'non-darwin platform', ->
         originalPlatform = process.platform

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3700,6 +3700,41 @@ describe "TreeView", ->
         runs ->
           expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
 
+    describe "when dropping a DirectoryView and FileViews onto a DirectoryView's header", ->
+      it "should move the files and directory to the hovered directory", ->
+        # Dragging alpha.txt and alphaDir into thetaDir
+        rootDir = $(treeView.roots[0])
+
+        alphaFile = rootDir[0].entries.children[2]
+        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
+        alphaDir[0].expand()
+
+        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
+        gammaDir[0].expand()
+        thetaDir = $(gammaDir[0].entries).find('.directory:contains(theta):first')
+
+        dragged = [alphaFile, alphaDir[0]]
+
+        [dragStartEvent, dragEnterEvent, dropEvent] =
+            eventHelpers.buildInternalDragEvents(dragged, thetaDir.find('.header')[0], thetaDir[0])
+
+        runs ->
+          treeView.onDragStart(dragStartEvent)
+          treeView.onDrop(dropEvent)
+          expect(thetaDir[0].children.length).toBe 2
+
+        waitsFor "directory view contents to refresh", ->
+          $(treeView.roots[0].entries).find('.directory:contains(theta):first .entry').length > 2
+
+        runs ->
+          thetaDir = $(gammaDir[0].entries).find('.directory:contains(theta):first')
+          thetaDir[0].expand()
+          expect(thetaDir.find('.entry').length).toBe 2
+          # alpha dir still has all its entries
+          alphaDir = $(thetaDir[0].entries).find('.directory:contains(alpha):first')
+          alphaDir[0].expand()
+          expect(alphaDir.find('.entry').length).toBe 2
+
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       beforeEach ->
         waitForWorkspaceOpenEvent ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3644,7 +3644,7 @@ describe "TreeView", ->
         deltaFile = gammaDir.entries.children[1]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'))
+            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), null, treeView)
         treeView.onDragStart(dragStartEvent)
         expect(deltaFile).toHaveClass('selected')
         treeView.onDragEnter(dragEnterEvent)
@@ -3669,7 +3669,7 @@ describe "TreeView", ->
         deltaFile = gammaDir.entries.children[1]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir)
+            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir, treeView)
 
         treeView.onDragStart(dragStartEvent)
         treeView.onDrop(dropEvent)
@@ -3703,7 +3703,7 @@ describe "TreeView", ->
           treeView.deselect()
 
           [dragStartEvent, dragEnterEvent, dropEvent] =
-              eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir)
+              eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir, treeView)
           console.log treeView.getSelectedEntries()
 
           treeView.onDragStart(dragStartEvent)
@@ -3725,7 +3725,7 @@ describe "TreeView", ->
         gammaFiles = [].slice.call(gammaDir.entries.children, 1, 3)
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(gammaFiles, alphaDir.querySelector('.header'), alphaDir)
+            eventHelpers.buildInternalDragEvents(gammaFiles, alphaDir.querySelector('.header'), alphaDir, treeView)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
@@ -3753,7 +3753,7 @@ describe "TreeView", ->
         dragged = [alphaFile, alphaDir]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(dragged, thetaDir.querySelector('.header'), thetaDir)
+            eventHelpers.buildInternalDragEvents(dragged, thetaDir.querySelector('.header'), thetaDir, treeView)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
@@ -3790,7 +3790,7 @@ describe "TreeView", ->
         thetaDir.expand()
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-          eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir)
+          eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir, treeView)
         treeView.onDragStart(dragStartEvent)
         treeView.onDrop(dropEvent)
         expect(alphaDir.children.length).toBe 2
@@ -3827,7 +3827,7 @@ describe "TreeView", ->
 
           runs ->
             [dragStartEvent, dragEnterEvent, dropEvent] =
-              eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir)
+              eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir, treeView)
             treeView.onDragStart(dragStartEvent)
             treeView.onDrop(dropEvent)
             expect(alphaDir.children.length).toBe 2
@@ -3846,7 +3846,7 @@ describe "TreeView", ->
         dragged = [alphaFile, alphaDir]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(dragged, alphaDir.querySelector('.header'), alphaDir)
+            eventHelpers.buildInternalDragEvents(dragged, alphaDir.querySelector('.header'), alphaDir, treeView)
 
         spyOn(treeView, 'moveEntry')
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3611,6 +3611,7 @@ describe "TreeView", ->
         [dragStartEvent, dragEnterEvent, dropEvent] =
             eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'))
         treeView.onDragStart(dragStartEvent)
+        expect(deltaFile).toHaveClass('selected')
         treeView.onDragEnter(dragEnterEvent)
         expect(alphaDir).toHaveClass('selected')
 
@@ -3674,6 +3675,30 @@ describe "TreeView", ->
           editors = atom.workspace.getTextEditors()
           expect(editors[0].getPath()).toBe deltaFilePath.replace('gamma', 'alpha')
           expect(editors[1].getPath()).toBe deltaFilePath2
+
+    describe "when dropping multiple FileViews onto a DirectoryView's header", ->
+      it "should move the files to the hovered directory", ->
+        # Dragging delta.txt onto alphaDir
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
+
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        gammaFiles = [].slice.call(gammaDir.entries.children, 1, 3)
+
+        [dragStartEvent, dragEnterEvent, dropEvent] =
+            eventHelpers.buildInternalDragEvents([gammaFiles], alphaDir.querySelector('.header'), alphaDir)
+
+        runs ->
+          treeView.onDragStart(dragStartEvent)
+          treeView.onDrop(dropEvent)
+          expect(alphaDir.children.length).toBe 2
+
+        waitsFor "directory view contents to refresh", ->
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+
+        runs ->
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
 
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       beforeEach ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3609,7 +3609,7 @@ describe "TreeView", ->
         deltaFile = gammaDir.entries.children[1]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'))
+            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'))
         treeView.onDragStart(dragStartEvent)
         expect(deltaFile).toHaveClass('selected')
         treeView.onDragEnter(dragEnterEvent)
@@ -3634,7 +3634,7 @@ describe "TreeView", ->
         deltaFile = gammaDir.entries.children[1]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'), alphaDir)
+            eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir)
 
         treeView.onDragStart(dragStartEvent)
         treeView.onDrop(dropEvent)
@@ -3687,12 +3687,12 @@ describe "TreeView", ->
         gammaFiles = [].slice.call(gammaDir.entries.children, 1, 3)
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents([gammaFiles], alphaDir.querySelector('.header'), alphaDir)
+            eventHelpers.buildInternalDragEvents(gammaFiles, alphaDir.querySelector('.header'), alphaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(alphaDir.children.length).toBe 2
+          expect(alphaDir.entries.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
           findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
@@ -3703,37 +3703,35 @@ describe "TreeView", ->
     describe "when dropping a DirectoryView and FileViews onto a DirectoryView's header", ->
       it "should move the files and directory to the hovered directory", ->
         # Dragging alpha.txt and alphaDir into thetaDir
-        rootDir = $(treeView.roots[0])
+        alphaFile = treeView.roots[0].entries.children[2]
+        alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
+        alphaDir.expand()
 
-        alphaFile = rootDir[0].entries.children[2]
-        alphaDir = $(treeView.roots[0].entries).find('.directory:contains(alpha):first')
-        alphaDir[0].expand()
+        gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
+        gammaDir.expand()
+        thetaDir = findDirectoryContainingText(treeView.roots[0], 'theta')
+        thetaDir.expand()
 
-        gammaDir = $(treeView.roots[0].entries).find('.directory:contains(gamma):first')
-        gammaDir[0].expand()
-        thetaDir = $(gammaDir[0].entries).find('.directory:contains(theta):first')
-
-        dragged = [alphaFile, alphaDir[0]]
+        dragged = [alphaFile, alphaDir]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-            eventHelpers.buildInternalDragEvents(dragged, thetaDir.find('.header')[0], thetaDir[0])
+            eventHelpers.buildInternalDragEvents(dragged, thetaDir.querySelector('.header'), thetaDir)
 
         runs ->
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
-          expect(thetaDir[0].children.length).toBe 2
+          expect(thetaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          $(treeView.roots[0].entries).find('.directory:contains(theta):first .entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'theta').querySelectorAll('.entry').length > 2
 
         runs ->
-          thetaDir = $(gammaDir[0].entries).find('.directory:contains(theta):first')
-          thetaDir[0].expand()
-          expect(thetaDir.find('.entry').length).toBe 2
+          thetaDir.expand()
+          expect(thetaDir.querySelectorAll('.entry').length).toBe 3
           # alpha dir still has all its entries
-          alphaDir = $(thetaDir[0].entries).find('.directory:contains(alpha):first')
-          alphaDir[0].expand()
-          expect(alphaDir.find('.entry').length).toBe 2
+          alphaDir = findDirectoryContainingText(thetaDir.entries, 'alpha')
+          alphaDir.expand()
+          expect(alphaDir.querySelectorAll('.entry').length).toBe 2
 
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       beforeEach ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3244,12 +3244,6 @@ describe "TreeView", ->
         fileView3.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
         expect(treeView.list).toHaveClass('full-menu')
 
-    describe 'selecting multiple items', ->
-      it 'switches the contextual menu to muli-select mode', ->
-        fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-        fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, shiftKey: true}))
-        expect(treeView.list).toHaveClass('multi-select')
-
       describe 'using the shift key', ->
         it 'selects the items between the already selected item and the shift clicked item', ->
           fileView1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3700,8 +3700,11 @@ describe "TreeView", ->
           gammaDir.expand()
           deltaFile = gammaDir.entries.children[1]
 
+          treeView.deselect()
+
           [dragStartEvent, dragEnterEvent, dropEvent] =
-              eventHelpers.buildInternalDragEvents(deltaFile, alphaDir.querySelector('.header'), alphaDir)
+              eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir)
+          console.log treeView.getSelectedEntries()
 
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)
@@ -3773,6 +3776,9 @@ describe "TreeView", ->
         waitForWorkspaceOpenEvent ->
           atom.workspace.open(thetaFilePath)
 
+        runs ->
+          treeView.deselect()
+
       it "should move the directory to the hovered directory", ->
         # Dragging thetaDir onto alphaDir
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
@@ -3784,7 +3790,7 @@ describe "TreeView", ->
         thetaDir.expand()
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
-          eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
+          eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir)
         treeView.onDragStart(dragStartEvent)
         treeView.onDrop(dropEvent)
         expect(alphaDir.children.length).toBe 2
@@ -3821,7 +3827,7 @@ describe "TreeView", ->
 
           runs ->
             [dragStartEvent, dragEnterEvent, dropEvent] =
-              eventHelpers.buildInternalDragEvents(thetaDir, alphaDir.querySelector('.header'), alphaDir)
+              eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir)
             treeView.onDragStart(dragStartEvent)
             treeView.onDrop(dropEvent)
             expect(alphaDir.children.length).toBe 2

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3735,7 +3735,6 @@ describe "TreeView", ->
 
           [dragStartEvent, dragEnterEvent, dropEvent] =
               eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir, treeView)
-          console.log treeView.getSelectedEntries()
 
           treeView.onDragStart(dragStartEvent)
           treeView.onDrop(dropEvent)


### PR DESCRIPTION
### Description of the Change

* Allow multiple items to be dragged to a folder. This is a rebase of #793 

![multi-drag screenshot](https://cloud.githubusercontent.com/assets/6645121/14222364/8df00814-f835-11e5-80b2-1184c6d454a1.gif)

* Allow multi-select to work like it is supposed to

![shift + ctrl + click screenshot](https://user-images.githubusercontent.com/97994/30246499-7440e930-95c1-11e7-9941-9e0a6de4301f.gif)


### Benefits

Multi-select will work like other file explorers

### Possible Drawbacks

none

### Applicable Issues

Fixes #232
Supersedes and closes https://github.com/atom/tree-view/pull/793
