### PR TITLE
Only destroy editors that are not modified

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -41,6 +41,7 @@ class TreeView
     @ignoredPatterns = []
     @useSyncFS = false
     @currentlyOpening = new Map
+    @editorsToDestroy = []
 
     @dragEventCounts = new WeakMap
     @rootDragAndDrop = new RootDragAndDrop(this)
@@ -73,10 +74,27 @@ class TreeView
     @disposables.add @onEntryMoved ({initialPath, newPath}) ->
       updateEditorsForPath(initialPath, newPath)
 
-    @disposables.add @onEntryDeleted ({path}) ->
+    @disposables.add @onWillDeleteEntry ({pathToDelete}) =>
+      if fs.isDirectorySync(pathToDelete)
+        pathToDelete += path.sep # Avoid destroying lib2's editors when lib was deleted
+        for editor in atom.workspace.getTextEditors()
+          if editor.getPath().startsWith(pathToDelete) and not editor.isModified()
+            @editorsToDestroy.push(editor.getPath())
+      else
+        for editor in atom.workspace.getTextEditors()
+          if editor.getPath() is pathToDelete and not editor.isModified()
+            @editorsToDestroy.push(pathToDelete)
+
+    @disposables.add @onEntryDeleted ({pathToDelete}) =>
       for editor in atom.workspace.getTextEditors()
-        if editor?.getPath()?.startsWith(path)
+        index = @editorsToDestroy.indexOf(editor.getPath())
+        if index isnt -1
           editor.destroy()
+          @editorsToDestroy.splice(index, 1)
+
+    @disposables.add @onDeleteEntryFailed ({pathToDelete}) =>
+      index = @editorsToDestroy.indexOf(pathToDelete)
+      @editorsToDestroy.splice(index, 1) if index isnt -1
 
   serialize: ->
     directoryExpansionStates: new ((roots) ->
@@ -123,8 +141,14 @@ class TreeView
   onEntryCopied: (callback) ->
     @emitter.on('entry-copied', callback)
 
+  onWillDeleteEntry: (callback) ->
+    @emitter.on('will-delete-entry', callback)
+
   onEntryDeleted: (callback) ->
     @emitter.on('entry-deleted', callback)
+
+  onDeleteEntryFailed: (callback) ->
+    @emitter.on('delete-entry-failed', callback)
 
   onEntryMoved: (callback) ->
     @emitter.on('entry-moved', callback)
@@ -599,10 +623,12 @@ class TreeView
             #   but the parent folder is deleted first
             continue unless fs.existsSync(selectedPath)
 
+            @emitter.emit 'will-delete-entry', {pathToDelete: selectedPath}
             if shell.moveItemToTrash(selectedPath)
-              @emitter.emit 'entry-deleted', {path: selectedPath}
+              @emitter.emit 'entry-deleted', {pathToDelete: selectedPath}
             else
-              failedDeletions.push "#{selectedPath}"
+              @emitter.emit 'delete-entry-failed', {pathToDelete: selectedPath}
+              failedDeletions.push selectedPath
 
             if repo = repoForPath(selectedPath)
               repo.getPathStatus(selectedPath)

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2502,8 +2502,7 @@ describe "TreeView", ->
         treeView.focus()
 
         spyOn(shell, 'moveItemToTrash').andReturn(false)
-        spyOn(atom, 'confirm').andCallFake (dialog) ->
-          dialog.buttons["Move to Trash"]()
+        spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
         atom.commands.dispatch(treeView.element, 'tree-view:remove')
 
@@ -2526,7 +2525,7 @@ describe "TreeView", ->
         expect(atom.notifications.getNotifications().length).toBe 0
 
       describe "when a directory is removed", ->
-        it "closes editors with files belonging to the removed folder", ->
+        it "closes editors with filepaths belonging to the removed folder", ->
           jasmine.attachToDOM(workspaceElement)
 
           waitForWorkspaceOpenEvent ->
@@ -2536,17 +2535,68 @@ describe "TreeView", ->
             atom.workspace.open(filePath3)
 
           runs ->
-            openFilePaths = atom.workspace.getTextEditors().map((e) -> e.getPath())
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
             expect(openFilePaths).toEqual([filePath2, filePath3])
             dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
             treeView.focus()
 
-            spyOn(atom, 'confirm').andCallFake (dialog) ->
-              dialog.buttons["Move to Trash"]()
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
             atom.commands.dispatch(treeView.element, 'tree-view:remove')
-            openFilePaths = (editor.getPath() for editor in atom.workspace.getTextEditors())
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
             expect(openFilePaths).toEqual([])
+
+        it "does not close modified editors with filepaths belonging to the removed folder", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath2)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath3)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2, filePath3])
+
+            atom.workspace.getActiveTextEditor().setText('MODIFIED')
+            dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath3])
+
+        it "does not close editors with filepaths belonging to a folder that starts with the removed folder", ->
+          dirPath20 = path.join(rootDirPath, 'test-dir20')
+          filePath20 = path.join(dirPath20, 'test-file20.txt')
+          fs.makeTreeSync(dirPath20)
+          fs.writeFileSync(filePath20, "doesn't matter 20")
+
+          jasmine.attachToDOM(workspaceElement)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath2)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath3)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath20)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2, filePath3, filePath20])
+            dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath20])
 
         it "focuses the directory's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
@@ -2554,8 +2604,7 @@ describe "TreeView", ->
           dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
           treeView.focus()
 
-          spyOn(atom, 'confirm').andCallFake (dialog) ->
-            dialog.buttons["Move to Trash"]()
+          spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(root1).toHaveClass('selected')
@@ -2568,17 +2617,56 @@ describe "TreeView", ->
             atom.workspace.open(filePath2)
 
           runs ->
-            openFilePaths = atom.workspace.getTextEditors().map((e) -> e.getPath())
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
             expect(openFilePaths).toEqual([filePath2])
             fileView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
             treeView.focus()
 
-            spyOn(atom, 'confirm').andCallFake (dialog) ->
-              dialog.buttons["Move to Trash"]()
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
             atom.commands.dispatch(treeView.element, 'tree-view:remove')
-            openFilePaths = (editor.getPath() for editor in atom.workspace.getTextEditors())
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
             expect(openFilePaths).toEqual([])
+
+        it "does not close editors that have been modified", ->
+          jasmine.attachToDOM(workspaceElement)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath2)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2])
+
+            atom.workspace.getActiveTextEditor().setText('MODIFIED')
+            fileView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2])
+
+        it "does not close editors with filepaths that begin with the removed file", ->
+          filePath2Copy = path.join(dirPath2, 'test-file2.txt0')
+          fs.writeFileSync(filePath2Copy, "doesn't matter 2 copy")
+          jasmine.attachToDOM(workspaceElement)
+
+          waitForWorkspaceOpenEvent ->
+            atom.workspace.open(filePath2Copy)
+
+          runs ->
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2Copy])
+            fileView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+            treeView.focus()
+
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
+
+            atom.commands.dispatch(treeView.element, 'tree-view:remove')
+            openFilePaths = atom.workspace.getTextEditors().map((editor) -> editor.getPath())
+            expect(openFilePaths).toEqual([filePath2Copy])
 
         it "focuses the file's parent folder", ->
           jasmine.attachToDOM(workspaceElement)
@@ -2587,8 +2675,7 @@ describe "TreeView", ->
           treeView.focus()
 
           runs ->
-            spyOn(atom, 'confirm').andCallFake (dialog) ->
-              dialog.buttons["Move to Trash"]()
+            spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
             atom.commands.dispatch(treeView.element, 'tree-view:remove')
             expect(dirView2).toHaveClass('selected')
@@ -2604,8 +2691,7 @@ describe "TreeView", ->
           dirView.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
           treeView.focus()
 
-          spyOn(atom, 'confirm').andCallFake (dialog) ->
-            dialog.buttons["Move to Trash"]()
+          spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(atom.notifications.getNotifications().length).toBe 0
@@ -2617,8 +2703,7 @@ describe "TreeView", ->
           fileView2.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, metaKey: true}))
           treeView.focus()
 
-          spyOn(atom, 'confirm').andCallFake (dialog) ->
-            dialog.buttons["Move to Trash"]()
+          spyOn(atom, 'confirm').andCallFake (dialog) -> dialog.buttons["Move to Trash"]()
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(root1).toHaveClass('selected')

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2987,7 +2987,7 @@ describe "TreeView", ->
           callback = jasmine.createSpy("onEntryDeleted")
           treeView.onEntryDeleted(callback)
 
-          deletedPath = treeView.selectedEntry().getPath()
+          pathToDelete = treeView.selectedEntry().getPath()
           expect(treeView.selectedEntry().getPath()).toContain(path.join('dir2', 'new2'))
           dirView = findDirectoryContainingText(treeView.roots[0], 'dir2')
           expect(dirView).not.toBeNull()
@@ -2996,7 +2996,7 @@ describe "TreeView", ->
             dialog.buttons["Move to Trash"]()
           atom.commands.dispatch(treeView.element, 'tree-view:remove')
           expect(dirView.directory.updateStatus).toHaveBeenCalled()
-          expect(callback).toHaveBeenCalledWith({path: deletedPath})
+          expect(callback).toHaveBeenCalledWith({pathToDelete})
 
     describe "on #darwin, when the project is a symbolic link to the repository root", ->
       beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR contains three bugfixes when deleting files through the Tree View.
1. Deleting a file would close its associated editor(s), even if there was unsaved content.
2. Deleting a path would cause other editors that _started with_ the deleted path to be destroyed.  For example, deleting `test` would destroy both `test` and `test1`'s editors.  The original intention was to destroy files under a deleted directory, but it was lacking appropriate checks to make sure that the deleted path was a) actually a directory, and b) that it wasn't inadvertently destroying a sibling folder's editors (e.g. deleting `lib/` would destroy editors under both `lib/` and `lib1/`).
3. The `entry-deleted` event passed its argument under the `path` variable, which I believe would override the global `path` require.  It and its companion events now pass the deleted path as `pathToDelete`.

### Alternate Designs

There probably are other alternate designs, but I don't see any.  I started at `editor.isModified()` and continued from there.

### Benefits

The primary benefit is that data loss no longer occurs when deleting files that have unsaved content.  The other benefit is some tightening of the editor-removal code.

### Possible Drawbacks

I had to add two new events: `onWillDeleteEntry` and `onDeleteEntryFailed`, as by the time `onEntryDeleted` is called `editor.isModified()` will always return true, due to its underlying file already having been deleted.

### Applicable Issues

Fixes #1051