### PR TITLE
Make 'Split <direction>' context menu option work with directories

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -463,12 +463,25 @@ class TreeView
     return unless selectedEntry?
 
     pane = atom.workspace.getCenter().getActivePane()
-    if pane and selectedEntry.classList.contains('file')
-      if atom.workspace.getCenter().getActivePaneItem()
-        split = pane.split orientation, side
-        atom.workspace.openURIInPane selectedEntry.getPath(), split
-      else
-        @openSelectedEntry yes
+    if pane
+      if selectedEntry.classList.contains('file')
+        if atom.workspace.getCenter().getActivePaneItem()
+          split = pane.split orientation, side
+          atom.workspace.openURIInPane selectedEntry.getPath(), split
+        else
+          @openSelectedEntry yes
+      else if selectedEntry.classList.contains('directory')
+        if atom.workspace.getCenter().getActivePaneItem()
+          split = pane.split orientation, side
+          selectedEntry.directory.entries.forEach((subEntry) ->
+            unless subEntry instanceof Directory
+              atom.workspace.openURIInPane subEntry.realPath, split
+          )
+        else
+          selectedEntry.directory.entries.forEach((subEntry) ->
+            unless subEntry instanceof Directory
+              atom.workspace.openURIInPane subEntry.realPath, pane
+          )
 
   openSelectedEntryRight: ->
     @openSelectedEntrySplit 'horizontal', 'after'

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -41,7 +41,7 @@
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
   ]
 
-  '.tree-view .full-menu [is="tree-view-file"]': [
+  '.tree-view .full-menu [is^="tree-view"]': [
     {'label': 'Split Up', 'command': 'tree-view:open-selected-entry-up'}
     {'label': 'Split Down', 'command': 'tree-view:open-selected-entry-down'}
     {'label': 'Split Left', 'command': 'tree-view:open-selected-entry-left'}


### PR DESCRIPTION
Note: No tests written yet

### Description of the Change

Currently, right clicking and selecting `Split <direction>` only works for single files; selecting `Split <direction>` on directories opens an empty pane, as explained in atom/atom#14201.

This PR makes the `Split <direction>` option open the contents of a directory in separate tabs within a single split pane instead. It does so by overriding the already existing context menu options `Split <direction>`([inherited from atom base](https://github.com/atom/atom/blob/d623a412435564955ab13474fa2bf9a4aaa22ec2/menus/linux.cson#L222-L230)), making it launch tree-view-specific commands.

### Benefits

The context menu items will get a `Split` functionality for directories that makes sense, without adding any new items to the menu.

The implemented functionality can be useful in many scenarios. Example use case: opening all tests in a directory in the same right pane at once.

### Possible Drawbacks
There is currently no warning when opening a directory containing many items.

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes #1189 
Fixes atom/atom#14201 (for tree-view only)