### PR TITLE
Do not rename similarly-named files when moving a folder

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -22,10 +22,3 @@ module.exports =
       fullExtension = extension + fullExtension
       filePath = path.basename(filePath, extension)
     fullExtension
-
-  updateEditorsForPath: (oldPath, newPath) ->
-    editors = atom.workspace.getTextEditors()
-    for editor in editors
-      filePath = editor.getPath()
-      if filePath?.startsWith(oldPath)
-        editor.getBuffer().setPath(filePath.replace(oldPath, newPath))

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -5,7 +5,7 @@ Dialog = require './dialog'
 
 module.exports =
 class MoveDialog extends Dialog
-  constructor: (@initialPath, {@onMove}) ->
+  constructor: (@initialPath, {@willMove, @onMove, @onMoveFailed}) ->
     if fs.isDirectorySync(@initialPath)
       prompt = 'Enter the new path for the directory.'
     else
@@ -34,6 +34,7 @@ class MoveDialog extends Dialog
 
     directoryPath = path.dirname(newPath)
     try
+      @willMove?(initialPath: @initialPath, newPath: newPath)
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
       @onMove?(initialPath: @initialPath, newPath: newPath)
@@ -43,6 +44,7 @@ class MoveDialog extends Dialog
       @close()
     catch error
       @showError("#{error.message}.")
+      @onMoveFailed?(initialPath: @initialPath, newPath: newPath)
 
   isNewPathValid: (newPath) ->
     try

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 {BufferedProcess, CompositeDisposable, Emitter} = require 'atom'
-{repoForPath, getStyleObject, getFullExtension, updateEditorsForPath} = require "./helpers"
+{repoForPath, getStyleObject, getFullExtension} = require "./helpers"
 fs = require 'fs-plus'
 
 AddDialog = require './add-dialog'
@@ -41,6 +41,7 @@ class TreeView
     @ignoredPatterns = []
     @useSyncFS = false
     @currentlyOpening = new Map
+    @editorsToMove = []
     @editorsToDestroy = []
 
     @dragEventCounts = new WeakMap
@@ -71,17 +72,41 @@ class TreeView
 
     @element.style.width = "#{state.width}px" if state.width > 0
 
-    @disposables.add @onEntryMoved ({initialPath, newPath}) ->
-      updateEditorsForPath(initialPath, newPath)
+    @disposables.add @onWillMoveEntry ({initialPath, newPath}) =>
+      editors = atom.workspace.getTextEditors()
+      if fs.isDirectorySync(initialPath)
+        initialPath += path.sep # Avoid moving lib2's editors when lib was moved
+        for editor in editors
+          filePath = editor.getPath()
+          if filePath?.startsWith(initialPath)
+            @editorsToMove.push(filePath)
+      else
+        for editor in editors
+          filePath = editor.getPath()
+          if filePath is initialPath
+            @editorsToMove.push(filePath)
+
+    @disposables.add @onEntryMoved ({initialPath, newPath}) =>
+      for editor in atom.workspace.getTextEditors()
+        filePath = editor.getPath()
+        index = @editorsToMove.indexOf(filePath)
+        if index isnt -1
+          editor.getBuffer().setPath(filePath.replace(initialPath, newPath))
+          @editorsToMove.splice(index, 1)
+
+    @disposables.add @onMoveEntryFailed ({initialPath, newPath}) =>
+      index = @editorsToMove.indexOf(initialPath)
+      @editorsToMove.splice(index, 1) if index isnt -1
 
     @disposables.add @onWillDeleteEntry ({pathToDelete}) =>
+      editors = atom.workspace.getTextEditors()
       if fs.isDirectorySync(pathToDelete)
         pathToDelete += path.sep # Avoid destroying lib2's editors when lib was deleted
-        for editor in atom.workspace.getTextEditors()
+        for editor in editors
           if editor.getPath().startsWith(pathToDelete) and not editor.isModified()
             @editorsToDestroy.push(editor.getPath())
       else
-        for editor in atom.workspace.getTextEditors()
+        for editor in editors
           if editor.getPath() is pathToDelete and not editor.isModified()
             @editorsToDestroy.push(pathToDelete)
 
@@ -150,8 +175,14 @@ class TreeView
   onDeleteEntryFailed: (callback) ->
     @emitter.on('delete-entry-failed', callback)
 
+  onWillMoveEntry: (callback) ->
+    @emitter.on('will-move-entry', callback)
+
   onEntryMoved: (callback) ->
     @emitter.on('entry-moved', callback)
+
+  onMoveEntryFailed: (callback) ->
+    @emitter.on('move-entry-failed', callback)
 
   onFileCreated: (callback) ->
     @emitter.on('file-created', callback)
@@ -500,8 +531,12 @@ class TreeView
 
     if oldPath
       dialog = new MoveDialog oldPath,
+        willMove: ({initialPath, newPath}) =>
+          @emitter.emit 'will-move-entry', {initialPath, newPath}
         onMove: ({initialPath, newPath}) =>
           @emitter.emit 'entry-moved', {initialPath, newPath}
+        onMoveFailed: ({initialPath, newPath}) =>
+          @emitter.emit 'move-entry-failed', {initialPath, newPath}
       dialog.attach()
 
   # Get the outline of a system call to the current platform's file manager.
@@ -733,9 +768,13 @@ class TreeView
           # Only move the target if the cut target doesn't exist and if the newPath
           # is not within the initial path
           unless fs.existsSync(newPath) or newPath.startsWith(initialPath)
-            catchAndShowFileErrors =>
+            try
+              @emitter.emit 'will-move-entry', {initialPath, newPath}
               fs.moveSync(initialPath, newPath)
               @emitter.emit 'entry-moved', {initialPath, newPath}
+            catch error
+              @emitter.emit 'move-entry-failed', {initialPath, newPath}
+              atom.notifications.addWarning("Unable to paste paths: #{initialPaths}", detail: error.message)
 
   add: (isCreatingFile) ->
     selectedEntry = @selectedEntry() ? @roots[0]
@@ -823,6 +862,7 @@ class TreeView
     newPath = "#{newDirectoryPath}/#{entryName}".replace(/\s+$/, '')
 
     try
+      @emitter.emit 'will-move-entry', {initialPath, newPath}
       fs.makeTreeSync(newDirectoryPath) unless fs.existsSync(newDirectoryPath)
       fs.moveSync(initialPath, newPath)
       @emitter.emit 'entry-moved', {initialPath, newPath}
@@ -832,6 +872,7 @@ class TreeView
         repo.getPathStatus(newPath)
 
     catch error
+      @emitter.emit 'move-entry-failed', {initialPath, newPath}
       atom.notifications.addWarning("Failed to move entry #{initialPath} to #{newDirectoryPath}", detail: error.message)
 
   onStylesheetsChanged: =>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is the same fix as item#2 in #1182, but for rename/move operations.  It adds two new events, `will-move-entry` and `move-entry-failed`, to keep track of whether or not a folder is being renamed and which editors to rename.

### Alternate Designs

None - this is mostly a redo of #1182.

### Benefits

Renames should no longer unexpectedly rename other files.

### Possible Drawbacks

Some of the code was duplicated.

### Applicable Issues

Fixes #1188

/cc @iolsen: as mentioned above, this is essentially the same as #1182, which you approved.