### PR TITLE
Fix exception when running tree-view:remove with an active file outside of the project

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -678,7 +678,8 @@ class TreeView
               dismissable: true
 
           # Focus the first parent folder
-          @selectEntry(selectedEntries[0].closest('.directory:not(.selected)'))
+          if firstSelectedEntry = selectedEntries[0]
+            @selectEntry(firstSelectedEntry.closest('.directory:not(.selected)'))
           @updateRoots() if atom.config.get('tree-view.squashDirectoryNames')
         "Cancel": null
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2577,6 +2577,22 @@ describe "TreeView", ->
           args = atom.confirm.mostRecentCall.args[0]
           expect(Object.keys(args.buttons)).toEqual ['Move to Trash', 'Cancel']
 
+      it "can delete an active path that isn't in the project", ->
+        spyOn(atom, 'confirm')
+
+        filePath = path.join(os.tmpdir(), 'non-project-file.txt')
+        fs.writeFileSync(filePath, 'test')
+
+        waitsForPromise ->
+          atom.workspace.open(filePath)
+
+        runs ->
+          atom.commands.dispatch(treeView.element, 'tree-view:remove')
+          args = atom.confirm.mostRecentCall.args[0]
+          args.buttons['Move to Trash']()
+
+          expect(fs.existsSync(filePath)).toBe(false)
+
       it "shows a notification on failure", ->
         jasmine.attachToDOM(workspaceElement)
         atom.notifications.clear()


### PR DESCRIPTION
Fixes #1194

This PR just adds a null guard and a regression test.