### PR TITLE
Add specs for element-icons service

### DIFF
--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,12 +1,14 @@
+# vim: ts=2
 DefaultFileIcons = require '../lib/default-file-icons'
 getIconServices = require '../lib/get-icon-services'
+{Disposable} = require 'atom'
 
 describe 'IconServices', ->
-  describe 'FileIcons', ->
-    afterEach ->
-      getIconServices().resetFileIcons()
-      getIconServices().resetElementIcons()
+  afterEach ->
+    getIconServices().resetFileIcons()
+    getIconServices().resetElementIcons()
 
+  describe 'FileIcons', ->
     it 'provides a default', ->
       expect(getIconServices().fileIcons).toBeDefined()
       expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
@@ -21,3 +23,23 @@ describe 'IconServices', ->
       getIconServices().setFileIcons service
       getIconServices().resetFileIcons()
       expect(getIconServices().fileIcons).toBe(DefaultFileIcons)
+
+  describe 'ElementIcons', ->
+    it 'does not provide a default', ->
+      expect(getIconServices().elementIcons).toBe(null)
+
+    it 'consumes the ElementIcons service', ->
+      service = ->
+      getIconServices().setElementIcons service
+      expect(getIconServices().elementIcons).toBe(service)
+
+    it 'does not call the FileIcons service when the ElementIcons service is provided', ->
+      elementIcons = ->
+        new Disposable ->
+      fileIcons =
+        iconClassForPath: ->
+      spyOn(fileIcons, 'iconClassForPath').andCallThrough()
+      getIconServices().setElementIcons elementIcons
+      getIconServices().setFileIcons fileIcons
+      getIconServices().updateFileIcon(file: {}, fileName: classList: add: ->)
+      expect(fileIcons.iconClassForPath).not.toHaveBeenCalled()

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,4 +1,3 @@
-# vim: ts=2
 DefaultFileIcons = require '../lib/default-file-icons'
 getIconServices = require '../lib/get-icon-services'
 {Disposable} = require 'atom'


### PR DESCRIPTION
[As requested](https://github.com/atom/tree-view/pull/1146#issuecomment-340806545) by @nathansobo while reviewing #1146.

I'm sorry this took longer than it should have. I made the mistake of doing The Right Thing™ by collating icon-related specs into a single test-file, but forgot how flaky the current specs are. 😢 So I bailed on that and swore an oath to destroy both Jasmine and CoffeeScript in a hellish inferno. One day.
