### PR TITLE
Don't open tree-view to auto-reveal files

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -12,7 +12,7 @@ class TreeViewPackage {
       'tree-view:show': () => this.getTreeViewInstance().show(),
       'tree-view:toggle': () => this.getTreeViewInstance().toggle(),
       'tree-view:toggle-focus': () => this.getTreeViewInstance().toggleFocus(),
-      'tree-view:reveal-active-file': () => this.getTreeViewInstance().revealActiveFile(),
+      'tree-view:reveal-active-file': () => this.getTreeViewInstance().revealActiveFile({show: true}),
       'tree-view:add-file': () => this.getTreeViewInstance().add(true),
       'tree-view:add-folder': () => this.getTreeViewInstance().add(false),
       'tree-view:duplicate': () => this.getTreeViewInstance().copySelectedEntry(),

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -236,7 +236,7 @@ class TreeView
 
     @disposables.add atom.workspace.getCenter().onDidChangeActivePaneItem =>
       @selectActiveFile()
-      @revealActiveFile(false) if atom.config.get('tree-view.autoReveal')
+      @revealActiveFile({show: false, focus: false}) if atom.config.get('tree-view.autoReveal')
     @disposables.add atom.project.onDidChangePaths =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>
@@ -359,10 +359,14 @@ class TreeView
     if activeFilePath = @getActivePath()
       @selectEntryForPath(activeFilePath)
 
-  revealActiveFile: (focus) ->
+  revealActiveFile: (options) ->
     return Promise.resolve() unless atom.project.getPaths().length
 
-    @show(focus ? atom.config.get('tree-view.focusOnReveal')).then =>
+    {show, focus} = options
+
+    focus ?= atom.config.get('tree-view.focusOnReveal')
+    promise = if show or focus then @show(focus) else Promise.resolve()
+    promise.then =>
       return unless activeFilePath = @getActivePath()
 
       [rootPath, relativePath] = atom.project.relativizePath(activeFilePath)

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -359,7 +359,7 @@ class TreeView
     if activeFilePath = @getActivePath()
       @selectEntryForPath(activeFilePath)
 
-  revealActiveFile: (options) ->
+  revealActiveFile: (options = {}) ->
     return Promise.resolve() unless atom.project.getPaths().length
 
     {show, focus} = options


### PR DESCRIPTION
This PR changes tree-view such that the dock is not expanded automatically when files are revealed due to the Auto Reveal option being checked.

The matrix of behavior for various states of **Auto Reveal** and **Focus On Reveal** settings is now:

|            Auto Reveal / Focus On Reveal ➡️  | **off**/**off** | **on**/**off** | **off**/**on** | **on**/**on** |
|-----------------------------------------|-----------------|----------------|----------------|---------------|
| *when changing pane items*               |                 |                |                |               |
| tree-view opens if closed                | ❌               | :x:             | :x:            | :x:            |
| active file is revealed                  | :x:              | :white_check_mark:             | :x:             | :white_check_mark:           |
| tree-view is focused                     | :x:              | :x:             | :x:             | :x:            |
| *when running Reval Active File command* |                 |                |                |               |
| tree-view opens if closed                | :white_check_mark:             | :white_check_mark:            | :white_check_mark:            | :white_check_mark:           |
| active file is revealed                  | :white_check_mark:             | :white_check_mark:            | :white_check_mark:            | :white_check_mark:           |
| tree-view is focused                     | :x:              | :x:             | :white_check_mark:            | :white_check_mark:           |

In short:

1. The tree-view will **only** be shown when running the Reveal Active File command
2. The tree-view will **only** be focused when the Reval Active File command is run **and** Focus On Reveal is on

Fixes https://github.com/atom/tree-view/issues/796
Closes https://github.com/atom/tree-view/pull/983