### PR TITLE
Add commands to non-active text editors

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -16,8 +16,8 @@ class TreeViewPackage {
       'tree-view:add-folder': () => this.getTreeViewInstance().add(false),
       'tree-view:duplicate': () => this.getTreeViewInstance().copySelectedEntry(),
       'tree-view:remove': () => this.getTreeViewInstance().removeSelectedEntries(),
-      'tree-view:rename': () => this.getTreeViewInstance().moveSelectedEntry(),
-      'tree-view:show-current-file-in-file-manager': () => this.getTreeViewInstance().showCurrentFileInFileManager()
+      'tree-view:rename': (event) => this.getTreeViewInstance().moveSelectedEntry(event),
+      'tree-view:show-current-file-in-file-manager': (event) => this.getTreeViewInstance().showSelectedEntryInFileManager(event)
     }))
 
     const treeView = this.getTreeViewInstance()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -225,7 +225,7 @@ class TreeView
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
      'tree-view:open-selected-entry-up': => @openSelectedEntryUp()
      'tree-view:open-selected-entry-down': => @openSelectedEntryDown()
-     'tree-view:move': (event) => @moveSelectedEntry(event)
+     'tree-view:move': => @moveSelectedEntry()
      'tree-view:copy': => @copySelectedEntries()
      'tree-view:cut': => @cutSelectedEntries()
      'tree-view:paste': => @pasteEntries()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -225,7 +225,7 @@ class TreeView
      'tree-view:open-selected-entry-left': => @openSelectedEntryLeft()
      'tree-view:open-selected-entry-up': => @openSelectedEntryUp()
      'tree-view:open-selected-entry-down': => @openSelectedEntryDown()
-     'tree-view:move': => @moveSelectedEntry()
+     'tree-view:move': (event) => @moveSelectedEntry(event)
      'tree-view:copy': => @copySelectedEntries()
      'tree-view:cut': => @cutSelectedEntries()
      'tree-view:paste': => @pasteEntries()
@@ -551,13 +551,14 @@ class TreeView
     if pane and selectedEntry.classList.contains('file')
       atom.workspace.openURIInPane selectedEntry.getPath(), pane
 
-  moveSelectedEntry: ->
+  moveSelectedEntry: (event) ->
     if @hasFocus()
       entry = @selectedEntry()
       return if not entry? or entry in @roots
       oldPath = entry.getPath()
     else
-      oldPath = @getActivePath()
+      oldPath = event.target.closest('.tab').querySelector('.title').getAttribute('data-path')
+      oldPath ?= @getActivePath()
 
     if oldPath
       dialog = new MoveDialog oldPath,
@@ -593,6 +594,20 @@ class TreeView
         return 'Explorer'
       else
         return 'File Manager'
+
+  showSelectedEntryInFileManager: (event) ->
+    if @hasFocus()
+      entry = @selectedEntry()
+      return unless entry?
+      entryPath = entry.getPath()
+    else
+      entryPath = event.target.closest('.tab').querySelector('.title').getAttribute('data-path')
+      entryPath ?= @getActivePath()
+      return unless entryPath?
+
+    isFile = fs.isFileSync(entryPath)
+    {command, args, label} = @fileManagerCommandForPath(entryPath, isFile)
+    @openInFileManager(command, args, label, isFile)
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -95,21 +95,21 @@
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 
-  'atom-pane[data-active-item-path] .tab.active': [
+  'atom-pane[data-active-item-path] .tab': [
     {'label': 'Rename', 'command': 'tree-view:rename'}
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
   ]
 
-  '.platform-darwin atom-pane[data-active-item-path] .tab.active': [
-    {'label': 'Reveal In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
+  '.platform-darwin atom-pane[data-active-item-path] .tab': [
+    {'label': 'Show In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  '.platform-win32 atom-pane[data-active-item-path] .tab.active': [
+  '.platform-win32 atom-pane[data-active-item-path] .tab': [
     {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  '.platform-linux atom-pane[data-active-item-path] .tab.active': [
-    {'label': 'Show in File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
+  '.platform-linux atom-pane[data-active-item-path] .tab': [
+    {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
   '.platform-darwin atom-text-editor:not([mini])': [

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2353,11 +2353,13 @@ describe "TreeView", ->
               expect(callback).not.toHaveBeenCalled()
 
     describe "tree-view:move", ->
+      beforeEach ->
+        jasmine.attachToDOM(workspaceElement)
+
       describe "when a file is selected", ->
         [moveDialog, callback] = []
 
         beforeEach ->
-          jasmine.attachToDOM(workspaceElement)
           callback = jasmine.createSpy("onEntryMoved")
           treeView.onEntryMoved(callback)
 
@@ -2518,8 +2520,6 @@ describe "TreeView", ->
         moveDialog = null
 
         beforeEach ->
-          jasmine.attachToDOM(workspaceElement)
-
           waitForWorkspaceOpenEvent ->
             atom.workspace.open(filePath)
 
@@ -3848,7 +3848,26 @@ describe "TreeView", ->
 
   describe "showSelectedEntryInFileManager()", ->
     beforeEach ->
-      spyOn(shell, 'showItemInFolder').andReturn(false)
+      atom.notifications.clear()
+      jasmine.attachToDOM(workspaceElement)
+
+    it "displays the standard error output when the process fails", ->
+      {BufferedProcess} = require 'atom'
+      spyOn(BufferedProcess.prototype, 'spawn').andCallFake ->
+        EventEmitter = require 'events'
+        fakeProcess = new EventEmitter()
+        fakeProcess.send = ->
+        fakeProcess.kill = ->
+        fakeProcess.stdout = new EventEmitter()
+        fakeProcess.stdout.setEncoding = ->
+        fakeProcess.stderr = new EventEmitter()
+        fakeProcess.stderr.setEncoding = ->
+        @process = fakeProcess
+        process.nextTick ->
+          fakeProcess.stderr.emit('data', 'bad process')
+          fakeProcess.stderr.emit('close')
+          fakeProcess.stdout.emit('close')
+          fakeProcess.emit('exit')
 
     it "does nothing if no entry is selected", ->
       treeView.deselect()

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3865,47 +3865,6 @@ describe "TreeView", ->
       expect(atom.notifications.getNotifications().length).toBe(1)
       expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Unable to show')
 
-  describe "showCurrentFileInFileManager()", ->
-    beforeEach ->
-      spyOn(shell, 'showItemInFolder').andReturn(false)
-
-    it "does nothing when no file is opened", ->
-      expect(atom.workspace.getCenter().getPaneItems().length).toBe(0)
-
-      treeView.showCurrentFileInFileManager()
-      expect(shell.showItemInFolder).not.toHaveBeenCalled()
-
-    it "does nothing when only an untitled tab is opened", ->
-      waitsForPromise ->
-        atom.workspace.open()
-
-      runs ->
-        workspaceElement.focus()
-        treeView.showCurrentFileInFileManager()
-        expect(shell.showItemInFolder).not.toHaveBeenCalled()
-
-    it "shows the current file in the OS's file manager", ->
-      filePath = path.join(os.tmpdir(), 'non-project-file.txt')
-      fs.writeFileSync(filePath, 'test')
-      waitsForPromise ->
-        atom.workspace.open(filePath)
-
-      runs ->
-        treeView.showCurrentFileInFileManager()
-        expect(shell.showItemInFolder).toHaveBeenCalled()
-
-    it "shows a notification if showing the file fails", ->
-      filePath = path.join(os.tmpdir(), 'non-project-file.txt')
-      fs.writeFileSync(filePath, 'test')
-      spyOn(fs, 'existsSync').andReturn(false)
-      waitsForPromise ->
-        atom.workspace.open(filePath)
-
-      runs ->
-        treeView.showCurrentFileInFileManager()
-        expect(atom.notifications.getNotifications().length).toBe(1)
-        expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Unable to show')
-
   describe "when reloading a directory with deletions and additions", ->
     it "does not throw an error (regression)", ->
       projectPath = temp.mkdirSync('atom-project')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add context menu commands to all tabs and use the resulting `event.element` property to figure out the path to execute the command on.  This makes right-clicking a better experience and is helpful for atom/atom#16192.

### Alternate Designs

None.

### Benefits

All tabs will have Rename and Show in <File Manager> commands.

### Possible Drawbacks

None.

### Applicable Issues

Fixes atom/atom#13617
Refs atom/atom#16191