### PR TITLE
Drop external folders onto the Tree View to create new project folders

### DIFF
--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -2,7 +2,8 @@ url = require 'url'
 
 {ipcRenderer, remote} = require 'electron'
 
-_ = require 'underscore-plus'
+# TODO: Support dragging external folders and using the drag-and-drop indicators for them
+# Currently they're handled in TreeView's drag listeners
 
 module.exports =
 class RootDragAndDropHandler
@@ -120,7 +121,6 @@ class RootDragAndDropHandler
 
     {dataTransfer} = e
 
-    # TODO: support dragging folders from the filesystem -- electron needs to add support first
     return unless @isAtomTreeViewEvent(e)
 
     fromWindowId = parseInt(dataTransfer.getData('from-window-id'))

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1056,6 +1056,9 @@ class TreeView
         # Drop event from OS
         for file in e.dataTransfer.files
           @moveEntry(file.path, newDirectoryPath)
+    else if e.dataTransfer.files.length
+      # Drop event from OS that isn't targeting a folder: add a new project folder
+      atom.project.addPath(entry.path) for entry in e.dataTransfer.files
 
   isVisible: ->
     @element.offsetWidth isnt 0 or @element.offsetHeight isnt 0


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Implements the popularly-requested feature #480.  Basically if no existing folder is selected the Tree View adds the entries in the data transfer event as new project folders.  There are a few rough edges with this implementation, such as but not limited to:
* Folders must be dropped to a blank section of the Tree View _after_ the last entry.  This means that if the Tree View scrolls you will be unable to create a project folder as the entries will get added to the last project.
  * I would like to add support to be able to create project folders when dropping them _between_ project folders, similar to how root drag-and-drop works currently.
* Cannot drag and drop folders onto the Tree View when no Tree View exists.

### Alternate Designs

No alternatives were considered.

### Benefits

External folders can now be dragged-and-dropped into the Tree View to be added as project folders.

### Possible Drawbacks

I don't believe there are any drawbacks with this other than the limitations addressed above.

### Applicable Issues

Fixes #480