### PR TITLE
Wait for treeViewOpenPromise to resolve before deactivating Tree View

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -35,8 +35,9 @@ class TreeViewPackage {
     }
   }
 
-  deactivate () {
+  async deactivate () {
     this.disposables.dispose()
+    await this.treeViewOpenPromise // Wait for Tree View to finish opening before destroying it
     if (this.treeView) this.treeView.destroy()
     this.treeView = null
   }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This ensures that the Tree View doesn't randomly pop up in a half-broken state after disabling the package.

### Alternate Designs

None.

### Benefits

An edge-case with deactivation will be fixed, and no longer will people wonder why a Tree View is still open even though they disabled the package.

### Possible Drawbacks

Deactivation will occasionally take longer if the open promise takes a long time to resolve.  Since this is async things shouldn't really matter.

### Applicable Issues

Fixes #1136