### PR TITLE
Lack of a shortcut to allow the renaming/moving of the current buffer

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -82,10 +82,9 @@
   'i': 'tree-view:toggle-vcs-ignored-files'
   'home': 'core:move-to-top'
   'end': 'core:move-to-bottom'
+  'alt-f2': 'tree-view:move'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'
   'escape': 'core:cancel'
-  
-'.atom-text-editor':
-'alt-f2': 'tree-view:move'
+

--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -82,8 +82,10 @@
   'i': 'tree-view:toggle-vcs-ignored-files'
   'home': 'core:move-to-top'
   'end': 'core:move-to-bottom'
-  'alt-f2': 'tree-view:move'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'
   'escape': 'core:cancel'
+  
+'atom-text-editor':
+'alt-f2': 'tree-view:move'

--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -87,5 +87,5 @@
   'enter': 'core:confirm'
   'escape': 'core:cancel'
   
-'atom-text-editor':
+'.atom-text-editor':
 'alt-f2': 'tree-view:move'

--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -82,6 +82,7 @@
   'i': 'tree-view:toggle-vcs-ignored-files'
   'home': 'core:move-to-top'
   'end': 'core:move-to-bottom'
+  'alt-f2': 'tree-view:move'
 
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'


### PR DESCRIPTION

### Description of the Change

To add this keybinding, a change was made to a CSON file located in the Atom/tree-view repository (tree-view/keymaps/tree-view.cson). This configuration file contains the keybindings related to the tree-view.

To fix the issue, we made the keybinding “alt - F2” trigger “tree-view:move” in the entire Atom text editor, instead of only in the tree-view package. 

### Alternate Designs

No alternate designs.

### Benefits

New shortcut that allows renaming/moving of the current buffer if the file is above the root folder.

### Possible Drawbacks

No drawbacks.

### Applicable Issues

[ #3212 ](https://github.com/atom/atom/issues/3212)
[ #549 ](https://github.com/atom/atom/issues/549)
