### PR TITLE
Use @atom/temp instead of node-temp

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
+  - ATOM_CHANNEL: dev
 
 install:
   - ps: Install-Product node 6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ environment:
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
-  - ATOM_CHANNEL: dev
 
 install:
   - ps: Install-Product node 6

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "fs-plus": "^3.0.0",
     "minimatch": "~0.3.0",
-    "nan": "2.7.0",
     "pathwatcher": "^8.0.0",
     "@atom/temp": "~0.8.4",
     "underscore-plus": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minimatch": "~0.3.0",
     "nan": "2.7.0",
     "pathwatcher": "^8.0.0",
-    "temp": "~0.8.1",
+    "@atom/temp": "~0.8.4",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -30,7 +30,8 @@ describe 'DefaultFileIcons', ->
       tempDir = temp.mkdirSync('atom-tree-view')
 
     afterEach ->
-      temp.cleanupSync()
+      try
+        temp.cleanupSync()
 
     it 'recognizes symlinks', ->
       filePath = path.join(tempDir, 'foo.bar')

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('temp').track()
+temp = require('@atom/temp').track()
 
 fileIcons = require '../lib/default-file-icons'
 

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -29,10 +29,6 @@ describe 'DefaultFileIcons', ->
     beforeEach ->
       tempDir = temp.mkdirSync('atom-tree-view')
 
-    afterEach ->
-      try
-        temp.cleanupSync()
-
     it 'recognizes symlinks', ->
       filePath = path.join(tempDir, 'foo.bar')
       linkPath = path.join(tempDir, 'link.bar')

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('temp').track()
+temp = require('@atom/temp').track()
 
 describe "FileStats", ->
   describe "provision of filesystem stats", ->

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -27,10 +27,6 @@ describe "FileStats", ->
       runs ->
         treeView = atom.workspace.getLeftDock().getActivePaneItem()
 
-    afterEach ->
-      try
-        temp.cleanupSync()
-
     it "passes stats to File instances", ->
       stats = treeView.roots[0].directory.entries.get("file1.txt").stats
       expect(stats).toBeDefined()

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -28,7 +28,8 @@ describe "FileStats", ->
         treeView = atom.workspace.getLeftDock().getActivePaneItem()
 
     afterEach ->
-      temp.cleanup()
+      try
+        temp.cleanupSync()
 
     it "passes stats to File instances", ->
       stats = treeView.roots[0].directory.entries.get("file1.txt").stats

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('temp').track()
+temp = require('@atom/temp').track()
 os = require 'os'
 {remote, shell} = require 'electron'
 Directory = require '../lib/directory'

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -64,8 +64,6 @@ describe "TreeView", ->
       expect(root1.directory.watchSubscription).toBeTruthy()
 
   afterEach ->
-    try
-      temp.cleanupSync()
     if treeViewOpenPromise = atom.packages.getActivePackage('tree-view')?.mainModule.treeViewOpenPromise
       waitsForPromise -> treeViewOpenPromise
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -64,7 +64,8 @@ describe "TreeView", ->
       expect(root1.directory.watchSubscription).toBeTruthy()
 
   afterEach ->
-    temp.cleanup()
+    try
+      temp.cleanupSync()
     if treeViewOpenPromise = atom.packages.getActivePackage('tree-view')?.mainModule.treeViewOpenPromise
       waitsForPromise -> treeViewOpenPromise
 


### PR DESCRIPTION
This change switches the use of the node-temp module to our
@atom/temp fork so that we can benefit from a newer rimraf
version that will resolve some recurring test failures on
AppVeyor.

Resolves #1203.
