### PR TITLE
[WIP] Use atom.watchPath instead of PathWatcher

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -1,8 +1,7 @@
 const path = require('path')
 const _ = require('underscore-plus')
-const {CompositeDisposable, Emitter} = require('atom')
+const {CompositeDisposable, Emitter, watchPath} = require('atom')
 const fs = require('fs-plus')
-const PathWatcher = require('pathwatcher')
 const File = require('./file')
 const {repoForPath} = require('./helpers')
 const realpathCache = {}
@@ -242,7 +241,7 @@ class Directory {
   // Public: Stop watching this directory for changes.
   unwatch() {
     if (this.watchSubscription != null) {
-      this.watchSubscription.close()
+      this.watchSubscription.dispose()
       this.watchSubscription = null
     }
 
@@ -253,18 +252,21 @@ class Directory {
   }
 
   // Public: Watch this directory for changes.
-  watch() {
+  async watch() {
     if (this.watchSubscription != null) return
     try {
-      this.watchSubscription = PathWatcher.watch(this.path, eventType => {
-        switch (eventType) {
-          case 'change':
-            this.reload()
-            break
-          case 'delete':
+      this.watchSubscription = await watchPath(this.path, {}, events => {
+        let reload = false
+        for (const event of events) {
+          if (event.action === 'deleted' && event.path === this.path) {
             this.destroy()
             break
+          } else {
+            reload = true
+          }
         }
+
+        if (reload) this.reload()
       })
     } catch (error) {}
   }

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const _ = require('underscore-plus')
-const {CompositeDisposable, Emitter, watchPath} = require('atom')
+const {CompositeDisposable, Emitter} = require('atom')
 const fs = require('fs-plus')
 const File = require('./file')
 const {repoForPath} = require('./helpers')
@@ -79,7 +79,6 @@ class Directory {
 
   destroy () {
     this.destroyed = true
-    this.unwatch()
     this.subscriptions.dispose()
     this.emitter.emit('did-destroy')
   }
@@ -239,39 +238,6 @@ class Directory {
     return false
   }
 
-  // Public: Stop watching this directory for changes.
-  unwatch () {
-    if (this.watchSubscription != null) {
-      this.watchSubscription.dispose()
-      this.watchSubscription = null
-    }
-
-    for (let [key, entry] of this.entries) {
-      entry.destroy()
-      this.entries.delete(key)
-    }
-  }
-
-  // Public: Watch this directory for changes.
-  async watch () {
-    if (this.watchSubscription != null) return
-    try {
-      this.watchSubscription = await watchPath(this.path, {}, events => {
-        let reload = false
-        for (const event of events) {
-          if (event.action === 'deleted' && event.path === this.path) {
-            this.destroy()
-            break
-          } else {
-            reload = true
-          }
-        }
-
-        if (reload) this.reload()
-      })
-    } catch (error) {}
-  }
-
   getEntries () {
     let names
     try {
@@ -399,20 +365,17 @@ class Directory {
     }
   }
 
-  // Public: Collapse this directory and stop watching it.
+  // Public: Collapse this directory
   collapse () {
     this.expansionState.isExpanded = false
     this.expansionState = this.serializeExpansionState()
-    this.unwatch()
     this.emitter.emit('did-collapse')
   }
 
-  // Public: Expand this directory, load its children, and start watching it for
-  // changes.
+  // Public: Expand this directory
   expand () {
     this.expansionState.isExpanded = true
     this.reload()
-    this.watch()
     this.emitter.emit('did-expand')
   }
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -374,7 +374,7 @@ class Directory {
   // Public: Expand this directory
   expand () {
     this.expansionState.isExpanded = true
-    this.reload()
+    // this.reload()
     this.emitter.emit('did-expand')
   }
 

--- a/lib/root-directory.js
+++ b/lib/root-directory.js
@@ -1,4 +1,4 @@
-const {watchPath} = require('atom')
+const {CompositeDisposable, watchPath} = require('atom')
 
 const _ = require('underscore-plus')
 const fs = require('fs-plus')
@@ -12,17 +12,44 @@ class RootDirectory extends Directory {
   constructor ({name, fullPath, symlink, expansionState, isRoot, ignoredNames, useSyncFS, stats}) {
     super({name, fullPath, symlink, expansionState, isRoot, ignoredNames, useSyncFS, stats})
 
+    this.directories = new Map()
+    this.files = new Map()
+
+    this.disposables = new CompositeDisposable()
+    this.disposables.add(this.onDidDeletePath(deletedPath => {
+      // todo
+    }))
+    this.disposables.add(this.onDidCreatePath(addedPath => {
+      // todo
+    }))
+    this.disposables.add(this.onDidRenamePath((newPath, oldPath) => {
+      // todo
+    }))
+
     this.loadEntries()
     this.watch()
   }
 
-  destroy () {
+  async destroy () {
     super.destroy()
-    this.unwatch()
+    await this.unwatch()
+    this.disposables.dispose()
   }
 
-  onDidAddEntry (callback) {
-    return this.emitter.on('did-add-entry', callback)
+  onDidDeletePath (callback) {
+    return this.emitter.on('did-delete-path', callback)
+  }
+
+  onDidRenamePath (callback) {
+    return this.emitter.on('did-rename-path', callback)
+  }
+
+  onDidCreatePath (callback) {
+    return this.emitter.on('did-create-path', callback)
+  }
+
+  onDidModifyPath (callback) {
+    return this.emitter.on('did-modify-path', callback)
   }
 
   loadEntries () {
@@ -63,10 +90,10 @@ class RootDirectory extends Directory {
               useSyncFS: this.useSyncFS,
               stats: statsFlat
             })
-            this.emitter.emit('did-add-entry', directory)
+            this.directories.set(fullPath, directory)
           } else if (stats.isFile()) {
             const file = new File({name, fullPath, symlink, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statsFlat})
-            this.emitter.emit('did-add-entry', file)
+            this.files.set(fullPath, file)
           }
         })
       }
@@ -80,27 +107,89 @@ class RootDirectory extends Directory {
     if (this.watchSubscription != null) return
     try {
       this.watchSubscription = await watchPath(this.path, {}, events => {
-        let reload = false
+        // let reload = false
         for (const event of events) {
           console.log(event)
-          if (event.action === 'deleted' && event.path === this.path) {
-            this.destroy()
-            break
-          } else {
-            reload = true
+          if (this.isPathIgnored(event.path)) continue
+          const relativePath = path.relative(this.path, event.path)
+          if (event.action === 'deleted') {
+            if (event.kind === 'file') {
+              this.files.get(relativePath).destroy()
+            } else if (event.kind === 'directory') {
+              this.directories.get(relativePath).destroy()
+            }
+            this.emitter.emit('did-delete-path', event.path)
+          } else if (event.action === 'renamed') {
+            // TODO: Will this be emitted if we move the file out of the root?
+            if (event.kind === 'file') {
+              this.files.set(relativePath, this.files.get(path.relative(this.path, event.oldPath)))
+            } else if (event.kind === 'directory') {
+              this.directories.set(relativePath, this.files.get(path.relative(this.path, event.oldPath)))
+            }
+            this.emitter.emit('did-rename-path', event.path, event.oldPath)
+          } else if (event.action === 'created') {
+            if (event.kind === 'file') {
+              fs.lstat(event.path, (err, stats) => {
+                if (err) return
+
+                const symlink = stats.isSymbolicLink()
+                if (symlink) {
+                  // TODO
+                  // stats = fs.statSyncNoException(fullPath)
+                }
+
+                const statsFlat = _.pick(stats, _.keys(stats))
+                for (let key of ['atime', 'birthtime', 'ctime', 'mtime']) {
+                  statsFlat[key] = statsFlat[key] && statsFlat[key].getTime()
+                }
+
+                const file = new File({name, fullPath: event.path, symlink, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statsFlat})
+                this.files.set(relativePath, file)
+              })
+            } else if (event.kind === 'directory') {
+              fs.lstat(event.path, (err, stats) => {
+                if (err) return
+
+                const symlink = stats.isSymbolicLink()
+                if (symlink) {
+                  // TODO
+                  // stats = fs.statSyncNoException(event.path)
+                }
+
+                const statsFlat = _.pick(stats, _.keys(stats))
+                for (let key of ['atime', 'birthtime', 'ctime', 'mtime']) {
+                  statsFlat[key] = statsFlat[key] && statsFlat[key].getTime()
+                }
+
+                const expansionState = this.expansionState.entries.get(name)
+                const directory = new Directory({
+                  name,
+                  fullPath: event.path,
+                  symlink,
+                  expansionState,
+                  ignoredNames: this.ignoredNames,
+                  useSyncFS: this.useSyncFS,
+                  stats: statsFlat
+                })
+                this.directories.set(relativePath, directory)
+              })
+            }
+            this.emitter.emit('did-create-path', event.path)
+          } else if (event.action === 'modified') {
+            this.emitter.emit('did-modify-path', event.path)
           }
         }
-
-        if (reload) this.reload()
       })
-    } catch (error) {}
+    } catch (error) {} // TODO
 
     this.reload()
   }
 
   // Public: Stop watching this project for changes.
-  unwatch () {
+  async unwatch () {
     if (this.watchSubscription != null) {
+      await this.watchSubscription
+      console.log(this.watchSubscription)
       this.watchSubscription.dispose()
       this.watchSubscription = null
     }

--- a/lib/root-directory.js
+++ b/lib/root-directory.js
@@ -4,6 +4,7 @@ const _ = require('underscore-plus')
 const fs = require('fs-plus')
 const path = require('path')
 
+const File = require('./file')
 const Directory = require('./directory')
 
 module.exports =
@@ -20,17 +21,18 @@ class RootDirectory extends Directory {
     this.unwatch()
   }
 
+  onDidAddEntry (callback) {
+    return this.emitter.on('did-add-entry', callback)
+  }
+
   loadEntries () {
-    fs.readdir(this.path, {}, (err, names) => {
+    fs.readdir(this.path, (err, names) => {
       if (err) {
         names = []
         atom.notifications.addWarning(`Could not read files in ${this.path}`, err.message)
       }
 
       names.sort(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'}).compare)
-
-      const files = []
-      const directories = []
 
       for (let name of names) {
         const fullPath = path.join(this.path, name)
@@ -51,35 +53,25 @@ class RootDirectory extends Directory {
           }
 
           if (stats.isDirectory()) {
-            if (this.entries.has(name)) {
-              // push a placeholder since this entry already exists but this helps
-              // track the insertion index for the created views
-              directories.push(name)
-            } else {
-              const expansionState = this.expansionState.entries.get(name)
-              directories.push(new Directory({
-                name,
-                fullPath,
-                symlink,
-                expansionState,
-                ignoredNames: this.ignoredNames,
-                useSyncFS: this.useSyncFS,
-                stats: statsFlat
-              }))
-            }
+            const expansionState = this.expansionState.entries.get(name)
+            const directory = new Directory({
+              name,
+              fullPath,
+              symlink,
+              expansionState,
+              ignoredNames: this.ignoredNames,
+              useSyncFS: this.useSyncFS,
+              stats: statsFlat
+            })
+            this.emitter.emit('did-add-entry', directory)
           } else if (stats.isFile()) {
-            if (this.entries.has(name)) {
-              // push a placeholder since this entry already exists but this helps
-              // track the insertion index for the created views
-              files.push(name)
-            } else {
-              files.push(new File({name, fullPath, symlink, realpathCache, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statFlat}))
-            }
+            const file = new File({name, fullPath, symlink, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statsFlat})
+            this.emitter.emit('did-add-entry', file)
           }
         })
       }
 
-      return this.sortEntries(directories.concat(files))
+      // return this.sortEntries(directories.concat(files))
     })
   }
 

--- a/lib/root-directory.js
+++ b/lib/root-directory.js
@@ -1,0 +1,121 @@
+const {watchPath} = require('atom')
+
+const _ = require('underscore-plus')
+const fs = require('fs-plus')
+const path = require('path')
+
+const Directory = require('./directory')
+
+module.exports =
+class RootDirectory extends Directory {
+  constructor ({name, fullPath, symlink, expansionState, isRoot, ignoredNames, useSyncFS, stats}) {
+    super({name, fullPath, symlink, expansionState, isRoot, ignoredNames, useSyncFS, stats})
+
+    this.loadEntries()
+    this.watch()
+  }
+
+  destroy () {
+    super.destroy()
+    this.unwatch()
+  }
+
+  loadEntries () {
+    fs.readdir(this.path, {}, (err, names) => {
+      if (err) {
+        names = []
+        atom.notifications.addWarning(`Could not read files in ${this.path}`, err.message)
+      }
+
+      names.sort(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'}).compare)
+
+      const files = []
+      const directories = []
+
+      for (let name of names) {
+        const fullPath = path.join(this.path, name)
+        if (this.isPathIgnored(fullPath)) continue
+
+        fs.lstat(fullPath, (err, stats) => {
+          if (err) return
+
+          const symlink = stats.isSymbolicLink()
+          if (symlink) {
+            // TODO
+            // stats = fs.statSyncNoException(fullPath)
+          }
+
+          const statsFlat = _.pick(stats, _.keys(stats))
+          for (let key of ['atime', 'birthtime', 'ctime', 'mtime']) {
+            statsFlat[key] = statsFlat[key] && statsFlat[key].getTime()
+          }
+
+          if (stats.isDirectory()) {
+            if (this.entries.has(name)) {
+              // push a placeholder since this entry already exists but this helps
+              // track the insertion index for the created views
+              directories.push(name)
+            } else {
+              const expansionState = this.expansionState.entries.get(name)
+              directories.push(new Directory({
+                name,
+                fullPath,
+                symlink,
+                expansionState,
+                ignoredNames: this.ignoredNames,
+                useSyncFS: this.useSyncFS,
+                stats: statsFlat
+              }))
+            }
+          } else if (stats.isFile()) {
+            if (this.entries.has(name)) {
+              // push a placeholder since this entry already exists but this helps
+              // track the insertion index for the created views
+              files.push(name)
+            } else {
+              files.push(new File({name, fullPath, symlink, realpathCache, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statFlat}))
+            }
+          }
+        })
+      }
+
+      return this.sortEntries(directories.concat(files))
+    })
+  }
+
+  // Public: Watch this project for changes.
+  async watch () {
+    if (this.watchSubscription != null) return
+    try {
+      this.watchSubscription = await watchPath(this.path, {}, events => {
+        let reload = false
+        for (const event of events) {
+          console.log(event)
+          if (event.action === 'deleted' && event.path === this.path) {
+            this.destroy()
+            break
+          } else {
+            reload = true
+          }
+        }
+
+        if (reload) this.reload()
+      })
+    } catch (error) {}
+
+    this.reload()
+  }
+
+  // Public: Stop watching this project for changes.
+  unwatch () {
+    if (this.watchSubscription != null) {
+      this.watchSubscription.dispose()
+      this.watchSubscription = null
+    }
+
+    for (let [key, entry] of this.entries) {
+      entry.destroy()
+      this.entries.delete(key)
+    }
+  }
+}

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -12,6 +12,7 @@ CopyDialog = require './copy-dialog'
 IgnoredNames = null # Defer requiring until actually needed
 
 Directory = require './directory'
+RootDirectory = require './root-directory'
 DirectoryView = require './directory-view'
 RootDragAndDrop = require './root-drag-and-drop'
 
@@ -328,7 +329,7 @@ class TreeView
       for key in ["atime", "birthtime", "ctime", "mtime"]
         stats[key] = stats[key].getTime()
 
-      directory = new Directory({
+      directory = new RootDirectory({
         name: path.basename(projectPath)
         fullPath: projectPath
         symlink: false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "fs-plus": "^3.0.0",
     "minimatch": "~0.3.0",
     "nan": "2.7.0",
-    "pathwatcher": "^8.0.0",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0"
   },

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -61,7 +61,12 @@ describe "TreeView", ->
       root2 = treeView.roots[1]
       sampleJs = files[0]
       sampleTxt = files[1]
-      expect(root1.directory.watchSubscription).toBeTruthy()
+
+      waitsFor ->
+        root1.directory.watchSubscription
+
+      runs ->
+        expect(root1.directory.watchSubscription).toBeTruthy()
 
   afterEach ->
     temp.cleanup()

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -556,15 +556,25 @@ describe "TreeView", ->
       grandchild = child.querySelector('li')
       grandchild.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
 
-      expect(root1.directory.watchSubscription).toBeTruthy()
-      expect(child.directory.watchSubscription).toBeTruthy()
-      expect(grandchild.directory.watchSubscription).toBeTruthy()
+      waitsFor ->
+        root1.directory.watchSubscription
 
-      root1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+      waitsFor ->
+        child.directory.watchSubscription
 
-      expect(root1.directory.watchSubscription).toBeFalsy()
-      expect(child.directory.watchSubscription).toBeFalsy()
-      expect(grandchild.directory.watchSubscription).toBeFalsy()
+      waitsFor ->
+        grandchild.directory.watchSubscription
+
+      runs ->
+        expect(root1.directory.watchSubscription).toBeTruthy()
+        expect(child.directory.watchSubscription).toBeTruthy()
+        expect(grandchild.directory.watchSubscription).toBeTruthy()
+
+        root1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+        expect(root1.directory.watchSubscription).toBeFalsy()
+        expect(child.directory.watchSubscription).toBeFalsy()
+        expect(grandchild.directory.watchSubscription).toBeFalsy()
 
   describe "when mouse down fires on a file or directory", ->
     it "selects the entry", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Replaces [pathwatcher](https://github.com/atom/node-pathwatcher) with [atom.watchPath](https://atom.io/docs/api/v1.24.0/PathWatcher).

### Alternate Designs

None.

### Benefits

A better watching library that doesn't lock files everywhere on Windows.

### Possible Drawbacks

TODO

### Applicable Issues

TODO