### PR TITLE
Add command for move

### DIFF
--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -86,3 +86,9 @@
 '.tree-view-dialog atom-text-editor[mini]':
   'enter': 'core:confirm'
   'escape': 'core:cancel'
+
+'.platform-win32 atom-text-editor'
+  'F12': 'tree-view:move'
+
+'atom-text-editor':
+  'alt-shift-m': 'tree-view:move'

--- a/keymaps/tree-view.cson
+++ b/keymaps/tree-view.cson
@@ -87,7 +87,7 @@
   'enter': 'core:confirm'
   'escape': 'core:cancel'
 
-'.platform-win32 atom-text-editor'
+'.platform-win32 atom-text-editor, .platform-linux atom-text-editor'
   'F12': 'tree-view:move'
 
 'atom-text-editor':


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

As per Atom issue [#3212](https://github.com/atom/atom/issues/3212), there is a desire for a hotkey to rename/move the current file if the file has been saved outside the scope of the root dir and it is not visible in the tree view. A [PR](https://github.com/atom/tree-view/pull/549) has already been submitted for this issue, but it had one outstanding change required and hasn't been updated in over a year.

This change adds the hotkey for the move command within the atom editor for darwin, windows, and linux systems.

### Alternate Designs

No alternate designs were considered.

### Benefits

The benefit of this change is that users will be able to rename/move files they are editing with a hotkey even if they can't find those files in their tree-view.

### Possible Drawbacks

One possible drawback is if someone expected this hotkey to do nothing, they would be unpleasantly surprised to find that they are renaming their files with the keybinding `alt-shift-m`. This won't be a problem for people who have overridden this keybinding.

### Applicable Issues

gitub.com/atom issue:
https://github.com/atom/atom/issues/3212

currently open PR:
https://github.com/atom/tree-view/pull/549
