### PR TITLE
Enable gitignore when opened a subdirectory

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -185,7 +185,7 @@ class Directory {
   isPathIgnored (filePath) {
     if (atom.config.get('tree-view.hideVcsIgnoredFiles')) {
       const repo = repoForPath(this.path)
-      if (repo && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)) return true
+      if (repo && !repo.isPathIgnored(this.path) && repo.isPathIgnored(filePath)) return true
     }
 
     if (atom.config.get('tree-view.hideIgnoredNames')) {

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2994,19 +2994,36 @@ describe "TreeView", ->
         atom.config.set('tree-view.hideIgnoredNames', true)
         expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual([])
 
-    describe "when the project's path is a subfolder of the repository's working directory", ->
+    describe "when the project's path is an ignored subfolder of the repository's working directory", ->
       beforeEach ->
         fixturePath = path.join(__dirname, 'fixtures', 'root-dir1')
         projectPath = temp.mkdirSync('tree-view-project')
         fs.copySync(fixturePath, projectPath)
         ignoreFile = path.join(projectPath, '.gitignore')
-        fs.writeFileSync(ignoreFile, 'tree-view.js')
+        fs.writeFileSync(ignoreFile, 'dir1\nfile1')
 
-        atom.project.setPaths([projectPath])
+        ignoredDirPath = path.join(projectPath, 'dir1')
+        atom.project.setPaths([ignoredDirPath])
         atom.config.set("tree-view.hideVcsIgnoredFiles", true)
 
-      it "does not hide git ignored files", ->
-        expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual(['.gitignore', 'tree-view.js', 'tree-view.txt'])
+      it "shows git ignored files", ->
+        expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual(['file1'])
+
+    describe "when the project's path is a non-ignored subfolder of the repository's working directory", ->
+      beforeEach ->
+        fixturePath = path.join(__dirname, 'fixtures', 'root-dir1')
+        projectPath = temp.mkdirSync('tree-view-project')
+        fs.copySync(fixturePath, projectPath)
+        ignoreFile = path.join(projectPath, '.gitignore')
+        fs.writeFileSync(ignoreFile, 'file1')
+
+        subdirPath = path.join(projectPath, 'dir1')
+
+        atom.project.setPaths([subdirPath])
+        atom.config.set("tree-view.hideVcsIgnoredFiles", true)
+
+      it "hides git ignored files", ->
+        expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual([])
 
   describe "the hideIgnoredNames config option", ->
     it "hides ignored files if the option is set, but otherwise shows them", ->


### PR DESCRIPTION
### Description of the Change

The use case that required the previous conditional is opening an ignored subdirectory.
The updated check handles this use case, but also fixes opening non-ignored subdirectories.

https://github.com/atom/tree-view/issues/100#issuecomment-41324015

### Alternate Designs

Even more exposed settings in the UI does not help the user.

### Benefits

Enables gitignore to work when Atom is opened on a subdirectory.

### Possible Drawbacks

The behavior changes for users who open a non-ignored subdirectory. The intent is to improve the behavior, but some users may have been relying on the previous functionality.

### Applicable Issues

Closes #100.
