### PR TITLE
Enable hideIgnoredNames with hideVcsIgnoredFiles

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -185,7 +185,7 @@ class Directory {
   isPathIgnored(filePath) {
     if (atom.config.get('tree-view.hideVcsIgnoredFiles')) {
       const repo = repoForPath(this.path)
-      if (repo && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)) return true;
+      if (repo && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)) return true
     }
 
     if (atom.config.get('tree-view.hideIgnoredNames')) {

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -185,7 +185,7 @@ class Directory {
   isPathIgnored(filePath) {
     if (atom.config.get('tree-view.hideVcsIgnoredFiles')) {
       const repo = repoForPath(this.path)
-      return repo != null && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)
+      if (repo && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)) return true;
     }
 
     if (atom.config.get('tree-view.hideIgnoredNames')) {

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2939,6 +2939,18 @@ describe "TreeView", ->
         atom.config.set("tree-view.hideVcsIgnoredFiles", false)
         expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual(['.gitignore', 'ignored.txt'])
 
+      it "works in conjunction with the hideIgnoredNames config option", ->
+        # https://github.com/atom/tree-view/issues/489
+
+        atom.config.set('tree-view.hideVcsIgnoredFiles', true)
+        atom.config.set('tree-view.hideIgnoredNames', false)
+        atom.config.set('core.ignoredNames', ['.gitignore'])
+
+        expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual(['.gitignore'])
+
+        atom.config.set('tree-view.hideIgnoredNames', true)
+        expect(Array.from(treeView.element.querySelectorAll('.file')).map((f) -> f.textContent)).toEqual([])
+
     describe "when the project's path is a subfolder of the repository's working directory", ->
       beforeEach ->
         fixturePath = path.join(__dirname, 'fixtures', 'root-dir1')


### PR DESCRIPTION
### Description of the Change

Interpreting English, when both “hide ignored names” and “hide vcs ignored files” are enabled, I would expect both to apply, and the union of the two options of files to be hidden.

Before this commit, however, the “hide vcs ignored files” would override the “hide ignored names” for no apparent benefit.

### Alternate Designs

No alternate designs were considered.

### Benefits

The behavior will more closely match the user’s expectation based on the shared interface in English.

### Possible Drawbacks

Some users may have been relying on the gitignored files overriding the custom “ignored names” setting.

### Applicable Issues

Fixes #489