### PR TITLE
Copy files on drop if control is pressed

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -707,7 +707,7 @@ class TreeView
         if copiedPaths
           @copyEntry(initialPath, newDirectoryPath)
         else if cutPaths
-          @moveEntry(initialPath, newDirectoryPath)
+          break unless @moveEntry(initialPath, newDirectoryPath)
 
   add: (isCreatingFile) ->
     selectedEntry = @selectedEntry() ? @roots[0]

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -843,8 +843,10 @@ class TreeView
     try
       @emitter.emit 'will-copy-entry', {initialPath, newPath}
       if initialPathIsDirectory
+        # use fs.copy to copy directories since read/write will fail for directories
         fs.copySync(initialPath, newPath)
       else
+        # read the old file and write a new one at target location
         fs.writeFileSync(newPath, fs.readFileSync(initialPath))
       @emitter.emit 'entry-copied', {initialPath, newPath}
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -720,16 +720,18 @@ class TreeView
   #         paste destination.
   pasteEntries: ->
     selectedEntry = @selectedEntry()
+    return unless selectedEntry
+
     cutPaths = if window.localStorage['tree-view:cutPath'] then JSON.parse(window.localStorage['tree-view:cutPath']) else null
     copiedPaths = if window.localStorage['tree-view:copyPath'] then JSON.parse(window.localStorage['tree-view:copyPath']) else null
     initialPaths = copiedPaths or cutPaths
+    return unless initialPaths?.length
 
-    for initialPath in initialPaths ? []
-      if selectedEntry and initialPath and fs.existsSync(initialPath)
-        newDirectoryPath = selectedEntry.getPath()
-        newDirectoryPath = path.dirname(newDirectoryPath) if selectedEntry.classList.contains('file')
-        newPath = path.join(newDirectoryPath, path.basename(initialPath))
+    newDirectoryPath = selectedEntry.getPath()
+    newDirectoryPath = path.dirname(newDirectoryPath) if selectedEntry.classList.contains('file')
 
+    for initialPath in initialPaths
+      if fs.existsSync(initialPath)
         if copiedPaths
           @copyEntry(initialPath, newDirectoryPath)
         else if cutPaths

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -1,4 +1,4 @@
-module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, treeView) ->
+module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, treeView, copy = false) ->
   dataTransfer =
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
@@ -25,6 +25,9 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, tree
   Object.defineProperty(dropEvent, 'target', value: dropTarget)
   Object.defineProperty(dropEvent, 'currentTarget', value: dropTarget)
   Object.defineProperty(dropEvent, 'dataTransfer', value: dataTransfer)
+  if copy
+    key = if process.platform is 'darwin' then 'metaKey' else 'ctrlKey'
+    Object.defineProperty(dropEvent, key, value: true)
 
   dragEnterEvent = new DragEvent('dragenter')
   Object.defineProperty(dragEnterEvent, 'target', value: enterTarget)
@@ -33,7 +36,7 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, tree
 
   [dragStartEvent, dragEnterEvent, dropEvent]
 
-module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
+module.exports.buildExternalDropEvent = (filePaths, dropTarget, copy = false) ->
   dataTransfer =
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
@@ -51,6 +54,9 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
   Object.defineProperty(dropEvent, 'target', value: dropTarget)
   Object.defineProperty(dropEvent, 'currentTarget', value: dropTarget)
   Object.defineProperty(dropEvent, 'dataTransfer', value: dataTransfer)
+  if copy
+    key = if process.platform is 'darwin' then 'metaKey' else 'ctrlKey'
+    Object.defineProperty(dropEvent, key, value: true)
 
   for filePath in filePaths
     dropEvent.dataTransfer.files.push({path: filePath})

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1911,7 +1911,7 @@ describe "TreeView", ->
           atom.notifications.clear()
           atom.commands.dispatch(treeView.element, "tree-view:paste")
 
-          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Unable to paste paths'
+          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Failed to copy entry'
           expect(atom.notifications.getNotifications()[0].getDetail()).toContain 'ENOENT: no such file or directory'
 
     describe "tree-view:add-file", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1541,67 +1541,66 @@ describe "TreeView", ->
         LocalStorage.clear()
         atom.notifications.clear()
 
-      for operation in ['copy', 'cut']
-        describe "when attempting to #{operation} and paste a directory into itself", ->
-          it "shows a warning notification and does not paste", ->
-            # /dir-1/ -> /dir-1/
-            LocalStorage["tree-view:#{operation}Path"] = JSON.stringify([dirPath])
-            newPath = path.join(dirPath, path.basename(dirPath))
-            dirView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
-            expect(fs.existsSync(newPath)).toBe false
-            expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot paste a folder into itself'
+      describe "when attempting to paste a directory into itself", ->
+        it "shows a warning notification and does not paste", ->
+          # /dir-1/ -> /dir-1/
+          LocalStorage["tree-view:copyPath"] = JSON.stringify([dirPath])
+          newPath = path.join(dirPath, path.basename(dirPath))
+          dirView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
+          expect(fs.existsSync(newPath)).toBe false
+          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot copy a folder into itself'
 
-        describe "when attempting to #{operation} and paste a directory into a nested child directory", ->
-          it "shows a warning notification and does not paste", ->
-            nestedPath = path.join(dirPath, 'nested')
-            fs.makeTreeSync(nestedPath)
+      describe "when attempting to paste a directory into a nested child directory", ->
+        it "shows a warning notification and does not paste", ->
+          nestedPath = path.join(dirPath, 'nested')
+          fs.makeTreeSync(nestedPath)
 
-            # /dir-1/ -> /dir-1/nested/
-            LocalStorage["tree-view:#{operation}Path"] = JSON.stringify([dirPath])
-            newPath = path.join(nestedPath, path.basename(dirPath))
-            dirView.reload()
-            nestedView = dirView.querySelector('.directory')
-            nestedView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
-            expect(fs.existsSync(newPath)).toBe false
-            expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot paste a folder into itself'
+          # /dir-1/ -> /dir-1/nested/
+          LocalStorage["tree-view:copyPath"] = JSON.stringify([dirPath])
+          newPath = path.join(nestedPath, path.basename(dirPath))
+          dirView.reload()
+          nestedView = dirView.querySelector('.directory')
+          nestedView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
+          expect(fs.existsSync(newPath)).toBe false
+          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot copy a folder into itself'
 
-        describe "when attempting to #{operation} and paste a directory into a sibling directory that starts with the same letter", ->
-          it "allows the paste to occur", ->
-            # /dir-1/ -> /dir-2/
-            LocalStorage["tree-view:#{operation}Path"] = JSON.stringify([dirPath])
-            newPath = path.join(dirPath2, path.basename(dirPath))
-            dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
-            expect(fs.existsSync(newPath)).toBe true
-            expect(atom.notifications.getNotifications()[0]).toBeUndefined()
+      describe "when attempting to paste a directory into a sibling directory that starts with the same letter", ->
+        it "allows the paste to occur", ->
+          # /dir-1/ -> /dir-2/
+          LocalStorage["tree-view:copyPath"] = JSON.stringify([dirPath])
+          newPath = path.join(dirPath2, path.basename(dirPath))
+          dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
+          expect(fs.existsSync(newPath)).toBe true
+          expect(atom.notifications.getNotifications()[0]).toBeUndefined()
 
-        describe "when attempting to #{operation} and paste a directory into a symlink of itself", ->
-          it "shows a warning notification and does not paste", ->
-            fs.symlinkSync(dirPath, path.join(rootDirPath, 'symdir'), 'junction')
+      describe "when attempting to paste a directory into a symlink of itself", ->
+        it "shows a warning notification and does not paste", ->
+          fs.symlinkSync(dirPath, path.join(rootDirPath, 'symdir'), 'junction')
 
-            # /dir-1/ -> symlink of /dir-1/
-            LocalStorage["tree-view:#{operation}Path"] = JSON.stringify([dirPath])
-            newPath = path.join(dirPath, path.basename(dirPath))
-            symlinkView = root1.querySelector('.directory')
-            symlinkView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
-            expect(fs.existsSync(newPath)).toBe false
-            expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot paste a folder into itself'
+          # /dir-1/ -> symlink of /dir-1/
+          LocalStorage["tree-view:copyPath"] = JSON.stringify([dirPath])
+          newPath = path.join(dirPath, path.basename(dirPath))
+          symlinkView = root1.querySelector('.directory')
+          symlinkView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
+          expect(fs.existsSync(newPath)).toBe false
+          expect(atom.notifications.getNotifications()[0].getMessage()).toContain 'Cannot copy a folder into itself'
 
-        describe "when attempting to #{operation} and paste a symlink into its target directory", ->
-          it "allows the paste to occur", ->
-            symlinkedPath = path.join(rootDirPath, 'symdir')
-            fs.symlinkSync(dirPath, symlinkedPath, 'junction')
+      describe "when attempting to paste a symlink into its target directory", ->
+        it "allows the paste to occur", ->
+          symlinkedPath = path.join(rootDirPath, 'symdir')
+          fs.symlinkSync(dirPath, symlinkedPath, 'junction')
 
-            # symlink of /dir-1/ -> /dir-1/
-            LocalStorage["tree-view:#{operation}Path"] = JSON.stringify([symlinkedPath])
-            newPath = path.join(dirPath, path.basename(symlinkedPath))
-            dirView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
-            expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
-            expect(fs.existsSync(newPath)).toBe true
-            expect(atom.notifications.getNotifications()[0]).toBeUndefined()
+          # symlink of /dir-1/ -> /dir-1/
+          LocalStorage["tree-view:copyPath"] = JSON.stringify([symlinkedPath])
+          newPath = path.join(dirPath, path.basename(symlinkedPath))
+          dirView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          expect(-> atom.commands.dispatch(treeView.element, "tree-view:paste")).not.toThrow()
+          expect(fs.existsSync(newPath)).toBe true
+          expect(atom.notifications.getNotifications()[0]).toBeUndefined()
 
       describe "when pasting entries which don't exist anymore", ->
         it "skips the entry which doesn't exist", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3750,7 +3750,7 @@ describe "TreeView", ->
         expect(alphaDir).not.toHaveClass('selected')
 
     describe "when dropping a FileView onto a DirectoryView's header", ->
-      it "should move the file to the hovered directory", ->
+      fit "should move the file to the hovered directory", ->
         # Dragging delta.txt onto alphaDir
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()
@@ -3758,6 +3758,9 @@ describe "TreeView", ->
         gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
         gammaDir.expand()
         deltaFile = gammaDir.entries.children[1]
+
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+        gammaDirContents = findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
             eventHelpers.buildInternalDragEvents([deltaFile], alphaDir.querySelector('.header'), alphaDir, treeView)
@@ -3767,10 +3770,12 @@ describe "TreeView", ->
         expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents and
+          findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length < gammaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 1
+          expect(findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length).toBe gammaDirContents - 1
 
       it "shouldn't update editors with similar file paths", ->
         deltaFilePath2 = path.join(gammaDirPath, 'delta.txt2')
@@ -3813,6 +3818,9 @@ describe "TreeView", ->
         gammaDir.expand()
         deltaFile = gammaDir.entries.children[1]
 
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+        gammaDirContents = findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length
+
         [dragStartEvent, dragEnterEvent, dropEvent] =
             eventHelpers.buildInternalDragEvents([deltaFile], betaFile, alphaDir, treeView)
 
@@ -3821,10 +3829,12 @@ describe "TreeView", ->
         expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents and
+          findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length < gammaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 1
+          expect(findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length).toBe gammaDirContents - 1
 
       it "shouldn't update editors with similar file paths", ->
         deltaFilePath2 = path.join(gammaDirPath, 'delta.txt2')
@@ -3859,13 +3869,16 @@ describe "TreeView", ->
 
     describe "when dropping multiple FileViews onto a DirectoryView's header", ->
       it "should move the files to the hovered directory", ->
-        # Dragging delta.txt onto alphaDir
+        # Dragging multiple files in gammaDir onto alphaDir
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()
 
         gammaDir = findDirectoryContainingText(treeView.roots[0], 'gamma')
         gammaDir.expand()
         gammaFiles = [].slice.call(gammaDir.entries.children, 1, 3)
+
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+        gammaDirContents = findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
             eventHelpers.buildInternalDragEvents(gammaFiles, alphaDir.querySelector('.header'), alphaDir, treeView)
@@ -3876,10 +3889,12 @@ describe "TreeView", ->
           expect(alphaDir.entries.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents and
+          findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length < gammaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 2
+          expect(findDirectoryContainingText(treeView.roots[0], 'gamma').querySelectorAll('.entry').length).toBe gammaDirContents - 2
 
     describe "when dropping a DirectoryView and FileViews onto a DirectoryView's header", ->
       it "should move the files and directory to the hovered directory", ->
@@ -3893,6 +3908,9 @@ describe "TreeView", ->
         thetaDir = findDirectoryContainingText(treeView.roots[0], 'theta')
         thetaDir.expand()
 
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+        thetaDirContents = findDirectoryContainingText(treeView.roots[0], 'theta').querySelectorAll('.entry').length
+
         dragged = [alphaFile, alphaDir]
 
         [dragStartEvent, dragEnterEvent, dropEvent] =
@@ -3904,15 +3922,15 @@ describe "TreeView", ->
           expect(thetaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'theta').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'theta').querySelectorAll('.entry').length > thetaDirContents
 
         runs ->
           thetaDir.expand()
-          expect(thetaDir.querySelectorAll('.entry').length).toBe 3
+          expect(thetaDir.querySelectorAll('.entry').length).toBe thetaDirContents + 2
           # alpha dir still has all its entries
           alphaDir = findDirectoryContainingText(thetaDir.entries, 'alpha')
           alphaDir.expand()
-          expect(alphaDir.querySelectorAll('.entry').length).toBe 2
+          expect(alphaDir.querySelectorAll('.entry').length).toBe alphaDirContents
 
     describe "when dropping a DirectoryView onto a DirectoryView's header", ->
       beforeEach ->
@@ -3929,6 +3947,9 @@ describe "TreeView", ->
         thetaDir = gammaDir.entries.children[0]
         thetaDir.expand()
 
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+        thetaDirContents = findDirectoryContainingText(treeView.roots[0], 'theta').querySelectorAll('.entry').length
+
         [dragStartEvent, dragEnterEvent, dropEvent] =
           eventHelpers.buildInternalDragEvents([thetaDir], alphaDir.querySelector('.header'), alphaDir, treeView)
         treeView.onDragStart(dragStartEvent)
@@ -3936,10 +3957,15 @@ describe "TreeView", ->
         expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 1
+
+          thetaDir = findDirectoryContainingText(alphaDir.entries, 'theta')
+          thetaDir.expand()
+          expect(thetaDir.querySelectorAll('.entry').length).toBe thetaDirContents
+
           editor = atom.workspace.getActiveTextEditor()
           expect(editor.getPath()).toBe(thetaFilePath.replace('gamma', 'alpha'))
 
@@ -4000,6 +4026,8 @@ describe "TreeView", ->
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()
 
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+
         dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir)
 
         runs ->
@@ -4007,10 +4035,10 @@ describe "TreeView", ->
           expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 1
 
     describe "when dragging a directory from the OS onto a DirectoryView's header", ->
       it "should move the directory to the hovered directory", ->
@@ -4018,21 +4046,25 @@ describe "TreeView", ->
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()
 
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
+
         dropEvent = eventHelpers.buildExternalDropEvent([gammaDirPath], alphaDir)
         treeView.onDrop(dropEvent)
         expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 3
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 1
 
     describe "when dragging a file and directory from the OS onto a DirectoryView's header", ->
       it "should move the file and directory to the hovered directory", ->
         # Dragging delta.txt and gammaDir from OS file explorer onto alphaDir
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()
+
+        alphaDirContents = findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length
 
         dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir)
 
@@ -4041,10 +4073,10 @@ describe "TreeView", ->
           expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
-          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 3
+          findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > alphaDirContents
 
         runs ->
-          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe 4
+          expect(findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length).toBe alphaDirContents + 2
 
     describe "when dragging a directory from the OS onto a blank section of the Tree View", ->
       it "should create a new project folder", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3750,7 +3750,7 @@ describe "TreeView", ->
         expect(alphaDir).not.toHaveClass('selected')
 
     describe "when dropping a FileView onto a DirectoryView's header", ->
-      fit "should move the file to the hovered directory", ->
+      it "should move the file to the hovered directory", ->
         # Dragging delta.txt onto alphaDir
         alphaDir = findDirectoryContainingText(treeView.roots[0], 'alpha')
         alphaDir.expand()

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1858,7 +1858,7 @@ describe "TreeView", ->
               expect(callback).not.toHaveBeenCalled()
 
               expect(atom.notifications.getNotifications().length).toBe(1)
-              expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Unable to paste')
+              expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Failed to move')
 
           describe 'when the file is currently open', ->
             beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

For consistency with OS behavior, copy files when dropping if control is pressed, rather than moving them.

### Alternate Designs

None?

### Benefits

Consistency with file managers such as Windows Explorer.

### Possible Drawbacks

Unknown

### Applicable Issues

Closes #703
Supersedes and closes #800

* [x] Make it work
  * [x] Add specs
* [x] Allow files to be copied to the same directory
  * [x] Add specs
* [ ] Regression testing