### PR TITLE
Use shell.showItemInFolder to show files

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -537,76 +537,16 @@ class TreeView
           @emitter.emit 'move-entry-failed', {initialPath, newPath}
       dialog.attach()
 
-  # Get the outline of a system call to the current platform's file manager.
-  #
-  # pathToOpen  - Path to a file or directory.
-  # isFile      - True if the path is a file, false otherwise.
-  #
-  # Returns an object containing a command, a human-readable label, and the
-  # arguments.
-  fileManagerCommandForPath: (pathToOpen, isFile) ->
-    switch process.platform
-      when 'darwin'
-        command: 'open'
-        label: 'Finder'
-        args: ['-R', pathToOpen]
-      when 'win32'
-        args = ["/select,\"#{pathToOpen}\""]
-
-        if process.env.SystemRoot
-          command = path.join(process.env.SystemRoot, 'explorer.exe')
-        else
-          command = 'explorer.exe'
-
-        command: command
-        label: 'Explorer'
-        args: args
-      else
-        # Strip the filename from the path to make sure we pass a directory
-        # path. If we pass xdg-open a file path, it will open that file in the
-        # most suitable application instead, which is not what we want.
-        pathToOpen =  path.dirname(pathToOpen) if isFile
-
-        command: 'xdg-open'
-        label: 'File Manager'
-        args: [pathToOpen]
-
-  openInFileManager: (command, args, label, isFile) ->
-    handleError = (errorMessage) ->
-      atom.notifications.addError "Opening #{if isFile then 'file' else 'folder'} in #{label} failed",
-        detail: errorMessage
-        dismissable: true
-
-    errorLines = []
-    stderr = (lines) -> errorLines.push(lines)
-    exit = (code) ->
-      failed = code isnt 0
-      errorMessage = errorLines.join('\n')
-
-      # Windows 8 seems to return a 1 with no error output even on success
-      if process.platform is 'win32' and code is 1 and not errorMessage
-        failed = false
-
-      handleError(errorMessage) if failed
-
-    showProcess = new BufferedProcess({command, args, stderr, exit})
-    showProcess.onWillThrowError ({error, handle}) ->
-      handle()
-      handleError(error?.message)
-    showProcess
-
   showSelectedEntryInFileManager: ->
     return unless entry = @selectedEntry()
 
-    isFile = entry.classList.contains('file')
-    {command, args, label} = @fileManagerCommandForPath(entry.getPath(), isFile)
-    @openInFileManager(command, args, label, isFile)
+    shell.showItemInFolder(entry.getPath())
 
   showCurrentFileInFileManager: ->
     return unless editor = atom.workspace.getCenter().getActiveTextEditor()
-    return unless editor.getPath()
-    {command, args, label} = @fileManagerCommandForPath(editor.getPath(), true)
-    @openInFileManager(command, args, label, true)
+    return unless filePath = editor.getPath()
+
+    shell.showItemInFolder(filePath)
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -538,15 +538,16 @@ class TreeView
       dialog.attach()
 
   showSelectedEntryInFileManager: ->
-    return unless entry = @selectedEntry()
+    return unless filePath = @selectedEntry()?.getPath()
 
-    shell.showItemInFolder(entry.getPath())
+    unless shell.showItemInFolder(filePath)
+      atom.notifications.addWarning("Unable to show #{filePath} in file manager")
 
   showCurrentFileInFileManager: ->
-    return unless editor = atom.workspace.getCenter().getActiveTextEditor()
-    return unless filePath = editor.getPath()
+    return unless filePath = atom.workspace.getCenter().getActiveTextEditor()?.getPath()
 
-    shell.showItemInFolder(filePath)
+    unless shell.showItemInFolder(filePath)
+      atom.notifications.addWarning("Unable to show #{filePath} in file manager")
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -39,6 +39,7 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
+    {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
   ]
 
   '.tree-view .full-menu [is="tree-view-file"]': [
@@ -70,7 +71,6 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
-    {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
   ]
 
   '.tree-view .multi-select': [

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -70,17 +70,6 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open In New Window', 'command': 'tree-view:open-in-new-window'}
-  ]
-
-  '.platform-darwin .tree-view .full-menu': [
-    {'label': 'Show in Finder', 'command': 'tree-view:show-in-file-manager'}
-  ]
-
-  '.platform-win32 .tree-view .full-menu': [
-    {'label': 'Show in Explorer', 'command': 'tree-view:show-in-file-manager'}
-  ]
-
-  '.platform-linux .tree-view .full-menu': [
     {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
   ]
 
@@ -98,28 +87,9 @@
   'atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Rename', 'command': 'tree-view:rename'}
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
-  ]
-
-  '.platform-darwin atom-pane[data-active-item-path] .tab.active': [
-    {'label': 'Show In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
-  ]
-
-  '.platform-win32 atom-pane[data-active-item-path] .tab.active': [
-    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
-  ]
-
-  '.platform-linux atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  '.platform-darwin atom-text-editor:not([mini])': [
-    {'label': 'Show In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
-  ]
-
-  '.platform-win32 atom-text-editor:not([mini])': [
-    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
-  ]
-
-  '.platform-linux atom-text-editor:not([mini])': [
+  'atom-text-editor:not([mini])': [
     {'label': 'Show In File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Electron's [`shell`](https://electronjs.org/docs/api/shell) module has a method [`shell.showItemInFolder`](https://electronjs.org/docs/api/shell#shellshowiteminfolderfullpath) to automatically open files in the OS's file manager.  I'm not sure why we decided to go ahead with our implementation instead of using that, but it makes much more sense to delegate to Electron instead of maintaining our own version.

### Alternate Designs

None.

### Benefits

`shell.showItemInFolder` will use the default file manager, rather than the one hardcoded by tree-view.  For example, on Windows, while the default file manager is commonly `explorer.exe`, that is not always the case.  This change also reduces the amount of code that tree-view needs to maintain.

### Possible Drawbacks

I have changed the menu text to always refer to a generic "File Manager", as it is no longer possible to know exactly which file manager will be used.

### Applicable Issues

Supersedes and closes #889.
_Should_ fix #685.
_Should_ fix #583.

Needs testing on macOS and Linux.