### PR TITLE
Remove realpathCache argument in fs.realpath

### DIFF
--- a/lib/directory.js
+++ b/lib/directory.js
@@ -115,7 +115,7 @@ class Directory {
         this.lowerCaseRealPath = this.realPath.toLowerCase()
       }
     } else {
-      fs.realpath(this.path, {}, (error, realPath) => {
+      fs.realpath(this.path, (error, realPath) => {
         // FIXME: Add actual error handling
         if (error || this.destroyed) return
         if (realPath && (realPath !== this.path)) {

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -5,7 +5,6 @@ const fs = require('fs-plus')
 const PathWatcher = require('pathwatcher')
 const File = require('./file')
 const {repoForPath} = require('./helpers')
-const realpathCache = {}
 
 module.exports =
 class Directory {
@@ -116,7 +115,7 @@ class Directory {
         this.lowerCaseRealPath = this.realPath.toLowerCase()
       }
     } else {
-      fs.realpath(this.path, realpathCache, (error, realPath) => {
+      fs.realpath(this.path, {}, (error, realPath) => {
         // FIXME: Add actual error handling
         if (error || this.destroyed) return
         if (realPath && (realPath !== this.path)) {
@@ -320,7 +319,7 @@ class Directory {
           // track the insertion index for the created views
           files.push(name)
         } else {
-          files.push(new File({name, fullPath, symlink, realpathCache, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statFlat}))
+          files.push(new File({name, fullPath, symlink, ignoredNames: this.ignoredNames, useSyncFS: this.useSyncFS, stats: statFlat}))
         }
       }
     }

--- a/lib/file.js
+++ b/lib/file.js
@@ -4,7 +4,7 @@ const {repoForPath} = require('./helpers')
 
 module.exports =
 class File {
-  constructor ({name, fullPath, symlink, realpathCache, ignoredNames, useSyncFS, stats}) {
+  constructor ({name, fullPath, symlink, ignoredNames, useSyncFS, stats}) {
     this.name = name
     this.symlink = symlink
     this.ignoredNames = ignoredNames
@@ -22,7 +22,7 @@ class File {
     if (useSyncFS) {
       this.realPath = fs.realpathSync(this.path)
     } else {
-      fs.realpath(this.path, realpathCache, (error, realPath) => {
+      fs.realpath(this.path, {}, (error, realPath) => {
         // FIXME: Add actual error handling
         if (error || this.destroyed) return
         if (realPath && realPath !== this.path) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -22,7 +22,7 @@ class File {
     if (useSyncFS) {
       this.realPath = fs.realpathSync(this.path)
     } else {
-      fs.realpath(this.path, {}, (error, realPath) => {
+      fs.realpath(this.path, (error, realPath) => {
         // FIXME: Add actual error handling
         if (error || this.destroyed) return
         if (realPath && realPath !== this.path) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Node 6 removed the `cache` argument from `fs.realpath` as it switched to a much faster native implementation. See https://github.com/nodejs/node/pull/3594 for details. As Atom is now on Node 8, this argument is currently sitting there doing...nothing.

### Alternate Designs

None.

### Benefits

Removal of a confusing argument from a bygone era.

### Possible Drawbacks

None.

### Applicable Issues

None, though I caught this when working on #1232.