### PR TITLE
Add option in config to always recursively collapse

### DIFF
--- a/lib/directory-view.js
+++ b/lib/directory-view.js
@@ -172,7 +172,7 @@ class DirectoryView {
     this.isExpanded = false
     this.element.isExpanded = false
 
-    if (isRecursive || atom.config.get('tree-view.alwaysRecursiveCollapse')) {
+    if (isRecursive || atom.config.get('tree-view.alwaysCollapseRecursively')) {
       for (let entry of this.entries.children) {
         if (entry.isExpanded) {
           entry.collapse(true)

--- a/lib/directory-view.js
+++ b/lib/directory-view.js
@@ -172,7 +172,7 @@ class DirectoryView {
     this.isExpanded = false
     this.element.isExpanded = false
 
-    if (isRecursive) {
+    if (isRecursive || atom.config.get('tree-view.alwaysRecursiveCollapse')) {
       for (let entry of this.entries.children) {
         if (entry.isExpanded) {
           entry.collapse(true)

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
       "default": false,
       "description": "When opening a file, always focus an already-existing view of the file even if it's in a another pane."
     },
-    "alwaysRecursiveCollapse": {
+    "alwaysCollapseRecursively": {
       "type": "boolean",
       "default": false,
-      "description": "When collapsing a folder, always collapse the children as well"
+      "description": "When collapsing a folder, always collapse all descendants as well"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
       "type": "boolean",
       "default": false,
       "description": "When opening a file, always focus an already-existing view of the file even if it's in a another pane."
+    },
+    "alwaysRecursiveCollapse": {
+      "type": "boolean",
+      "default": false,
+      "description": "When collapsing a folder, always collapse the children as well"
     }
   }
 }

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -769,6 +769,39 @@ describe "TreeView", ->
           expect(child).not.toHaveClass 'expanded'
         expect(treeView.roots[0]).toHaveClass 'expanded'
 
+
+  describe "the alwaysCollapseRecursively config option", ->
+    it "defaults to unset", ->
+      expect(atom.config.get("tree-view.alwaysCollapseRecursively")).toBeFalsy()
+
+    describe "when an expanded directory is clicked", ->
+      parent    = null
+      children  = null
+
+      beforeEach ->
+        atom.config.set("tree-view.alwaysCollapseRecursively", true)
+        parent = root1.querySelectorAll('.entries > .directory')[2]
+        parent.expand()
+        children = parent.querySelectorAll('.expanded.directory')
+        for child in children
+          child.expand()
+
+      it "recursively collapses the directory", ->
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+        parent.expand()
+        expect(parent).toHaveClass 'expanded'
+        for child in children
+          child.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          child.expand()
+          expect(child).toHaveClass 'expanded'
+
+        parent.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+
+        expect(parent).not.toHaveClass 'expanded'
+        for child in children
+          expect(child).not.toHaveClass 'expanded'
+        expect(treeView.roots[0]).toHaveClass 'expanded'
+
   describe "when the active item changes on the active pane", ->
     describe "when the item has a path", ->
       it "selects the entry with that path in the tree view if it is visible", ->


### PR DESCRIPTION
### Description of the Change
Adds option in settings (package.json) for the user to select "Always Recursive Collapse."
This makes it so that whenever a parent folder is collapsed in the tree-view, all child folders are ALWAYS also collapsed.
In essence, it adds a boolean override for "isRecursive."

### Alternate Designs
No other design options considered. Simple setting addition.

### Benefits
This allows users to specify their preference as to how the folders in the tree-view should be collapsed.
This should be an option since several other editors have this functionality by default.

### Possible Drawbacks
None (defaults to false, so same default functionality will not change)

### Applicable Issues
None