### PR TITLE
Reselect entries when updating roots

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -132,7 +132,7 @@ class TreeView
       @[root.directory.path] = root.directory.serializeExpansionState() for root in roots
       this)(@roots)
     deserializer: 'TreeView'
-    selectedPaths: Array.from(@getSelectedEntries())?.map((entry) -> entry.getPath())
+    selectedPaths: Array.from(@getSelectedEntries(), (entry) -> entry.getPath())
     scrollLeft: @element.scrollLeft
     scrollTop: @element.scrollTop
     width: parseInt(@element.style.width or 0)
@@ -315,8 +315,9 @@ class TreeView
       atom.workspace.open(uri, options)
 
   updateRoots: (expansionStates={}) ->
-    oldExpansionStates = {}
     selectedPaths = @selectedPaths()
+
+    oldExpansionStates = {}
     for root in @roots
       oldExpansionStates[root.directory.path] = root.directory.serializeExpansionState()
       root.directory.destroy()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -59,9 +59,11 @@ class TreeView
       @disposables.add atom.styles.onDidUpdateStyleElement(onStylesheetsChanged)
 
     @updateRoots(state.directoryExpansionStates)
-    @selectEntry(@roots[0])
 
-    @selectEntryForPath(state.selectedPath) if state.selectedPath
+    if state.selectedPaths?.length > 0
+      @selectMultipleEntries(@entryForPath(selectedPath)) for selectedPath in state.selectedPaths
+    else
+      @selectEntry(@roots[0])
 
     if state.scrollTop? or state.scrollLeft?
       observer = new IntersectionObserver(=>
@@ -130,7 +132,7 @@ class TreeView
       @[root.directory.path] = root.directory.serializeExpansionState() for root in roots
       this)(@roots)
     deserializer: 'TreeView'
-    selectedPath: @selectedEntry()?.getPath()
+    selectedPaths: Array.from(@getSelectedEntries())?.map((entry) -> entry.getPath())
     scrollLeft: @element.scrollLeft
     scrollTop: @element.scrollTop
     width: parseInt(@element.style.width or 0)
@@ -314,6 +316,7 @@ class TreeView
 
   updateRoots: (expansionStates={}) ->
     oldExpansionStates = {}
+    selectedPaths = @selectedPaths()
     for root in @roots
       oldExpansionStates[root.directory.path] = root.directory.serializeExpansionState()
       root.directory.destroy()
@@ -343,6 +346,9 @@ class TreeView
       root = new DirectoryView(directory).element
       @list.appendChild(root)
       root
+
+    # The DOM has been recreated; reselect everything
+    @selectMultipleEntries(@entryForPath(selectedPath)) for selectedPath in selectedPaths
 
   getActivePath: -> atom.workspace.getCenter().getActivePaneItem()?.getPath?()
 

--- a/spec/tree-view-spec.js
+++ b/spec/tree-view-spec.js
@@ -81,4 +81,26 @@ describe('TreeView', () => {
       expect(treeView.multiSelectEnabled()).toBe(true)
     })
   })
+
+  describe('file selection', () => {
+    it('keeps files selected after roots have been updated', () => {
+      const treeView = new TreeView({})
+      treeView.roots[0].expand()
+      treeView.roots[0].entries.firstChild.expand()
+      treeView.selectEntry(treeView.roots[0].entries.firstChild.entries.firstChild)
+      treeView.selectMultipleEntries(treeView.roots[0].entries.lastChild)
+
+      expect(Array.from(treeView.getSelectedEntries())).toEqual([
+        treeView.roots[0].entries.firstChild.entries.firstChild,
+        treeView.roots[0].entries.lastChild
+      ])
+
+      treeView.updateRoots()
+
+      expect(Array.from(treeView.getSelectedEntries())).toEqual([
+        treeView.roots[0].entries.firstChild.entries.firstChild,
+        treeView.roots[0].entries.lastChild
+      ])
+    })
+  })
 })

--- a/spec/tree-view-spec.js
+++ b/spec/tree-view-spec.js
@@ -2,18 +2,22 @@ const TreeView = require('../lib/tree-view')
 
 describe('TreeView', () => {
   describe('serialization', () => {
-    it('restores the expanded directories and selected file', () => {
+    it('restores the expanded directories and selected files', () => {
       const treeView = new TreeView({})
       treeView.roots[0].expand()
       treeView.roots[0].entries.firstChild.expand()
       treeView.selectEntry(treeView.roots[0].entries.firstChild.entries.firstChild)
+      treeView.selectMultipleEntries(treeView.roots[0].entries.lastChild)
 
       const treeView2 = new TreeView(treeView.serialize())
 
       expect(treeView2.roots[0].isExpanded).toBe(true)
       expect(treeView2.roots[0].entries.children[0].isExpanded).toBe(true)
       expect(treeView2.roots[0].entries.children[1].isExpanded).toBeUndefined()
-      expect(Array.from(treeView2.getSelectedEntries())).toEqual([treeView2.roots[0].entries.firstChild.entries.firstChild])
+      expect(Array.from(treeView2.getSelectedEntries())).toEqual([
+        treeView2.roots[0].entries.firstChild.entries.firstChild,
+        treeView2.roots[0].entries.lastChild
+      ])
     })
 
     it('restores the scroll position', () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, whenever the roots were updated (resulting in the entire DOM being recreated), any selected entries wouldn't stay selected.  This would happen whenever projects were added or removed or certain tree-view settings were changed.  Now, whenever the roots are updated, the selected entries are maintained.

Additionally, if you select multiple entries before closing Atom, those same entries will remain selected the next time you open Atom instead of only the first entry.

### Alternate Designs

Well, it would certainly be nice if the entire DOM wasn't erased and recreated.

### Benefits

Entries stay more consistently selected.

### Possible Drawbacks

There is one caveat: after merging this PR, the lack of `state.selectedPaths` on the first run will cause all existing entry serialization (in `state.selectedPath`) to be disregarded, and the root will be selected.  I don't see this as a problem though, considering `updateRoots` blew away the selection anyway.

### Applicable Issues

I couldn't find any.