### PR TITLE
Prevent multiple instances of tree-view being opened

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -28,7 +28,8 @@ class TreeViewPackage {
       const showOnAttach = !atom.workspace.getActivePaneItem()
       this.treeViewOpenPromise = atom.workspace.open(treeView, {
         activatePane: showOnAttach,
-        activateItem: showOnAttach
+        activateItem: showOnAttach,
+        searchAllPanes: true
       })
     } else {
       this.treeViewOpenPromise = Promise.resolve()


### PR DESCRIPTION

### Description of the Change

Currently tree-view opens itself with a call to `atom.workspace.open` which by default: "only the active pane will be searched for an existing item"

When the left dock is split, only the bottom pane of that dock is searched, and if tree-view already exists in another pane then two instances of tree-view are opened. Initially the duplicate instance is blank, but upon restarting atom it causes atom to crash with `Error: The workspace can only contain one instance of item`.

### Alternate Designs

None

### Benefits

Atom doesn't crash

### Possible Drawbacks

None

### Applicable Issues

This should fix:

- https://github.com/atom/atom/issues/6121#issuecomment-335487266
- https://github.com/atom/atom/issues/14201
