### PR TITLE
Collapse all directories even when nothing is selected

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -481,12 +481,14 @@ class TreeView
       directory.expand(isRecursive)
 
   collapseDirectory: (isRecursive=false, allDirectories=false) ->
+    if allDirectories
+      root.collapse(true) for root in @roots
+      return
+
     selectedEntry = @selectedEntry()
     return unless selectedEntry?
 
-    if allDirectories
-      root.collapse(true) for root in @roots
-    else if directory = selectedEntry.closest('.expanded.directory')
+    if directory = selectedEntry.closest('.expanded.directory')
       directory.collapse(isRecursive)
       @selectEntry(directory)
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1218,8 +1218,20 @@ describe "TreeView", ->
             expect(child).not.toHaveClass 'expanded'
           expect(root).not.toHaveClass 'expanded'
 
-      it "collapses all the project directories recursively", ->
+      it "collapses all the project directories recursively when an entry is selected", ->
         expandAll()
+
+        expect(treeView.element.querySelectorAll('.selected').length).toBeGreaterThan 0
+
+        atom.commands.dispatch(treeView.element, 'tree-view:collapse-all')
+        checkAllCollapsed()
+
+      it "collapses all the project directories when nothing is selected", ->
+        expandAll()
+
+        treeView.deselect()
+        expect(treeView.element.querySelectorAll('.selected').length).toBe 0
+
         atom.commands.dispatch(treeView.element, 'tree-view:collapse-all')
         checkAllCollapsed()
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This pull request updates the `collapseDirectory` method so that when the `allDirectories` parameter is set to `true`, all directories will be closed, even if nothing is selected in the tree view. Previously, if nothing was selected in the tree view, this method would return before collapsing anything (even if `allDirectories` was set to `true`.

### Alternate Designs

N/A

### Benefits

Triggering collapse-all will always collapse all directories, even if an item isn't currently selected in the tree-view.

### Possible Drawbacks

None that I'm aware of.

### Applicable Issues

None that I'm aware of.
