### PR TITLE
Fix intermittent test failure re: destroyed tree-view

### DIFF
--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -306,6 +306,8 @@ describe "TreeView", ->
 
   describe "when the tree-view is destroyed", ->
     it "can correctly re-create the tree-view", ->
+      treeView.useSyncFS = true
+
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
       treeViewHTML = treeView.element.outerHTML
       treeView.roots[0].collapse()

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -306,9 +306,8 @@ describe "TreeView", ->
 
   describe "when the tree-view is destroyed", ->
     it "can correctly re-create the tree-view", ->
-      treeView.useSyncFS = true
-
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
+      treeView.useSyncFS = true
       treeViewHTML = treeView.element.outerHTML
       treeView.roots[0].collapse()
       treeView.destroy()
@@ -318,6 +317,7 @@ describe "TreeView", ->
 
       runs ->
         treeView2 = atom.workspace.getLeftDock().getActivePaneItem()
+        treeView2.useSyncFS = true
         treeView2.roots[0].expand()
         expect(treeView2.element.outerHTML).toBe(treeViewHTML)
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -307,8 +307,7 @@ describe "TreeView", ->
   describe "when the tree-view is destroyed", ->
     it "can correctly re-create the tree-view", ->
       treeView = atom.workspace.getLeftDock().getActivePaneItem()
-      treeView.useSyncFS = true
-      treeViewHTML = treeView.element.outerHTML
+      entryCountBeforeRecreatingView = treeView.element.getElementsByClassName('entry').length
       treeView.roots[0].collapse()
       treeView.destroy()
 
@@ -317,9 +316,9 @@ describe "TreeView", ->
 
       runs ->
         treeView2 = atom.workspace.getLeftDock().getActivePaneItem()
-        treeView2.useSyncFS = true
         treeView2.roots[0].expand()
-        expect(treeView2.element.outerHTML).toBe(treeViewHTML)
+        entryCountAfterRecreatingView = treeView2.element.getElementsByClassName('entry').length
+        expect(entryCountAfterRecreatingView).toBe(entryCountBeforeRecreatingView)
 
   describe "when tree-view:reveal-active-file is triggered", ->
     beforeEach ->


### PR DESCRIPTION
### Description of the Change

We've been seeing this assertion fail intermittently on AppVeyor recently:

https://github.com/atom/tree-view/blob/1b731e365c8678a81d6f4b6373ff0738086de577/spec/tree-view-package-spec.coffee#L320

Example failing build: https://ci.appveyor.com/project/Atom/tree-view/builds/20338242/job/v7t0rvbkmv8ih0mq

#### What specifically is failing?

We can see the output of the failing assertion here in the build log [here](https://ci.appveyor.com/project/Atom/tree-view/builds/20338242/job/v7t0rvbkmv8ih0mq#L127). Let's look at a diff between the expected value and the actual value in that assertion:

```diff
@@ -1,6 +1,6 @@
 <div class="tool-panel tree-view" tabindex="-1">
   <ol class="tree-view-root full-menu list-tree has-collapsable-children focusable-panel" style="">
-    <li is="tree-view-directory" class="directory entry list-nested-item project-root status-added expanded selected">
+    <li is="tree-view-directory" class="directory entry list-nested-item project-root expanded selected">
       <div class="header list-item project-root-header"><span class="name icon icon-file-directory" data-path="C:\projects\tree-view\spec\fixtures\root-dir1" data-name="root-dir1" title="root-dir1">root-dir1</span></div>
       <ol class="entries list-tree">
         <li is="tree-view-directory" class="directory entry list-nested-item collapsed" draggable="true">
@@ -19,14 +19,15 @@
         <li is="tree-view-file" draggable="true" class="file entry list-item"><span class="name icon icon-file-text" title="tree-view.txt" data-name="tree-view.txt" data-path="C:\projects\tree-view\spec\fixtures\root-dir1\tree-view.txt">tree-view.txt</span></li>
       </ol>
     </li>
-    <li is="tree-view-directory" class="directory entry list-nested-item project-root status-added expanded">
+    <li is="tree-view-directory" class="directory entry list-nested-item project-root expanded">
       <div class="header list-item project-root-header"><span class="name icon icon-file-directory" data-path="C:\projects\tree-view\spec\fixtures\root-dir2" data-name="root-dir2" title="root-dir2">root-dir2</span></div>
       <ol class="entries list-tree">
```

The only difference is that the actual content is missing the `status-added` class.

#### Why is the the `status-added` class missing?

From what I can tell, the `status-*` classes get added asynchronously as a side effect of creating or altering a `Directory`. Interestingly, we have a set of tests that cover the handling of these status classes. For example:

https://github.com/atom/tree-view/blob/cadf5c6aa345cc67028da3fb8b8767813ff34d18/spec/tree-view-package-spec.coffee#L3276-L3278

And even more interestingly, those tests explicitly configure the tree view to use *synchronous* file system calls before asserting the state of the `status-*` classes:

https://github.com/atom/tree-view/blob/cadf5c6aa345cc67028da3fb8b8767813ff34d18/spec/tree-view-package-spec.coffee#L3243

Given that the failure we're seeing has to do with a missing `status-added` class, it seems like the intermittent test failure is the result of a nondeterministic behavior due to *asynchronous* file system calls.

#### Proposed solution

https://github.com/atom/tree-view/compare/1b731e365c8678a81d6f4b6373ff0738086de577...bcbf9913ac629923aa1015d41aba3ea6e1dd3942 explored the possibility of updating the test to use *synchronous* file system calls, but that approach is insufficient/problematic for the reasons described in https://github.com/atom/tree-view/pull/1288#issuecomment-440880435.

Instead, as described in https://github.com/atom/tree-view/pull/1288#issuecomment-441666990, this pull request updates the test to be less fragile while still exercising the core functionality under test. Instead of asserting a character-by-character match of the original tree-view HTML and the re-created tree-view HTML (which is dependent on asynchronous Git status operations), the updated implementation ensures that the number of entries in the original tree-view matches the number of entries in the re-created tree-view. To me, this feels like it strikes a nice balance:

- It should avoid the intermittent failures that we've been seeing in this test, and ...
- It should still fail if we make a change that prevents the tree-view from being re-created after it gets destroyed (which is the essence of the test)

### Alternate Designs

See https://github.com/atom/tree-view/pull/1288#issuecomment-440880435, which discusses an alternative based on the use of `useSyncFS` and `updateRoots`.

### Benefits

Assuming this works, the test will consistently pass :pray:

### Possible Drawbacks

None that I'm aware of

### Applicable Issues

Refs https://github.com/atom/tree-view/pull/789 (which introduced the use of synchronous file system calls for the set of tests referenced above)

Closes #1276
