### PR TITLE
Restrict drag-and-drop actions to events from the Tree View

### DIFF
--- a/lib/root-drag-and-drop.coffee
+++ b/lib/root-drag-and-drop.coffee
@@ -27,7 +27,7 @@ class RootDragAndDropHandler
     return unless @treeView.list.contains(e.target)
 
     @prevDropTargetIndex = null
-    e.dataTransfer.setData 'atom-tree-view-event', 'true'
+    e.dataTransfer.setData 'atom-tree-view-root-event', 'true'
     projectRoot = e.target.closest('.project-root')
     directory = projectRoot.directory
 
@@ -54,26 +54,27 @@ class RootDragAndDropHandler
 
   onDragEnter: (e) ->
     return unless @treeView.list.contains(e.target)
+    return unless @isAtomTreeViewEvent(e)
 
     e.stopPropagation()
 
   onDragLeave: (e) =>
     return unless @treeView.list.contains(e.target)
+    return unless @isAtomTreeViewEvent(e)
 
     e.stopPropagation()
     @removePlaceholder() if e.target is e.currentTarget
 
   onDragEnd: (e) =>
     return unless e.target.matches('.project-root-header')
+    return unless @isAtomTreeViewEvent(e)
 
     e.stopPropagation()
     @clearDropTarget()
 
   onDragOver: (e) =>
     return unless @treeView.list.contains(e.target)
-
-    unless @isAtomTreeViewEvent(e)
-      return
+    return unless @isAtomTreeViewEvent(e)
 
     e.preventDefault()
     e.stopPropagation()
@@ -115,13 +116,12 @@ class RootDragAndDropHandler
 
   onDrop: (e) =>
     return unless @treeView.list.contains(e.target)
+    return unless @isAtomTreeViewEvent(e)
 
     e.preventDefault()
     e.stopPropagation()
 
     {dataTransfer} = e
-
-    return unless @isAtomTreeViewEvent(e)
 
     fromWindowId = parseInt(dataTransfer.getData('from-window-id'))
     fromRootPath  = dataTransfer.getData('from-root-path')
@@ -179,7 +179,7 @@ class RootDragAndDropHandler
 
   isAtomTreeViewEvent: (e) ->
     for item in e.dataTransfer.items
-      if item.type is 'atom-tree-view-event'
+      if item.type is 'atom-tree-view-root-event'
         return true
 
     return false

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -986,6 +986,7 @@ class TreeView
   onDragEnter: (e) =>
     if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
+      return unless @isAtomTreeViewEvent(e)
 
       e.stopPropagation()
 
@@ -998,6 +999,7 @@ class TreeView
   onDragLeave: (e) =>
     if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
+      return unless @isAtomTreeViewEvent(e)
 
       e.stopPropagation()
 
@@ -1045,6 +1047,7 @@ class TreeView
       e.dataTransfer.effectAllowed = "move"
       e.dataTransfer.setDragImage(dragImage, 0, 0)
       e.dataTransfer.setData("initialPaths", initialPaths)
+      e.dataTransfer.setData("atom-tree-view-event", "true")
 
       window.requestAnimationFrame ->
         dragImage.remove()
@@ -1053,6 +1056,7 @@ class TreeView
   onDragOver: (e) ->
     if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
+      return unless @isAtomTreeViewEvent(e)
 
       e.preventDefault()
       e.stopPropagation()
@@ -1097,6 +1101,13 @@ class TreeView
     else if e.dataTransfer.files.length
       # Drop event from OS that isn't targeting a folder: add a new project folder
       atom.project.addPath(entry.path) for entry in e.dataTransfer.files
+
+  isAtomTreeViewEvent: (e) ->
+    for item in e.dataTransfer.items
+      if item.type is 'atom-tree-view-event' or item.kind is 'file'
+        return true
+
+    return false
 
   isVisible: ->
     @element.offsetWidth isnt 0 or @element.offsetHeight isnt 0

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1069,6 +1069,7 @@ class TreeView
     @dragEventCounts = new WeakMap
     if entry = e.target.closest('.entry.directory')
       return if @rootDragAndDrop.isDragging(e)
+      return unless @isAtomTreeViewEvent(e)
 
       e.preventDefault()
       e.stopPropagation()

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -3,6 +3,11 @@ module.exports.buildInternalDragEvents = (dragged, enterTarget, dropTarget, tree
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
+    clearData: (key) ->
+      if key
+        delete @data[key]
+      else
+        @data = {}
     setDragImage: (@image) -> return
 
   Object.defineProperty(
@@ -38,6 +43,11 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
+    clearData: (key) ->
+      if key
+        delete @data[key]
+      else
+        @data = {}
     files: []
 
   Object.defineProperty(
@@ -63,7 +73,7 @@ buildElementPositionalDragEvents = (el, dataTransfer, currentTargetSelector) ->
 
   currentTarget = if currentTargetSelector then el.closest(currentTargetSelector) else el
 
-  topEvent = new DragEvent('dragstart')
+  topEvent = new DragEvent('dragover')
   Object.defineProperty(topEvent, 'target', value: el)
   Object.defineProperty(topEvent, 'currentTarget', value: currentTarget)
   Object.defineProperty(topEvent, 'dataTransfer', value: dataTransfer)
@@ -75,7 +85,7 @@ buildElementPositionalDragEvents = (el, dataTransfer, currentTargetSelector) ->
   Object.defineProperty(middleEvent, 'dataTransfer', value: dataTransfer)
   Object.defineProperty(middleEvent, 'pageY', value: el.getBoundingClientRect().top + el.offsetHeight * 0.5)
 
-  bottomEvent = new DragEvent('dragend')
+  bottomEvent = new DragEvent('dragover')
   Object.defineProperty(bottomEvent, 'target', value: el)
   Object.defineProperty(bottomEvent, 'currentTarget', value: currentTarget)
   Object.defineProperty(bottomEvent, 'dataTransfer', value: dataTransfer)
@@ -89,6 +99,11 @@ module.exports.buildPositionalDragEvents = (dragged, target, currentTargetSelect
     data: {}
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
+    clearData: (key) ->
+      if key
+        delete @data[key]
+      else
+        @data = {}
     setDragImage: (@image) -> return
 
   Object.defineProperty(

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -54,7 +54,7 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
     dataTransfer,
     'items',
     get: ->
-      Object.keys(dataTransfer.data).map((key) -> {type: key})
+      Object.keys(dataTransfer.data).map((key) -> {type: key, kind: 'file'})
   )
 
   dropEvent = new DragEvent('drop')
@@ -64,6 +64,7 @@ module.exports.buildExternalDropEvent = (filePaths, dropTarget) ->
 
   for filePath in filePaths
     dropEvent.dataTransfer.files.push({path: filePath})
+    dropEvent.dataTransfer.setData(filePath, 'bla') # Not technically correct, but gets the job done
 
   dropEvent
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -4122,9 +4122,8 @@ describe "TreeView", ->
 
         dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath], alphaDir)
 
-        runs ->
-          treeView.onDrop(dropEvent)
-          expect(alphaDir.children.length).toBe 2
+        treeView.onDrop(dropEvent)
+        expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
           findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 2
@@ -4156,9 +4155,8 @@ describe "TreeView", ->
 
         dropEvent = eventHelpers.buildExternalDropEvent([deltaFilePath, gammaDirPath], alphaDir)
 
-        runs ->
-          treeView.onDrop(dropEvent)
-          expect(alphaDir.children.length).toBe 2
+        treeView.onDrop(dropEvent)
+        expect(alphaDir.children.length).toBe 2
 
         waitsFor "directory view contents to refresh", ->
           findDirectoryContainingText(treeView.roots[0], 'alpha').querySelectorAll('.entry').length > 3

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -4538,6 +4538,7 @@ describe "TreeView", ->
         dragStartEvent.dataTransfer.clearData('atom-tree-view-root-event')
         dragOverEvents.top.dataTransfer.clearData('atom-tree-view-root-event')
         dragEndEvent.dataTransfer.clearData('atom-tree-view-root-event')
+
         treeView.rootDragAndDrop.onDragOver(dragOverEvents.top)
         expect(alphaDir.previousSibling).not.toHaveClass('placeholder')
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -4469,7 +4469,7 @@ describe "TreeView", ->
         [_, dragDropEvents] = eventHelpers.buildPositionalDragEvents(null, alphaDir.querySelector('.project-root-header'), '.tree-view')
 
         dropEvent = dragDropEvents.bottom
-        dropEvent.dataTransfer.setData('atom-tree-view-event', true)
+        dropEvent.dataTransfer.setData('atom-tree-view-root-event', true)
         dropEvent.dataTransfer.setData('from-window-id', treeView.rootDragAndDrop.getWindowId() + 1)
         dropEvent.dataTransfer.setData('from-root-path', etaDirPath)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, the Tree View would respond to all items dragged over it, irrespective of whether or not any action could be performed with said item. This would result in the _illusion_ of being able to drop anything onto the Tree View, whereas in reality the drop action wouldn't do anything.

With this PR, the Tree View only responds when it knows that it can handle the event.

| Before | After |
|--------|-------|
|![tree-view-drag-and-drop-before](https://user-images.githubusercontent.com/2766036/50309932-84a79680-046e-11e9-932d-d42fc28084e7.gif)|![tree-view-drag-and-drop-after](https://user-images.githubusercontent.com/2766036/50309939-88d3b400-046e-11e9-98d2-7e92d12faa02.gif)|

(Note: you'll notice that an empty pane is still created. Fixed in atom/tabs#550)

### Alternate Designs

None.

### Benefits

There are two benefits.
1. Tree View folders will not be incorrectly highlighted when something that can't be dropped onto the Tree View is dragged over it.
2. Tree View does not unnecessarily prevent drag-and-drop event propagation, meaning that other packages (such as Tabs) can continue to receive those events.

### Possible Drawbacks

In the unlikely event that someone was using the `atom-tree-view-event` or `initialPaths` data items in a different package to work with the Tree View, that functionality will break. They will now need to use `atom-tree-view-root-event` and `atom-tree-view-event` (in addition to `initialPaths`), respectively.

### Applicable Issues

atom/tabs#539, which prior to this PR was not working correctly when a tab was dragged over the Tree View as it was preventing any drag-and-drop events from propagating up to the tabs package.