### PR TITLE
⬆️ temp@0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@atom/temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@atom/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha1-RVFIywz2ygNI5xpc+ZiGq8rERek=",
-      "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.6.2"
-      }
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -1369,7 +1360,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -1872,6 +1864,14 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      }
+    },
+    "temp": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
+      "requires": {
+        "rimraf": "~2.6.2"
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fs-plus": "^3.0.0",
     "minimatch": "~0.3.0",
     "pathwatcher": "^8.0.0",
-    "@atom/temp": "~0.8.4",
+    "temp": "~0.9.0",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('@atom/temp').track()
+temp = require('temp').track()
 
 fileIcons = require '../lib/default-file-icons'
 

--- a/spec/file-stats-spec.coffee
+++ b/spec/file-stats-spec.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('@atom/temp').track()
+temp = require('temp').track()
 
 describe "FileStats", ->
   describe "provision of filesystem stats", ->

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
-temp = require('@atom/temp').track()
+temp = require('temp').track()
 os = require 'os'
 {remote, shell} = require 'electron'
 Directory = require '../lib/directory'


### PR DESCRIPTION
https://github.com/atom/tree-view/pull/1225 switched tree-view from using the official `temp` module to using a fork of the `temp` module ([@atom/temp](https://github.com/atom/node-temp)). We adopted the fork in order to get a newer version of rimraf: https://github.com/atom/node-temp/commit/b5266daad693ec90a83180135ead5c566a97c1b7

Since the time we created the fork, the official `temp` module has upgraded to the same version of rimraf that we're using in our fork: https://github.com/bruce/node-temp/commit/b5266daad693ec90a83180135ead5c566a97c1b7  

With that in mind, I think we can switch back to using the official `temp` module, and we can decommission our fork.

/xref https://github.com/atom/atom/issues/18991#issuecomment-482194708

/fyi @50Wliu @daviwil 

---

*List of changes between `@atom/temp@0.8.4` and `temp@0.9.0`: https://github.com/atom/node-temp/compare/v0.8.4...upstream-v0.9.0*
