### PR TITLE
♿️ Restore platform-centric menu names for showing in file manager

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -560,13 +560,22 @@ class TreeView
     return unless filePath = @selectedEntry()?.getPath()
 
     unless shell.showItemInFolder(filePath)
-      atom.notifications.addWarning("Unable to show #{filePath} in file manager")
+      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName().toLowerCase()}")
 
   showCurrentFileInFileManager: ->
     return unless filePath = atom.workspace.getCenter().getActiveTextEditor()?.getPath()
 
     unless shell.showItemInFolder(filePath)
-      atom.notifications.addWarning("Unable to show #{filePath} in file manager")
+      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName().toLowerCase()}")
+
+  getFileManagerName: ->
+    switch process.platform
+      when 'darwin'
+        return 'Finder'
+      when 'win32'
+        return 'Explorer'
+      else
+        return 'File Manager'
 
   openSelectedEntryInNewWindow: ->
     if pathToOpen = @selectedEntry()?.getPath()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -560,13 +560,13 @@ class TreeView
     return unless filePath = @selectedEntry()?.getPath()
 
     unless shell.showItemInFolder(filePath)
-      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName().toLowerCase()}")
+      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName()}")
 
   showCurrentFileInFileManager: ->
     return unless filePath = atom.workspace.getCenter().getActiveTextEditor()?.getPath()
 
     unless shell.showItemInFolder(filePath)
-      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName().toLowerCase()}")
+      atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName()}")
 
   getFileManagerName: ->
     switch process.platform

--- a/menus/tree-view.cson
+++ b/menus/tree-view.cson
@@ -39,7 +39,6 @@
     {'label': 'Copy Full Path', 'command': 'tree-view:copy-full-path'}
     {'label': 'Copy Project Path', 'command': 'tree-view:copy-project-path'}
     {'label': 'Open in New Window', 'command': 'tree-view:open-in-new-window'}
-    {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
   ]
 
   '.tree-view .full-menu [is="tree-view-file"]': [
@@ -73,6 +72,18 @@
     {'label': 'Open in New Window', 'command': 'tree-view:open-in-new-window'}
   ]
 
+  '.platform-darwin .tree-view .full-menu': [
+    {'label': 'Reveal in Finder', 'command': 'tree-view:show-in-file-manager'}
+  ]
+
+  '.platform-win32 .tree-view .full-menu': [
+    {'label': 'Show in Explorer', 'command': 'tree-view:show-in-file-manager'}
+  ]
+
+  '.platform-linux .tree-view .full-menu': [
+    {'label': 'Show in File Manager', 'command': 'tree-view:show-in-file-manager'}
+  ]
+
   '.tree-view .multi-select': [
     {'label': 'Delete', 'command': 'tree-view:remove'}
     {'label': 'Copy', 'command': 'tree-view:copy'}
@@ -87,9 +98,28 @@
   'atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Rename', 'command': 'tree-view:rename'}
     {'label': 'Reveal in Tree View', 'command': 'tree-view:reveal-active-file'}
+  ]
+
+  '.platform-darwin atom-pane[data-active-item-path] .tab.active': [
+    {'label': 'Reveal In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-win32 atom-pane[data-active-item-path] .tab.active': [
+    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-linux atom-pane[data-active-item-path] .tab.active': [
     {'label': 'Show in File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]
 
-  'atom-text-editor:not([mini])': [
+  '.platform-darwin atom-text-editor:not([mini])': [
+    {'label': 'Reveal In Finder', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-win32 atom-text-editor:not([mini])': [
+    {'label': 'Show In Explorer', 'command': 'tree-view:show-current-file-in-file-manager'}
+  ]
+
+  '.platform-linux atom-text-editor:not([mini])': [
     {'label': 'Show in File Manager', 'command': 'tree-view:show-current-file-in-file-manager'}
   ]


### PR DESCRIPTION
### Description of the Change

Addresses #1307. Restore platform-centric menu names for showing files in the user's file manager.

### Benefits

- Following each platform's idiomatic naming conventions will improve usability.

### Possible Drawbacks

- The name of the platform's default file manager is always used. This will be slightly misleading if `shell.showItemInFolder` opens a third-party file manager.

### Applicable Issues

- #1307 
- #1266
- atom/atom#18694