### PR TITLE
Always show Tree View

### DIFF
--- a/lib/add-projects-view.js
+++ b/lib/add-projects-view.js
@@ -6,23 +6,16 @@ class AddProjectView {
 
     this.icon = document.createElement('div')
     this.icon.classList.add('icon', 'icon-large', 'icon-telescope')
-
     this.element.appendChild(this.icon)
-
-    this.title = document.createElement('h1')
-    this.title.innerText = 'Add projects'
-
-    this.element.appendChild(this.title)
 
     this.description = document.createElement('div')
     this.description.classList.add('description')
-    this.description.innerText = 'Add or reopen projects to view their contents'
-
+    this.description.innerText = 'Your project is currently empty'
     this.element.appendChild(this.description)
 
     this.addProjectsButton = document.createElement('button')
     this.addProjectsButton.classList.add('btn', 'btn-primary')
-    this.addProjectsButton.innerText = 'Add projects'
+    this.addProjectsButton.innerText = 'Add folders'
     this.addProjectsButton.addEventListener('click', () => {
       atom.pickFolder(paths => {
         if (paths) {
@@ -30,16 +23,14 @@ class AddProjectView {
         }
       })
     })
-
     this.element.appendChild(this.addProjectsButton)
 
     this.reopenProjectButton = document.createElement('button')
     this.reopenProjectButton.classList.add('btn')
-    this.reopenProjectButton.innerText = 'Reopen project'
+    this.reopenProjectButton.innerText = 'Reopen a project'
     this.reopenProjectButton.addEventListener('click', () => {
       atom.commands.dispatch(this.element, 'application:reopen-project')
     })
-
     this.element.appendChild(this.reopenProjectButton)
   }
 }

--- a/lib/add-projects-view.js
+++ b/lib/add-projects-view.js
@@ -1,45 +1,45 @@
 module.exports =
 class AddProjectView {
-	constructor () {
-		this.element = document.createElement('div')
-		this.element.id = 'add-projects-view'
+  constructor () {
+    this.element = document.createElement('div')
+    this.element.id = 'add-projects-view'
 
-		this.icon = document.createElement('div')
-		this.icon.classList.add('icon', 'icon-large', 'icon-telescope')
+    this.icon = document.createElement('div')
+    this.icon.classList.add('icon', 'icon-large', 'icon-telescope')
 
-		this.element.appendChild(this.icon)
+    this.element.appendChild(this.icon)
 
-		this.title = document.createElement('h1')
-		this.title.innerText = 'Add projects'
+    this.title = document.createElement('h1')
+    this.title.innerText = 'Add projects'
 
-		this.element.appendChild(this.title)
+    this.element.appendChild(this.title)
 
-		this.description = document.createElement('div')
-		this.description.classList.add('description')
-		this.description.innerText = 'Add or reopen projects to view their contents'
+    this.description = document.createElement('div')
+    this.description.classList.add('description')
+    this.description.innerText = 'Add or reopen projects to view their contents'
 
-		this.element.appendChild(this.description)
+    this.element.appendChild(this.description)
 
-		this.addProjectsButton = document.createElement('button')
-		this.addProjectsButton.classList.add('btn', 'btn-primary')
-		this.addProjectsButton.innerText = 'Add projects'
-		this.addProjectsButton.addEventListener('click', () => {
-			atom.pickFolder(paths => {
-				if (paths) {
-					atom.project.setPaths(paths)
-				}
-			})
-		})
+    this.addProjectsButton = document.createElement('button')
+    this.addProjectsButton.classList.add('btn', 'btn-primary')
+    this.addProjectsButton.innerText = 'Add projects'
+    this.addProjectsButton.addEventListener('click', () => {
+      atom.pickFolder(paths => {
+        if (paths) {
+          atom.project.setPaths(paths)
+        }
+      })
+    })
 
-		this.element.appendChild(this.addProjectsButton)
+    this.element.appendChild(this.addProjectsButton)
 
-		this.reopenProjectButton = document.createElement('button')
-		this.reopenProjectButton.classList.add('btn')
-		this.reopenProjectButton.innerText = 'Reopen project'
-		this.reopenProjectButton.addEventListener('click', () => {
-			atom.commands.dispatch(this.element, 'application:reopen-project')
-		})
+    this.reopenProjectButton = document.createElement('button')
+    this.reopenProjectButton.classList.add('btn')
+    this.reopenProjectButton.innerText = 'Reopen project'
+    this.reopenProjectButton.addEventListener('click', () => {
+      atom.commands.dispatch(this.element, 'application:reopen-project')
+    })
 
-		this.element.appendChild(this.reopenProjectButton)
-	}
+    this.element.appendChild(this.reopenProjectButton)
+  }
 }

--- a/lib/add-projects-view.js
+++ b/lib/add-projects-view.js
@@ -1,0 +1,45 @@
+module.exports =
+class AddProjectView {
+	constructor () {
+		this.element = document.createElement('div')
+		this.element.id = 'add-projects-view'
+
+		this.icon = document.createElement('div')
+		this.icon.classList.add('icon', 'icon-large', 'icon-telescope')
+
+		this.element.appendChild(this.icon)
+
+		this.title = document.createElement('h1')
+		this.title.innerText = 'Add projects'
+
+		this.element.appendChild(this.title)
+
+		this.description = document.createElement('div')
+		this.description.classList.add('description')
+		this.description.innerText = 'Add or reopen projects to view their contents'
+
+		this.element.appendChild(this.description)
+
+		this.addProjectsButton = document.createElement('button')
+		this.addProjectsButton.classList.add('btn', 'btn-primary')
+		this.addProjectsButton.innerText = 'Add projects'
+		this.addProjectsButton.addEventListener('click', () => {
+			atom.pickFolder(paths => {
+				if (paths) {
+					atom.project.setPaths(paths)
+				}
+			})
+		})
+
+		this.element.appendChild(this.addProjectsButton)
+
+		this.reopenProjectButton = document.createElement('button')
+		this.reopenProjectButton.classList.add('btn')
+		this.reopenProjectButton.innerText = 'Reopen project'
+		this.reopenProjectButton.addEventListener('click', () => {
+			atom.commands.dispatch(this.element, 'application:reopen-project')
+		})
+
+		this.element.appendChild(this.reopenProjectButton)
+	}
+}

--- a/lib/get-icon-services.js
+++ b/lib/get-icon-services.js
@@ -49,6 +49,9 @@ class IconServices {
   }
 
   updateDirectoryIcon (view) {
+    view.directoryName.className = ''
+
+    const classes = ['name', 'icon']
     if (this.elementIcons) {
       const disposable = this.elementIcons(view.directoryName, view.directory.path)
       this.elementIconDisposables.add(disposable)
@@ -65,11 +68,14 @@ class IconServices {
           if (view.directory.submodule) iconClass = 'icon-file-submodule'
         }
       }
-      view.directoryName.classList.add(iconClass)
+      classes.push(iconClass)
+      view.directoryName.classList.add(...classes)
     }
   }
 
   updateFileIcon (view) {
+    view.fileName.className = ''
+
     const classes = ['name', 'icon']
     let iconClass
     if (this.elementIcons) {
@@ -81,7 +87,8 @@ class IconServices {
     if (iconClass) {
       if (!Array.isArray(iconClass)) {
         iconClass = iconClass.toString().split(/\s+/g)
-      } classes.push(...iconClass)
+      }
+      classes.push(...iconClass)
     }
     view.fileName.classList.add(...classes)
   }

--- a/lib/get-icon-services.js
+++ b/lib/get-icon-services.js
@@ -69,8 +69,8 @@ class IconServices {
         }
       }
       classes.push(iconClass)
-      view.directoryName.classList.add(...classes)
     }
+    view.directoryName.classList.add(...classes)
   }
 
   updateFileIcon (view) {

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -1,5 +1,4 @@
 const {Disposable, CompositeDisposable} = require('atom')
-const path = require('path')
 
 const getIconServices = require('./get-icon-services')
 const TreeView = require('./tree-view')

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -21,18 +21,12 @@ class TreeViewPackage {
       'tree-view:show-current-file-in-file-manager': () => this.getTreeViewInstance().showCurrentFileInFileManager()
     }))
 
-    this.disposables.add(atom.project.onDidChangePaths(this.createOrDestroyTreeViewIfNeeded.bind(this)))
-
-    if (this.shouldAttachTreeView()) {
-      const treeView = this.getTreeViewInstance()
-      const showOnAttach = !atom.workspace.getActivePaneItem()
-      this.treeViewOpenPromise = atom.workspace.open(treeView, {
-        activatePane: showOnAttach,
-        activateItem: showOnAttach
-      })
-    } else {
-      this.treeViewOpenPromise = Promise.resolve()
-    }
+    const treeView = this.getTreeViewInstance()
+    const showOnAttach = !atom.workspace.getActivePaneItem()
+    this.treeViewOpenPromise = atom.workspace.open(treeView, {
+      activatePane: showOnAttach,
+      activateItem: showOnAttach
+    })
   }
 
   async deactivate () {
@@ -71,44 +65,5 @@ class TreeViewPackage {
       this.treeView.onDidDestroy(() => { this.treeView = null })
     }
     return this.treeView
-  }
-
-  createOrDestroyTreeViewIfNeeded () {
-    if (this.shouldAttachTreeView()) {
-      const treeView = this.getTreeViewInstance()
-      const paneContainer = atom.workspace.paneContainerForURI(treeView.getURI())
-      if (paneContainer) {
-        paneContainer.show()
-      } else {
-        atom.workspace.open(treeView, {
-          activatePane: false,
-          activateItem: false
-        }).then(() => {
-          const paneContainer = atom.workspace.paneContainerForURI(treeView.getURI())
-          if (paneContainer) paneContainer.show()
-        })
-      }
-    } else {
-      if (this.treeView) {
-        const pane = atom.workspace.paneForItem(this.treeView)
-        if (pane) pane.removeItem(this.treeView)
-      }
-    }
-  }
-
-  shouldAttachTreeView () {
-    if (atom.project.getPaths().length === 0) return false
-
-    // Avoid opening the tree view if Atom was opened as the Git editor...
-    // Only show it if the .git folder was explicitly opened.
-    if (path.basename(atom.project.getPaths()[0]) === '.git') {
-      return atom.project.getPaths()[0] === atom.getLoadSettings().pathToOpen
-    }
-
-    return true
-  }
-
-  shouldShowTreeViewAfterAttaching () {
-    if (atom.workspace.getActivePaneItem()) return false
   }
 }

--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -45,10 +45,8 @@ class TreeViewPackage {
 
   consumeFileIcons (service) {
     getIconServices().setFileIcons(service)
-    if (this.treeView) this.treeView.updateRoots()
     return new Disposable(() => {
       getIconServices().resetFileIcons()
-      if (this.treeView) this.treeView.updateRoots()
     })
   }
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -11,6 +11,8 @@ MoveDialog = require './move-dialog'
 CopyDialog = require './copy-dialog'
 IgnoredNames = null # Defer requiring until actually needed
 
+AddProjectsView = require './add-projects-view'
+
 Directory = require './directory'
 DirectoryView = require './directory-view'
 RootDragAndDrop = require './root-drag-and-drop'
@@ -32,7 +34,6 @@ class TreeView
 
     @list = document.createElement('ol')
     @list.classList.add('tree-view-root', 'full-menu', 'list-tree', 'has-collapsable-children', 'focusable-panel')
-    @element.appendChild(@list)
 
     @disposables = new CompositeDisposable
     @emitter = new Emitter
@@ -315,41 +316,56 @@ class TreeView
       atom.workspace.open(uri, options)
 
   updateRoots: (expansionStates={}) ->
-    selectedPaths = @selectedPaths()
-
     oldExpansionStates = {}
     for root in @roots
       oldExpansionStates[root.directory.path] = root.directory.serializeExpansionState()
       root.directory.destroy()
       root.remove()
 
-    IgnoredNames ?= require('./ignored-names')
 
-    @roots = for projectPath in atom.project.getPaths()
-      stats = fs.lstatSyncNoException(projectPath)
-      continue unless stats
-      stats = _.pick stats, _.keys(stats)...
-      for key in ["atime", "birthtime", "ctime", "mtime"]
-        stats[key] = stats[key].getTime()
+    projectPaths = atom.project.getPaths()
+    if projectPaths.length > 0
+      unless @element.getElementsByClassName('tree-view-root')[0]
+        @element.appendChild(@list)
 
-      directory = new Directory({
-        name: path.basename(projectPath)
-        fullPath: projectPath
-        symlink: false
-        isRoot: true
-        expansionState: expansionStates[projectPath] ?
-                        oldExpansionStates[projectPath] ?
-                        {isExpanded: true}
-        ignoredNames: new IgnoredNames()
-        @useSyncFS
-        stats
-      })
-      root = new DirectoryView(directory).element
-      @list.appendChild(root)
-      root
+      addProjectsViewElement = document.getElementById('add-projects-view')
+      @element.removeChild(addProjectsViewElement) if addProjectsViewElement
 
-    # The DOM has been recreated; reselect everything
-    @selectMultipleEntries(@entryForPath(selectedPath)) for selectedPath in selectedPaths
+      selectedPaths = @selectedPaths()
+
+      IgnoredNames ?= require('./ignored-names')
+
+      @roots = for projectPath in projectPaths
+        stats = fs.lstatSyncNoException(projectPath)
+        continue unless stats
+        stats = _.pick stats, _.keys(stats)...
+        for key in ["atime", "birthtime", "ctime", "mtime"]
+          stats[key] = stats[key].getTime()
+
+        directory = new Directory({
+          name: path.basename(projectPath)
+          fullPath: projectPath
+          symlink: false
+          isRoot: true
+          expansionState: expansionStates[projectPath] ?
+                          oldExpansionStates[projectPath] ?
+                          {isExpanded: true}
+          ignoredNames: new IgnoredNames()
+          @useSyncFS
+          stats
+        })
+        root = new DirectoryView(directory).element
+        @list.appendChild(root)
+        root
+
+      # The DOM has been recreated; reselect everything
+      @selectMultipleEntries(@entryForPath(selectedPath)) for selectedPath in selectedPaths
+    else
+      if @element.getElementsByClassName('tree-view-root')[0]
+        @element.removeChild(@list)
+
+      unless document.getElementById('add-projects-view')
+        @element.appendChild(new AddProjectsView().element)
 
   getActivePath: -> atom.workspace.getCenter().getActivePaneItem()?.getPath?()
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -316,6 +316,8 @@ class TreeView
       atom.workspace.open(uri, options)
 
   updateRoots: (expansionStates={}) ->
+    selectedPaths = @selectedPaths()
+
     oldExpansionStates = {}
     for root in @roots
       oldExpansionStates[root.directory.path] = root.directory.serializeExpansionState()
@@ -330,8 +332,6 @@ class TreeView
 
       addProjectsViewElement = @element.querySelector('#add-projects-view')
       @element.removeChild(addProjectsViewElement) if addProjectsViewElement
-
-      selectedPaths = @selectedPaths()
 
       IgnoredNames ?= require('./ignored-names')
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -326,10 +326,9 @@ class TreeView
 
     projectPaths = atom.project.getPaths()
     if projectPaths.length > 0
-      unless @element.getElementsByClassName('tree-view-root')[0]
-        @element.appendChild(@list)
+      @element.appendChild(@list) unless @element.querySelector('tree-view-root')
 
-      addProjectsViewElement = document.getElementById('add-projects-view')
+      addProjectsViewElement = @element.querySelector('#add-projects-view')
       @element.removeChild(addProjectsViewElement) if addProjectsViewElement
 
       selectedPaths = @selectedPaths()
@@ -362,11 +361,8 @@ class TreeView
       # The DOM has been recreated; reselect everything
       @selectMultipleEntries(@entryForPath(selectedPath)) for selectedPath in selectedPaths
     else
-      if @element.getElementsByClassName('tree-view-root')[0]
-        @element.removeChild(@list)
-
-      unless document.getElementById('add-projects-view')
-        @element.appendChild(new AddProjectsView().element)
+      @element.removeChild(@list) if @element.querySelector('.tree-view-root')
+      @element.appendChild(new AddProjectsView().element) unless @element.querySelector('#add-projects-view')
 
   getActivePath: -> atom.workspace.getCenter().getActivePaneItem()?.getPath?()
 

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -322,6 +322,7 @@ class TreeView
       root.directory.destroy()
       root.remove()
 
+    @roots = []
 
     projectPaths = atom.project.getPaths()
     if projectPaths.length > 0

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -13,6 +13,41 @@
   display: flex;
   flex-direction: column;
 
+  #add-projects-view {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    font-size: 1.25em;
+    padding: 30px;
+    cursor: default;
+
+    > * {
+      margin: 10px 0;
+    }
+
+    h1 {
+      margin-bottom: 30px;
+    }
+
+    .description {
+      margin: 10px 0;
+    }
+
+    .icon::before {
+      color: #c1c1c1;
+    }
+  }
+
+  .icon-large::before {
+    margin-right: 0;
+    margin-bottom: 50px;
+    width: auto;
+    height: auto;
+    font-size: 8em;
+  }
+
   .tree-view-root {
     padding-left: @component-icon-padding;
     padding-right: @component-padding;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -27,10 +27,6 @@
       margin: 10px 0;
     }
 
-    h1 {
-      margin-bottom: 30px;
-    }
-
     .description {
       margin: 10px 0;
     }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The Tree View isn't created if no projects are open in a window, limiting discoverability of how to add a project. To make it easier to add projects, this PR now always shows the Tree View. If no projects are open, the Tree View prompts to add projects:
![tree-view-add-projects](https://user-images.githubusercontent.com/2766036/57207314-b0996380-6f9a-11e9-815e-069efcfc3980.png)

### Alternate Designs

None.

### Benefits

Easier to add projects directly through the Tree View.

### Possible Drawbacks

Tree View will now appear, even when no projects are open.

### Applicable Issues

Refs #1313. There currently is no way to "promote" a single file to a full project without manually selecting its project root.
Closes #1312
Fixes #68

### Todo
* [ ] A lot of the styles for the new view were copied over from the GitHub package. Is there a way to improve on that situation, somehow...?
* [ ] Some potential functionality-changing behavior with regards to consuming file icons. I did this so that `updateRoots` wasn't called twice in a row on startup, which sometimes led to two of the add-project-views being added to the DOM.