### PR TITLE
Typo in Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "alwaysOpenExisting": {
       "type": "boolean",
       "default": false,
-      "description": "When opening a file, always focus an already-existing view of the file even if it's in a another pane."
+      "description": "When opening a file, always focus an already-existing view of the file even if it's in another pane."
     }
   }
 }


### PR DESCRIPTION
Change "a another" to "another" in the Settings view