### PR TITLE
replace autoReveal config with autoTrackActiveFile.{enabled,autoScroll}

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -243,8 +243,13 @@ class TreeView
         @openSelectedEntryInPane index
 
     @disposables.add atom.workspace.getCenter().onDidChangeActivePaneItem =>
-      @selectActiveFile()
-      @revealActiveFile({show: false, focus: false}) if atom.config.get('tree-view.autoReveal')
+      # migrate old tree-view.autoReveal config
+      if atom.config.get 'tree-view.autoReveal'
+        atom.config.set 'tree-view.autoTrackActivePane.autoReveal', true
+        atom.config.unset 'tree-view.autoReveal'
+      autoTrackActivePane = atom.config.get('tree-view.autoTrackActivePane.enabled')
+      @selectActiveFile() if autoTrackActivePane
+      @revealActiveFile({show: false, focus: false}) if autoTrackActivePane and atom.config.get('tree-view.autoTrackActivePane.autoReveal')
     @disposables.add atom.project.onDidChangePaths =>
       @updateRoots()
     @disposables.add atom.config.onDidChange 'tree-view.hideVcsIgnoredFiles', =>

--- a/package.json
+++ b/package.json
@@ -80,15 +80,31 @@
       "default": true,
       "description": "When listing directory items, list subdirectories before listing files."
     },
-    "autoReveal": {
-      "type": "boolean",
-      "default": false,
-      "description": "Reveal tree view entries when they become the active pane item."
+    "autoTrackActivePane": {
+      "type": "object",
+      "title": "Auto Select Active Pane",
+      "description": "The Active Pane is typically the focused editor buffer", 
+      "properties": {
+        "enabled": {
+          "order": 1,
+          "title": "Enabled",
+          "type": "boolean",
+          "default": true,
+          "description": "Change the selected tree node to reflect the active pane item as it changes."
+        },
+        "autoReveal": {
+          "order": 2,
+          "title": "Auto Reveal",
+          "type": "boolean",
+          "default": false,
+          "description": "If the new tree selection is not visible, expand and scroll as needed to reveal it into view."
+        }
+      }
     },
     "focusOnReveal": {
       "type": "boolean",
       "default": true,
-      "description": "Focus the tree view when revealing entries."
+      "description": "Make the `Reveal Active File` command focus the tree view after it selects and reveals the active pane item"
     },
     "alwaysOpenExisting": {
       "type": "boolean",

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -776,10 +776,10 @@ describe "TreeView", ->
           dirView = root1.querySelector('.directory')
           expect(dirView).toHaveClass 'selected'
 
-      describe "when the tree-view.autoReveal config setting is true", ->
+      describe "when the tree-view.autoTrackActivePane.autoReveal config setting is true", ->
         beforeEach ->
           jasmine.attachToDOM(atom.workspace.getElement())
-          atom.config.set "tree-view.autoReveal", true
+          atom.config.set "tree-view.autoTrackActivePane.autoReveal", true
 
         it "selects the active item's entry in the tree view, expanding parent directories if needed", ->
           waitsForPromise ->
@@ -790,6 +790,27 @@ describe "TreeView", ->
 
           runs ->
             expect(atom.workspace.getActiveTextEditor().getElement()).toHaveFocus()
+
+      describe "when the tree-view.autoTrackActivePane.enabled config setting is false", ->
+        beforeEach ->
+          jasmine.attachToDOM(atom.workspace.getElement())
+          atom.config.set "tree-view.autoTrackActivePane.enabled", false
+
+        it "does not change the selection", ->
+          currentSelection = treeView.getSelectedEntries()[0].textContent
+          console.log "currentSelection="+currentSelection
+          done = false
+          disposable = atom.workspace.getCenter().onDidChangeActivePaneItem =>
+            disposable.dispose()
+            done = true
+
+          waitsForPromise ->
+            atom.workspace.open(path.join('dir1', 'sub-dir1', 'sub-file1'))
+
+          waitsFor -> done
+
+          runs ->
+            expect(treeView.getSelectedEntries()[0].textContent).toBe(currentSelection)
 
   describe "when a different editor becomes active", ->
     beforeEach ->


### PR DESCRIPTION
* closes #1335
* the defaults are Enabled:true, AutoScroll:false which maintains the same default behavior as before this change.
* it migrates the old autoReveal if its present in the config.
  * migration is required not only to keep the user's preference, but also we need to call unset on it so that the Settings View does not keep displaying it even though its no longer in the schema.
* note that I also changed the description of the "Focus On Reveal" config to make it clear that it does not affect Auto Reveal but just the Reveal Active File command.
* I believe that this is 100% non-breaking, backward compatible.

### Description of the Change

Enhance the tree-view config to allow turning off the behavior to change the tree selection when the active pane item changes. 

Moved  tree-view:autoReveal config into a config object that also has an enable boolean 
tree-view:autoTrackActivePane
  |  enable
  '  autoReveal

tree-view's onDidChangeActivePaneItem handler now 1) migrates the old autoReveal to new autoTrackActivePane.autoReveal (if its present) and 2) uses autoTrackActivePane.enable to decide whether to call selectActiveFile and revealActiveFile 


### Alternate Designs

Considered changing autoReveal to an enum. See #1335 

### Benefits

Backward compatible with previous behavior and now allows a new behavior. See #1335 

### Possible Drawbacks

If other packages use  tree-view:autoReveal they should eventually be updated to use autoTrackActivePane.autoReveal instead but in the mean time the impact should not be severe. If they enable autoReveal, it will still take effect because of the migration condition in the code. 

### Applicable Issues

#1335 