### PR TITLE
Add autoopen option

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -21,7 +21,10 @@ class TreeViewPackage {
     }))
 
     const treeView = this.getTreeViewInstance()
-    const showOnAttach = !atom.workspace.getActivePaneItem()
+    const showOnAttach = (
+      atom.config.get('tree-view.showOnAttach') &&
+      !atom.workspace.getActivePaneItem()
+    )
     this.treeViewOpenPromise = atom.workspace.open(treeView, {
       activatePane: showOnAttach,
       activateItem: showOnAttach

--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
       "type": "boolean",
       "default": false,
       "description": "When opening a file, always focus an already-existing view of the file even if it's in another pane."
+    },
+    "showOnAttach": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show tree view when a new window is opened."
     }
   }
 }


### PR DESCRIPTION
Since builds are currently failing #1344 I can't run tests, so leaving them to update after that's resolved. I'm calling this a draft PR until then.

### Description of the Change

Adds boolean config setting Show On Attach to control whether the tree view is automatically shown when a new window is opened.

Default is true to preserve current behavior.

### Alternate Designs

None. The change is small.

### Benefits

Allow keeping the tree view hidden by default. This has been requested for years [on the forum](https://discuss.atom.io/t/hide-treeview-by-default/7718).

### Possible Drawbacks

Choice fatigue. It adds a new option which must be thought through when the configuring the package.

I don't think there are excessive options. After this change there are 8 boolean options. The default value preserves current behavior so most people won't need to think about it.

### Applicable Issues