### PR TITLE
Fix default location getter

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -151,7 +151,7 @@ class TreeView
 
   getURI: -> TREE_VIEW_URI
 
-  getPreferredLocation: ->
+  getDefaultLocation: ->
     if atom.config.get('tree-view.showOnRightSide')
       'right'
     else


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Renames  `getPreferredLocation` to `getDefaultLocation`. The former was introduced in #1056, but the [Dock API](https://flight-manual.atom.io/api/v1.49.0/Workspace/) uses the latter. I don't know if the error was an oversight, or if the API itself changed since then.

There are no references to `getPreferredLocation` in this code base otherwise. The config value itself is intentionally not advertised, as per https://github.com/atom/tree-view/pull/1056#issuecomment-297180562. It was probably intended to be removed at some point, but this PR is just meant to fix the method name, nothing more.

No tests, there were none before and I don't see a point in testing how the Dock controller behaves.

### Alternate Designs

NA

### Benefits

Get's picked up by Dock API.

### Possible Drawbacks

NA

### Applicable Issues

Was brought up in https://discuss.atom.io/t/tree-view-on-the-right-side/76834
