### PR TITLE
Fix Uncaught Error: ENOENT: no such file or directory

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -1111,7 +1111,7 @@ class TreeView
 
       e.dataTransfer.effectAllowed = "move"
       e.dataTransfer.setDragImage(dragImage, 0, 0)
-      e.dataTransfer.setData("initialPaths", initialPaths)
+      e.dataTransfer.setData("initialPaths", JSON.stringify(initialPaths))
       e.dataTransfer.setData("atom-tree-view-event", "true")
 
       window.requestAnimationFrame ->
@@ -1146,7 +1146,7 @@ class TreeView
 
       if initialPaths
         # Drop event from Atom
-        initialPaths = initialPaths.split(',')
+        initialPaths = JSON.parse(initialPaths)
         return if initialPaths.includes(newDirectoryPath)
 
         entry.classList.remove('drag-over', 'selected')


### PR DESCRIPTION


### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Use `JSON.stringify` and `JSON.parse` since setting `initialPaths` using
`e.dataTransfer.setData` sets the array value to a `DOMString`. 

Splitting the initialPaths on `,` fails if the root directory has a ',' as part of its name.

__Relevant links__

- https://developer.mozilla.org/en-US/docs/Web/API/DOMString
- https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setData

### Alternate Designs
We could split `initialPaths` on `,/` but that would mean the items from index `1` onwards would have the incorrect path and we have to append `/` on every path.
consider
```js
initialPaths = '/Users/home/some/file,/Users/home/some/anotherfile'
// If we split on './'
initialPaths = ['/Users/home/some/file', 'Users/home/some/anotherfile']
```

### Benefits
Allow files to be moved to a root directory that has a ',' comma as part of its name


### Possible Drawbacks
Not that i am aware of.

### Applicable Issues
Resolves: https://github.com/atom/tree-view/issues/1357
