### PR TITLE
Do not wipe original file when duplicating

### DIFF
--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -23,7 +23,7 @@ class CopyDialog extends Dialog
       @close()
       return
 
-    unless @isNewPathValid(newPath)
+    if fs.existsSync(newPath)
       @showError("'#{newPath}' already exists.")
       return
 
@@ -46,17 +46,3 @@ class CopyDialog extends Dialog
       @close()
     catch error
       @showError("#{error.message}.")
-
-  isNewPathValid: (newPath) ->
-    try
-      oldStat = fs.statSync(@initialPath)
-      newStat = fs.statSync(newPath)
-
-      # New path exists so check if it points to the same file as the initial
-      # path to see if the case of the file name is being changed on a on a
-      # case insensitive filesystem.
-      @initialPath.toLowerCase() is newPath.toLowerCase() and
-        oldStat.dev is newStat.dev and
-        oldStat.ino is newStat.ino
-    catch
-      true # new path does not exist so it is valid


### PR DESCRIPTION
### Description of the Change

When duplicating a file, if the file already exists, an error should be thrown. Node's `fs.existsSync` is already aware of filesystem case sensitivity, so just checking if a file exists or not is enough. On case-sensitive file systems, it will allow to create a new file with different case. On case-insensitive ones, it will complain that the file already exists.

So for example, in Windows, that is case-insensitive, you can't duplicate `FOO.txt` if `foo.txt` exists. On Linux, that is case-sensitive, you can.

Now this is hard to test, because it depends on the OS-specific behavior. I created a little helper function to check the current FS for case-sensitivity and ran the suite on Windows, and it worked. I also tested the feature manually on macOS. I don't have a Linux setup though, so I was not able to test on Linux. I did test on WSL and `existsSync` was working as expected.

### Alternate Designs

--

### Benefits

This will fix the bug described in https://github.com/atom/atom/issues/20657

### Possible Drawbacks

I did not test the full feature on Linux, only tested on Windows and macOS. I did test the `existsSync` functionality using WSL and it was working as expected.

### Applicable Issues

https://github.com/atom/tree-view/issues/1361
