### PR TITLE
Fixes unable to show file warning

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -572,8 +572,10 @@ class TreeView
   showSelectedEntryInFileManager: ->
     return unless filePath = @selectedEntry()?.getPath()
 
-    unless shell.showItemInFolder(filePath)
+    return unless fs.existsSync(filePath)
       atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName()}")
+    
+    shell.showItemInFolder(filePath)
 
   showCurrentFileInFileManager: ->
     return unless filePath = atom.workspace.getCenter().getActiveTextEditor()?.getPath()

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -574,14 +574,16 @@ class TreeView
 
     return unless fs.existsSync(filePath)
       atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName()}")
-    
+
     shell.showItemInFolder(filePath)
 
   showCurrentFileInFileManager: ->
     return unless filePath = atom.workspace.getCenter().getActiveTextEditor()?.getPath()
 
-    unless shell.showItemInFolder(filePath)
+    return unless fs.existsSync(filePath)
       atom.notifications.addWarning("Unable to show #{filePath} in #{@getFileManagerName()}")
+
+    shell.showItemInFolder(filePath)
 
   getFileManagerName: ->
     switch process.platform

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3854,7 +3854,7 @@ describe "TreeView", ->
       expect(shell.showItemInFolder).toHaveBeenCalled()
 
     it "displays a notification if showing the file fails", ->
-      spyOn(fs,'existsSync').andReturn(false)
+      spyOn(fs, 'existsSync').andReturn(false)
       treeView.showSelectedEntryInFileManager()
       expect(atom.notifications.getNotifications().length).toBe(1)
       expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Unable to show')
@@ -3891,7 +3891,7 @@ describe "TreeView", ->
     it "shows a notification if showing the file fails", ->
       filePath = path.join(os.tmpdir(), 'non-project-file.txt')
       fs.writeFileSync(filePath, 'test')
-      spyOn(fs,'existsSync').andReturn(false)
+      spyOn(fs, 'existsSync').andReturn(false)
       waitsForPromise ->
         atom.workspace.open(filePath)
 

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -3854,6 +3854,7 @@ describe "TreeView", ->
       expect(shell.showItemInFolder).toHaveBeenCalled()
 
     it "displays a notification if showing the file fails", ->
+      spyOn(fs,'existsSync').andReturn(false)
       treeView.showSelectedEntryInFileManager()
       expect(atom.notifications.getNotifications().length).toBe(1)
       expect(atom.notifications.getNotifications()[0].getMessage()).toContain('Unable to show')
@@ -3890,6 +3891,7 @@ describe "TreeView", ->
     it "shows a notification if showing the file fails", ->
       filePath = path.join(os.tmpdir(), 'non-project-file.txt')
       fs.writeFileSync(filePath, 'test')
+      spyOn(fs,'existsSync').andReturn(false)
       waitsForPromise ->
         atom.workspace.open(filePath)
 


### PR DESCRIPTION


### Description of the Change
A change in `showItemInFolder` API broke the reveal in finder feature in tree-view. The [API on electron 5 returns a boolean](https://github.com/electron/electron/blob/v5.0.12/docs/api/shell.md#shellshowiteminfolderfullpath) while [the API on electron 6](https://github.com/electron/electron/blob/v6.1.12/docs/api/shell.md#shellshowiteminfolderfullpath) does not return anything(atom currently run on electron 6), the reveal in finder feature depends on the boolean returned to display a warning.

#### Fixes: https://github.com/atom/atom/issues/21577
