### PR TITLE
Fix subfolder git detection

### DIFF
--- a/lib/add-dialog.coffee
+++ b/lib/add-dialog.coffee
@@ -49,7 +49,8 @@ class AddDialog extends Dialog
           @showError("File names must not end with a '#{path.sep}' character.")
         else
           fs.writeFileSync(newPath, '')
-          repoForPath(newPath)?.getPathStatus(newPath)
+          repoForPath(newPath).then (repo) ->
+            repo?.getPathStatus(newPath)
           @emitter.emit('did-create-file', newPath)
           @close()
       else

--- a/lib/copy-dialog.coffee
+++ b/lib/copy-dialog.coffee
@@ -40,9 +40,10 @@ class CopyDialog extends Dialog
             activatePane: true
             initialLine: activeEditor?.getLastCursor().getBufferRow()
             initialColumn: activeEditor?.getLastCursor().getBufferColumn()
-      if repo = repoForPath(newPath)
-        repo.getPathStatus(@initialPath)
-        repo.getPathStatus(newPath)
+      repoForPath(newPath).then (repo) ->
+        if repo
+          repo.getPathStatus(@initialPath)
+          repo.getPathStatus(newPath)
       @close()
     catch error
       @showError("#{error.message}.")

--- a/lib/directory-view.js
+++ b/lib/directory-view.js
@@ -79,6 +79,10 @@ class DirectoryView {
     getIconServices().updateDirectoryIcon(this)
   }
 
+  updateRepoIcon () {
+    getIconServices().updateRepoDirectoryIcon(this)
+  }
+
   updateStatus () {
     this.element.classList.remove('status-ignored', 'status-ignored-name', 'status-modified', 'status-added')
     if (this.directory.status != null) {
@@ -101,6 +105,11 @@ class DirectoryView {
         } else {
           this.entries.appendChild(view.element)
         }
+      }
+    }),
+    this.directory.onDidStatusChange(() => {
+      if (this.directory.repo) {
+        this.updateRepoIcon()
       }
     }))
   }

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -69,11 +69,18 @@ class Directory {
     this.status = null
     this.entries = new Map()
 
-    const repo = repoForPath(this.path)
-    this.submodule = repo && repo.isSubmodule(this.path)
+    repoForPath(this.path).then((repo) => {
+      this.repo = repo
+      if (repo) {
+        this.submodule = repo.isSubmodule(this.path)
+        this.isRoot = this.isRoot || repo.relativize(this.path) === ''
 
-    this.subscribeToRepo()
-    this.updateStatus()
+        this.emitter.emit('did-status-change', null)
+
+        this.subscribeToRepo()
+        this.updateStatus()
+      }
+    })
     this.loadRealPath()
   }
 
@@ -131,9 +138,7 @@ class Directory {
 
   // Subscribe to project's repo for changes to the Git status of this directory.
   subscribeToRepo () {
-    const repo = repoForPath(this.path)
-    if (repo == null) return
-
+    const repo = this.repo
     this.subscriptions.add(repo.onDidChangeStatus(event => {
       if (this.contains(event.path)) {
         this.updateStatus(repo)
@@ -146,7 +151,7 @@ class Directory {
 
   // Update the status property of this directory using the repo.
   updateStatus () {
-    const repo = repoForPath(this.path)
+    const repo = this.repo
     if (repo == null) return
 
     let newStatus = null
@@ -184,7 +189,7 @@ class Directory {
   // Is the given path ignored?
   isPathIgnored (filePath) {
     if (atom.config.get('tree-view.hideVcsIgnoredFiles')) {
-      const repo = repoForPath(this.path)
+      const repo = this.repo
       if (repo && repo.isProjectAtRoot() && repo.isPathIgnored(filePath)) return true
     }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -15,9 +15,13 @@ class File {
 
     this.path = fullPath
     this.realPath = this.path
-
-    this.subscribeToRepo()
-    this.updateStatus()
+    repoForPath(this.path).then((repo) => {
+      this.repo = repo
+      if (repo) {
+        this.subscribeToRepo()
+        this.updateStatus()
+      }
+    })
 
     if (useSyncFS) {
       this.realPath = fs.realpathSync(this.path)
@@ -49,9 +53,7 @@ class File {
 
   // Subscribe to the project's repo for changes to the Git status of this file.
   subscribeToRepo () {
-    const repo = repoForPath(this.path)
-    if (repo == null) return
-
+    const repo = this.repo
     this.subscriptions.add(repo.onDidChangeStatus(event => {
       if (this.isPathEqual(event.path)) {
         this.updateStatus(repo)
@@ -64,7 +66,7 @@ class File {
 
   // Update the status property of this directory using the repo.
   updateStatus () {
-    const repo = repoForPath(this.path)
+    const repo = this.repo
     if (repo == null) return
 
     let newStatus = null

--- a/lib/get-icon-services.js
+++ b/lib/get-icon-services.js
@@ -1,6 +1,5 @@
 const DefaultFileIcons = require('./default-file-icons')
 const {Emitter, CompositeDisposable} = require('atom')
-const {repoForPath} = require('./helpers')
 
 let iconServices
 module.exports = function getIconServices () {
@@ -61,16 +60,18 @@ class IconServices {
         iconClass = 'icon-file-symlink-directory'
       } else {
         iconClass = 'icon-file-directory'
-        if (view.directory.isRoot) {
-          const repo = repoForPath(view.directory.path)
-          if (repo && repo.isProjectAtRoot()) iconClass = 'icon-repo'
-        } else {
-          if (view.directory.submodule) iconClass = 'icon-file-submodule'
-        }
+        if (!view.directory.isRoot && view.directory.submodule) iconClass = 'icon-file-submodule'
       }
       classes.push(iconClass)
     }
     view.directoryName.classList.add(...classes)
+  }
+
+  updateRepoDirectoryIcon (view) {
+    if (!view.directory.symlink && view.directory.repo.relativize(view.directory.path) === '') {
+      view.directoryName.className = ''
+      view.directoryName.classList.add('name', 'icon', 'icon-repo')
+    }
   }
 
   updateFileIcon (view) {

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,10 +1,10 @@
+{Directory} = require "atom"
 path = require "path"
 
 module.exports =
   repoForPath: (goalPath) ->
-    for projectPath, i in atom.project.getPaths()
-      if goalPath is projectPath or goalPath.indexOf(projectPath + path.sep) is 0
-        return atom.project.getRepositories()[i]
+    if goalPath
+      return atom.project.repositoryForDirectory(new Directory(goalPath))
     null
 
   getStyleObject: (el) ->

--- a/lib/move-dialog.coffee
+++ b/lib/move-dialog.coffee
@@ -38,9 +38,10 @@ class MoveDialog extends Dialog
       fs.makeTreeSync(directoryPath) unless fs.existsSync(directoryPath)
       fs.moveSync(@initialPath, newPath)
       @onMove?(initialPath: @initialPath, newPath: newPath)
-      if repo = repoForPath(newPath)
-        repo.getPathStatus(@initialPath)
-        repo.getPathStatus(newPath)
+      repoForPath(newPath).then (repo) ->
+        if (repo)
+          repo.getPathStatus(@initialPath)
+          repo.getPathStatus(newPath)
       @close()
     catch error
       @showError("#{error.message}.")

--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -652,8 +652,9 @@ class TreeView
             @emitter.emit 'delete-entry-failed', {pathToDelete: selectedPath}
             failedDeletions.push selectedPath
 
-          if repo = repoForPath(selectedPath)
-            repo.getPathStatus(selectedPath)
+          repoForPath(selectedPath).then (repo) ->
+            if (repo)
+              repo.getPathStatus(selectedPath)
 
         if failedDeletions.length > 0
           atom.notifications.addError @formatTrashFailureMessage(failedDeletions),
@@ -844,9 +845,10 @@ class TreeView
         fs.writeFileSync(newPath, fs.readFileSync(initialPath))
       @emitter.emit 'entry-copied', {initialPath, newPath}
 
-      if repo = repoForPath(newPath)
-        repo.getPathStatus(initialPath)
-        repo.getPathStatus(newPath)
+      repoForPath(newPath).then (repo) ->
+        if (repo)
+          repo.getPathStatus(initialPath)
+          repo.getPathStatus(newPath)
 
     catch error
       @emitter.emit 'copy-entry-failed', {initialPath, newPath}
@@ -873,9 +875,10 @@ class TreeView
       fs.moveSync(initialPath, newPath)
       @emitter.emit 'entry-moved', {initialPath, newPath}
 
-      if repo = repoForPath(newPath)
-        repo.getPathStatus(initialPath)
-        repo.getPathStatus(newPath)
+      repoForPath(newPath).then (repo) ->
+        if (repo)
+          repo.getPathStatus(initialPath)
+          repo.getPathStatus(newPath)
 
     catch error
       if error.code is 'EEXIST'
@@ -900,9 +903,10 @@ class TreeView
             fs.renameSync(initialPath, newPath)
             @emitter.emit 'entry-moved', {initialPath, newPath}
 
-            if repo = repoForPath(newPath)
-              repo.getPathStatus(initialPath)
-              repo.getPathStatus(newPath)
+            repoForPath(newPath).then (repo) ->
+              if (repo)
+                repo.getPathStatus(initialPath)
+                repo.getPathStatus(newPath)
             break
           when 2 # Cancel
             return false


### PR DESCRIPTION
# Identify the Bug

Fixes https://github.com/atom/tree-view/issues/1366.

### Description of the Change

By using atom.project.repositoryForPath function instead of matching the path with added directories, subfolders will get identified.
Made necessary changes to referenced places to handle the async nature of the atom.project.repositoryForPath.

### Alternate Designs

None.

### Possible Drawbacks

Since atom.project.repositoryForPath is an async function, there may be a little lag when loading files with existing changes.

### Verification Process

TODO

### Release Notes

- Fixed subfolders of project folders not getting detected as git repositories.