### PR TITLE
Wrap fs.realpathSync in a try catch

### DIFF
--- a/lib/tree-view.coffee
+++ b/lib/tree-view.coffee
@@ -856,12 +856,15 @@ class TreeView
   moveEntry: (initialPath, newDirectoryPath) ->
     # Do not allow moving test/a/ into test/a/b/
     # Note: A trailing path.sep is added to prevent false positives, such as test/a -> test/ab
-    realNewDirectoryPath = fs.realpathSync(newDirectoryPath) + path.sep
-    realInitialPath = fs.realpathSync(initialPath) + path.sep
-    if fs.isDirectorySync(initialPath) and realNewDirectoryPath.startsWith(realInitialPath)
-      unless fs.isSymbolicLinkSync(initialPath)
-        atom.notifications.addWarning('Cannot move a folder into itself')
-        return
+    try
+      realNewDirectoryPath = fs.realpathSync(newDirectoryPath) + path.sep
+      realInitialPath = fs.realpathSync(initialPath) + path.sep
+      if fs.isDirectorySync(initialPath) and realNewDirectoryPath.startsWith(realInitialPath)
+        unless fs.isSymbolicLinkSync(initialPath)
+          atom.notifications.addWarning('Cannot move a folder into itself')
+          return
+    catch error
+      atom.notifications.addWarning("Failed to move entry #{initialPath} to #{newDirectoryPath}", detail: error.message)
 
     newPath = path.join(newDirectoryPath, path.basename(initialPath))
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

- Wrap `fs.realpathSync` in a try-catch expression.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- Warn the user of the error detected when moving files.

### Possible Drawbacks

N/A

### Applicable Issues

atom/atom#22155
