### PR TITLE
Add popup explaining root cannot be renamed, and add tests to verify fix.

### DIFF
--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -2353,6 +2353,19 @@ describe "TreeView", ->
               expect(callback).not.toHaveBeenCalled()
 
     describe "tree-view:move", ->
+      describe "when rename is selected on a root directory", ->
+        beforeEach ->
+          jasmine.attachToDOM(workspaceElement)
+
+        it "won't be renamed", ->
+          spyOn(atom, 'confirm')
+          treeView.focus()
+          root1.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}))
+          atom.commands.dispatch(treeView.element, 'tree-view:move')
+
+          args = atom.confirm.mostRecentCall.args[0]
+          expect(args.buttons).toEqual ['OK']
+
       describe "when a file is selected", ->
         [moveDialog, callback] = []
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In the method removeSelectedEntries (tree-view.coffee: 616) there is a piece of logic which opens a confirmation box explaining that a root directory cannot be deleted. This pull request would implement that logic in the method moveSelectedEntry (tree-view.coffee: 554) explaining that a root directory cannot be named. Before this pull request's changes, upon attempting to rename a root directory, simply nothing happens.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

In my initial research of the code base, I attempted to find out if there was a way to make a root directory able to be renamed. During my research I came to the conclusion that it wasn't possible for similar reasons that a root directory cannot be deleted, and instead opted to provide feedback to the user on there attempt.

### Benefits

<!-- What benefits will be realized by the code change? -->

Feedback will be given to the user when he or she attempts to rename a root directory. Before this pull requests changes, no such feedback was given, contributing to the feeling that the feature was bugged since there was no explanation as to why no action was being taken. This pull request should eliminate that feeling.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This pull request is not impactful enough to affect the code base in any negative way that I can imagine. The only drawback I can think of would be on the side of the user.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#179 