### PR TITLE
Implement option to hid tree pane on startup

### DIFF
--- a/lib/tree-view-package.js
+++ b/lib/tree-view-package.js
@@ -26,6 +26,12 @@ class TreeViewPackage {
       activatePane: showOnAttach,
       activateItem: showOnAttach
     })
+
+    if (atom.config.get("tree-view.hiddenOnStartup")) {
+      this.getTreeViewInstance().hide();
+    } else {
+      this.getTreeViewInstance().show();
+    }
   }
 
   async deactivate () {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
       "type": "boolean",
       "default": false,
       "description": "When opening a file, always focus an already-existing view of the file even if it's in another pane."
+    },
+    "hiddenOnStartup": {
+      "type": "boolean",
+      "default": false,
+      "description": "When Atom is opened, the view is hidden."
     }
   }
 }

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -5254,3 +5254,42 @@ describe 'Icon class handling', ->
 
       files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
       expect(files[0].fileName.className).toBe('name icon icon-file-text')
+
+ffdescribe 'Hidden on startup', ->
+
+  describe 'When not configured', ->
+    it 'defaults to false', ->
+      expect(atom.config.get("tree-view.hiddenOnStartup")).toBeFalsy()
+
+  describe 'When set to true', ->
+  it 'hides the tree view pane on startup', ->
+    waitsForPromise ->
+      # First deactivate the package so that we can start from scratch
+      atom.packages.deactivatePackage('tree-view')
+
+    runs ->
+      atom.config.set("tree-view.hiddenOnStartup", true)
+
+    # activate the package and wait for focus to settle on editor
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('tree-view')
+      waitsForPromise ->
+        atom.workspace.open()
+
+    runs ->
+      expect(atom.workspace.getLeftDock().isVisible()).toBe(false)
+
+  describe 'When set to false', ->
+    it 'allows the pane to show up as normal', ->
+      waitsForPromise ->
+        # First deactivate the package so that we can start from scratch
+        atom.packages.deactivatePackage('tree-view')
+
+      runs ->
+        atom.config.set("tree-view.hiddenOnStartup", false)
+
+      waitForPackageActivation()
+
+      runs ->
+        expect(atom.workspace.getLeftDock().isVisible()).toBe(true)

--- a/spec/tree-view-package-spec.coffee
+++ b/spec/tree-view-package-spec.coffee
@@ -5255,7 +5255,7 @@ describe 'Icon class handling', ->
       files = workspaceElement.querySelectorAll('li[is="tree-view-file"]')
       expect(files[0].fileName.className).toBe('name icon icon-file-text')
 
-ffdescribe 'Hidden on startup', ->
+describe 'Hidden on startup', ->
 
   describe 'When not configured', ->
     it 'defaults to false', ->


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

Refers to issues:
#1370 #1375 

### Description of the Change

Adds a new configuration option, `hiddenOnStartup`, that allows a user to ask for the project pane to be hidden when Atom starts.
If option isn't present or set to false, behavior stays the same, i.e., project pane is shown on startup.
Option is checked on package activation function, pane is hidden/shown accordingly.

### Alternate Designs

None that I could see.

### Possible Drawbacks

None that I could see. Default behavior is preserved, so users do not have to update any configuration file.

### Verification Process

Added corresponding tests in package spec to verify that:

- Absence of option preserves default behavior
- Default of option is to be false, preserving old behavior
- Setting flag hides panel as designed.


### Release Notes

Adds new configuration option 'hiddenOnStartup', that allows starting atom with the tree-view collapsed (hidden).
