### PR TITLE
Handle text overflow in add-projects-view buttons

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -34,6 +34,12 @@
     .icon::before {
       color: #c1c1c1;
     }
+
+    .btn {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   .icon-large::before {


### PR DESCRIPTION
This makes sure that text does not overflow outside of buttons (if the view width is small enough) by truncating the text and adding trailing ellipsis.

### Description of the Change

Disable wrapping and set `text-overflow` to `ellipsis` in `add-projects-view` `btn` class

**Before this change**

![before](https://user-images.githubusercontent.com/16486114/128642508-3f2cd88e-07f7-4cae-ac6f-4c2048769798.png)


**After this change**

![after](https://user-images.githubusercontent.com/16486114/128642515-2c11d1bf-c8b2-466d-824a-5ff97db3da62.png)



